### PR TITLE
fix unclosed session when staring orchestrator flow

### DIFF
--- a/orc/orchestrator.py
+++ b/orc/orchestrator.py
@@ -27,11 +27,10 @@ AZURE_OPENAI_STREAM = True if AZURE_OPENAI_STREAM.lower() == "true" else False
 
 ANSWER_FORMAT = "html" # html, markdown, none
 
-def get_credentials():
-    is_local_env = os.getenv('LOCAL_ENV') == 'true'
-    # return DefaultAzureCredential(exclude_managed_identity_credential=is_local_env, exclude_environment_credential=is_local_env)
-    return DefaultAzureCredential()
-
+async def get_credentials():
+    async with DefaultAzureCredential() as credential:
+        return credential
+    
 async def run(conversation_id, ask, client_principal):
     
     start_time = time.time()
@@ -46,7 +45,7 @@ async def run(conversation_id, ask, client_principal):
     logging.info(f"[orchestrator] {conversation_id} starting conversation flow.")
 
     # get conversation
-    credential = get_credentials()
+    credential = await get_credentials()
 
     async with CosmosClient(AZURE_DB_URI, credential=credential) as db_client:
         db = db_client.get_database_client(database=AZURE_DB_NAME)


### PR DESCRIPTION
This pull request includes changes in the `orc/orchestrator.py` file. The changes primarily focus on modifying the `get_credentials` function to be asynchronous and adjusting the `run` function to accommodate this change. 

The `DefaultAzureCredential()` from `azure.identity.aio` was called without using `async with`, which might be causing the unclosed client session error.

Key changes:

* [`orc/orchestrator.py`](diffhunk://#diff-09a07a8d252c22e9fc1bfa27b214c255713ce5e63a2e44e0843dc9d286c4ef49L30-R32): The `get_credentials` function has been updated to be an asynchronous function. It now includes an async context manager for `DefaultAzureCredential` which ensures that the credential is properly cleaned up after use.
* [`orc/orchestrator.py`](diffhunk://#diff-09a07a8d252c22e9fc1bfa27b214c255713ce5e63a2e44e0843dc9d286c4ef49L49-R48): In the `run` function, the call to `get_credentials` is now awaited to accommodate the change to an asynchronous function.