### PR TITLE
Temporarily disabling content filtering

### DIFF
--- a/orc/code_orchestration.py
+++ b/orc/code_orchestration.py
@@ -95,7 +95,8 @@ async def get_answer(history,client_principal_id):
     # import RAG plugins
     conversationPluginTask = asyncio.create_task(asyncio.to_thread(kernel.import_plugin_from_prompt_directory, PLUGINS_FOLDER, "Conversation"))
     retrievalPluginTask = asyncio.create_task(asyncio.to_thread(kernel.import_native_plugin_from_directory, PLUGINS_FOLDER, "Retrieval"))
-    raiNativePluginTask = asyncio.create_task(asyncio.to_thread(kernel.import_native_plugin_from_directory, f"{PLUGINS_FOLDER}/ResponsibleAI/Native", "Filters"))
+    # temporary disabled
+    # raiNativePluginTask = asyncio.create_task(asyncio.to_thread(kernel.import_native_plugin_from_directory, f"{PLUGINS_FOLDER}/ResponsibleAI/Native", "Filters"))
     if(SECURITY_HUB_CHECK):
         securityPluginTask = asyncio.create_task(asyncio.to_thread(kernel.import_native_plugin_from_directory, PLUGINS_FOLDER, "Security"))
     if(RESPONSIBLE_AI_CHECK):
@@ -104,13 +105,16 @@ async def get_answer(history,client_principal_id):
     #############################
     # GUARDRAILS (QUESTION)
     #############################
-    raiNativePlugin= await raiNativePluginTask
-    filterResult = await kernel.invoke(raiNativePlugin["ContentFliterValidator"], sk.KernelArguments(input=ask,apim_key=apim_key))
-    if not ('PASSED' in filterResult.value):
-        logging.info(f"[code_orchest] filtered content found in question: {ask}.")
-        answer = get_message('BLOCKED_ANSWER')
-        answer_generated_by = 'content_filters_check'
-        bypass_nxt_steps = True
+    
+    # temporary disabled
+    # raiNativePlugin= await raiNativePluginTask
+    # filterResult = await kernel.invoke(raiNativePlugin["ContentFliterValidator"], sk.KernelArguments(input=ask,apim_key=apim_key))
+    # if not ('PASSED' in filterResult.value):
+    #     logging.info(f"[code_orchest] filtered content found in question: {ask}.")
+    #     answer = get_message('BLOCKED_ANSWER')
+    #     answer_generated_by = 'content_filters_check'
+    #     bypass_nxt_steps = True
+
     if BLOCKED_LIST_CHECK:
         logging.debug(f"[code_orchest] blocked list check.")
         try:


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve contribution guidelines and temporarily disables the Responsible AI plugin in the `orc/code_orchestration.py` file. The most important changes are summarized below:

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R43): Updated the contribution guidelines to refer to the `CONTRIBUTING.md` page for detailed instructions, including information about the Contributor License Agreement (CLA) and code of conduct.

### Code Changes:

* [`orc/code_orchestration.py`](diffhunk://#diff-0037002d516507919acc661b1549ee05510c5e99a0fb4668ff4275a00e5d4182L98-R99): Temporarily disabled the import and invocation of the Responsible AI plugin (`raiNativePluginTask` and related code) in the `get_answer` function. This change affects both the plugin import and the content filter validation steps. [[1]](diffhunk://#diff-0037002d516507919acc661b1549ee05510c5e99a0fb4668ff4275a00e5d4182L98-R99) [[2]](diffhunk://#diff-0037002d516507919acc661b1549ee05510c5e99a0fb4668ff4275a00e5d4182L107-R117)