### PR TITLE
Update config.json

### DIFF
--- a/orc/plugins/Conversation/Answer/config.json
+++ b/orc/plugins/Conversation/Answer/config.json
@@ -12,7 +12,7 @@
     },
     "input_variables": [
         {
-          "name": "question",
+          "name": "ask",
           "description": "User question(i.e., How do I execute task A?)",
           "defaultValue": "",
           "required": true	


### PR DESCRIPTION

This pull request includes a small change to the `orc/plugins/Conversation/Answer/config.json` file. The change renames the input variable from `question` to `ask`.

* [`orc/plugins/Conversation/Answer/config.json`](diffhunk://#diff-eb31d1ed4e5ae09a52fadc58a82190bd90c57fbd428a1c02b33c81b80f2f733bL15-R15): Renamed the input variable from `question` to `ask` to better align with the terminology used in the rest of the codebase.