### PR TITLE
Added isWorkMode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ __queuestorage__
 __azurite_db*__.json
 
 .azure
+.history/

--- a/orc/__init__.py
+++ b/orc/__init__.py
@@ -23,10 +23,11 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
         'name': client_principal_name,
         'group_names': client_group_names        
     }
+    is_work_mode = req_body.get('is_work_mode', False)
 
     if question:
 
-        result = await orchestrator.run(conversation_id, question, client_principal)
+        result = await orchestrator.run(conversation_id, question, client_principal, is_work_mode)
 
         return func.HttpResponse(json.dumps(result), mimetype="application/json", status_code=200)
     else:

--- a/orc/code_orchestration.py
+++ b/orc/code_orchestration.py
@@ -59,14 +59,16 @@ async def get_answer(history, security_ids,conversation_id, is_work_mode):
     #############################
 
     # work mode:
-    #  true - prioritize search retrieval
-    # false - prioritize bing retrieval
+    #  true - prioritize search retrieval, turn off bing search
+    # false - prioritize bing retrieval, turn off search retrieval
     if is_work_mode:
-        if SEARCH_RETRIEVAL:
-            RETRIEVAL_PRIORITY = "search"
+        SEARCH_RETRIEVAL = True
+        RETRIEVAL_PRIORITY = "search"
+        BING_RETRIEVAL = False
     else:
         if BING_RETRIEVAL:
             RETRIEVAL_PRIORITY = "bing"
+        SEARCH_RETRIEVAL = False
 
     #initialize variables
     answer_dict = {}

--- a/orc/code_orchestration.py
+++ b/orc/code_orchestration.py
@@ -58,16 +58,17 @@ async def get_answer(history, security_ids,conversation_id, is_work_mode):
     # INITIALIZATION
     #############################
 
-    #initialize variables    
+    # work mode:
+    #  true - prioritize search retrieval
+    # false - prioritize bing retrieval
     if is_work_mode:
-        SEARCH_RETRIEVAL = True
-        BING_RETRIEVAL = False
-        RETRIEVAL_PRIORITY = "search"
+        if SEARCH_RETRIEVAL:
+            RETRIEVAL_PRIORITY = "search"
     else:
-        SEARCH_RETRIEVAL = False
-        BING_RETRIEVAL = True
-        RETRIEVAL_PRIORITY = "bing"
+        if BING_RETRIEVAL:
+            RETRIEVAL_PRIORITY = "bing"
 
+    #initialize variables
     answer_dict = {}
     prompt = "The prompt is only recorded for question-answering intents"
     answer = ""

--- a/orc/code_orchestration.py
+++ b/orc/code_orchestration.py
@@ -52,13 +52,21 @@ APIM_ENABLED = True if APIM_ENABLED.lower() == "true" else False
 if SECURITY_HUB_CHECK:
     SECURITY_HUB_THRESHOLDS=[get_possitive_int_or_default(os.environ.get("SECURITY_HUB_HATE_THRESHHOLD"), 0),get_possitive_int_or_default(os.environ.get("SECURITY_HUB_SELFHARM_THRESHHOLD"), 0),get_possitive_int_or_default(os.environ.get("SECURITY_HUB_SEXUAL_THRESHHOLD"), 0),get_possitive_int_or_default(os.environ.get("SECURITY_HUB_VIOLENCE_THRESHHOLD"), 0)]
 
-async def get_answer(history, security_ids,conversation_id):
+async def get_answer(history, security_ids,conversation_id, is_work_mode):
 
     #############################
     # INITIALIZATION
     #############################
 
     #initialize variables    
+    if is_work_mode:
+        SEARCH_RETRIEVAL = True
+        BING_RETRIEVAL = False
+        RETRIEVAL_PRIORITY = "search"
+    else:
+        SEARCH_RETRIEVAL = False
+        BING_RETRIEVAL = True
+        RETRIEVAL_PRIORITY = "bing"
 
     answer_dict = {}
     prompt = "The prompt is only recorded for question-answering intents"

--- a/orc/code_orchestration.py
+++ b/orc/code_orchestration.py
@@ -58,6 +58,11 @@ async def get_answer(history, security_ids,conversation_id, is_work_mode):
     # INITIALIZATION
     #############################
 
+    #initialize variables    
+    global BING_RETRIEVAL
+    global SEARCH_RETRIEVAL
+    global RETRIEVAL_PRIORITY 
+
     # work mode:
     #  true - prioritize search retrieval, turn off bing search
     # false - prioritize bing retrieval, turn off search retrieval
@@ -70,7 +75,6 @@ async def get_answer(history, security_ids,conversation_id, is_work_mode):
             RETRIEVAL_PRIORITY = "bing"
         SEARCH_RETRIEVAL = False
 
-    #initialize variables
     answer_dict = {}
     prompt = "The prompt is only recorded for question-answering intents"
     answer = ""

--- a/orc/orchestrator.py
+++ b/orc/orchestrator.py
@@ -42,7 +42,7 @@ def generate_security_ids(client_principal):
         security_ids = f"{client_principal['id']}" + (f",{group_names}" if group_names else "")
     return security_ids    
     
-async def run(conversation_id, ask, client_principal):
+async def run(conversation_id, ask, client_principal, is_work_mode):
     
     start_time = time.time()
 
@@ -84,7 +84,7 @@ async def run(conversation_id, ask, client_principal):
 
             logging.info(f"[orchestrator] executing RAG retrieval using code orchestration")
             security_ids = generate_security_ids(client_principal)
-            answer_dict = await code_orchestration.get_answer(history, security_ids,conversation_id)
+            answer_dict = await code_orchestration.get_answer(history, security_ids,conversation_id,is_work_mode)
 
             # 3) update and save conversation (containing history and conversation data)
             


### PR DESCRIPTION
## Purpose

This PR adds a new Work/LM mode toggle feature to the chat interface, allowing users to switch between two different interaction modes:

Work mode: Focuses queries on work-related content and knowledge bases
LM mode: Uses the language model's general knowledge for wider topic coverage
The implementation adds a UI toggle in the chat interface and passes the selected mode to the backend API via the is_work_mode parameter, enabling the backend to provide context-appropriate responses based on the selected mode.

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Related Backlog Item or Issue

If applicable, provide a link to the relevant backlog item or issue.

<!-- Example: https://github.com/placerda/gpt-rag-orchestrator/issues/123 -->

## Is this change disruptive or does it break existing applications?

If deploying this change could impact existing applications, please specify.

```
[X ] Yes
[ ] No
```

## Cross-Repository Dependencies

If this change depends on pull requests in other repositories within the solution, provide the links below.

- [ ] [gpt-rag](https://github.com/azure/gpt-rag) <!-- Example: — Link: https://github.com/placerda/gpt-rag-orchestrator/pull/456 -->
- [ ] [gpt-rag-agentic](https://github.com/azure/gpt-rag) <!-- Example: — Link: https://github.com/placerda/gpt-rag/pull/456 -->
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion) <!-- Example: — Link: https://github.com/placerda/gpt-rag-ingestion/pull/456 -->
- [ ] [gpt-rag-frontend](https://github.com/azure/gpt-rag-frontend) <!-- Example: — Link: https://github.com/placerda/gpt-rag-frontend/pull/456 -->

## Does this require changes to project documentation?

If the changes add new functionality, update the documentation accordingly.

```
[X ] Yes
[ ] No
```

## Documentation Link

If this change adds a new functionality, provide a link to its documentation.

<!-- Example: https://github.com/placerda/gpt-rag-orchestrator/wiki/New-Feature-Guide -->

## Code quality checklist

- [X ] I verified the changes locally to ensure they work as expected
- [ ] I have tested the new functionality and ensured existing features still work
- [ ] I have updated the CHANGELOG.md file to document these changes
- [ ] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request



## Contributing guidelines

See [CONTRIBUTING.md](https://github.com/Azure/GPT-RAG/blob/main/CONTRIBUTING.md) for more details.
