### PR TITLE
chore: refresh python-dotenv dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Changed
+- **Dependency refresh:** Updated `python-dotenv` to 1.2.2 for runtime configuration loading.
+
 ## [v2.6.10] - 2026-05-27
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ chardet>=5.2,<6.0.0
 
 # For evaluation
 requests==2.33.0
-python-dotenv==1.1.0
+python-dotenv==1.2.2
 
 # fastapi
 fastapi==0.115.12


### PR DESCRIPTION
## Summary
- Updates python-dotenv to 1.2.2.
- Documents the dependency refresh in the changelog.

## Validation
- Verified python-dotenv 1.2.2 imports and dotenv parsing in an isolated Python environment.