### PR TITLE
fix: scope RAG retrieval to conversation so uploaded docs are found (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Uploaded documents now retrieved in chat (issue #478):** `SingleAgentRAGStrategyV2` now scopes the Azure AI Search retrieval to the active conversation. It passes the chat `conversation_id` (from the orchestrator-provided conversation dict, falling back to `set_context()`) into `set_request_context`, so the search filter includes per-conversation uploaded chunks (`conversationId eq '<cid>' or conversationId eq 'NaN'`) instead of only the shared corpus. Previously the conversation id was never propagated, so uploaded documents were filtered out and the model answered without them.
 
 All notable changes to this project will be documented in this file.
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).

--- a/src/strategies/single_agent_rag_strategy_v2.py
+++ b/src/strategies/single_agent_rag_strategy_v2.py
@@ -250,6 +250,37 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
         if conversation_id:
             self.conversation_id = conversation_id
 
+    def _resolve_conversation_id(self) -> Optional[str]:
+        """Resolve the chat conversation id for retrieval scoping.
+
+        Prefer the conversation dict id assigned by the orchestrator; fall back
+        to the id captured via set_context(). Never use thread_id — that is the
+        agent thread id, not the chat conversation id used to tag documents.
+        """
+        return (getattr(self, "conversation", None) or {}).get("id") \
+            or getattr(self, "conversation_id", None)
+
+    def _apply_search_request_context(self) -> None:
+        """Push per-request retrieval context onto the (singleton) search client.
+
+        Scopes the AI Search filter to the current conversation so uploaded
+        documents (tagged with this conversation id by the ingestion service)
+        are included alongside the shared corpus (issue #478).
+        """
+        if not self.search_client:
+            return
+        allow_anonymous = self.cfg.get("ALLOW_ANONYMOUS", default=True, type=bool)
+        request_access_token = getattr(self, "request_access_token", None)
+        conversation_id = self._resolve_conversation_id()
+        try:
+            self.search_client.set_request_context(
+                api_access_token=request_access_token,
+                allow_anonymous=allow_anonymous,
+                conversation_id=conversation_id,
+            )
+        except Exception:
+            pass
+
     async def initiate_agent_flow(self, user_message: str):
         """
         V2 Latency-Optimized Agent Flow.
@@ -531,24 +562,7 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
 
         # Agent SDK Features: Auto-functions
         if self.search_client:
-            # OBO prep
-            allow_anonymous = self.cfg.get("ALLOW_ANONYMOUS", default=True, type=bool)
-            request_access_token = getattr(self, "request_access_token", None)
-            # Scope retrieval to the current conversation so uploaded documents
-            # (tagged with this conversation id by the ingestion service) are
-            # included in the search filter. Prefer the conversation dict id set
-            # by the orchestrator; fall back to the id captured via set_context().
-            # Never use thread_id here — it is the agent thread, not the chat id.
-            conversation_id = (getattr(self, "conversation", None) or {}).get("id") \
-                or getattr(self, "conversation_id", None)
-            try:
-                self.search_client.set_request_context(
-                    api_access_token=request_access_token,
-                    allow_anonymous=allow_anonymous,
-                    conversation_id=conversation_id,
-                )
-            except Exception:
-                pass
+            self._apply_search_request_context()
 
         # Determine if we need to create an agent this request
         # Priority: _cached_agent (pre-warmed) > existing_agent_id (config) > create new

--- a/src/strategies/single_agent_rag_strategy_v2.py
+++ b/src/strategies/single_agent_rag_strategy_v2.py
@@ -200,6 +200,12 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
         self.tools_list = []
         self.tool_resources = {}
 
+        # Conversation scope for retrieval. Set by the orchestrator via set_context()
+        # and/or read from self.conversation["id"] at stream time. Without it, the
+        # AI Search filter falls back to shared ('NaN') chunks only and uploaded
+        # per-conversation documents are never retrieved (see issue #478).
+        self.conversation_id: Optional[str] = None
+
         aisearch_enabled = self.cfg.get("SEARCH_RETRIEVAL_ENABLED", True, type=bool)
         if not aisearch_enabled:
             logging.warning("[Init V2] SEARCH_RETRIEVAL_ENABLED set to false. SearchClient will not be available.")
@@ -232,6 +238,17 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
 
         # Initialize Direct LLM Client for Bypass scenario (singleton)
         self.llm_client = get_genai_client()
+
+    def set_context(self, conversation_id: Optional[str]) -> None:
+        """Receive the active conversation id from the orchestrator.
+
+        The orchestrator calls this (guarded by hasattr) before the agent flow
+        runs. Storing it lets _stream_agent scope the AI Search retrieval to the
+        current conversation so uploaded documents tagged with this id are
+        returned alongside the shared corpus (issue #478).
+        """
+        if conversation_id:
+            self.conversation_id = conversation_id
 
     async def initiate_agent_flow(self, user_message: str):
         """
@@ -517,8 +534,19 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
             # OBO prep
             allow_anonymous = self.cfg.get("ALLOW_ANONYMOUS", default=True, type=bool)
             request_access_token = getattr(self, "request_access_token", None)
+            # Scope retrieval to the current conversation so uploaded documents
+            # (tagged with this conversation id by the ingestion service) are
+            # included in the search filter. Prefer the conversation dict id set
+            # by the orchestrator; fall back to the id captured via set_context().
+            # Never use thread_id here — it is the agent thread, not the chat id.
+            conversation_id = (getattr(self, "conversation", None) or {}).get("id") \
+                or getattr(self, "conversation_id", None)
             try:
-                self.search_client.set_request_context(api_access_token=request_access_token, allow_anonymous=allow_anonymous)
+                self.search_client.set_request_context(
+                    api_access_token=request_access_token,
+                    allow_anonymous=allow_anonymous,
+                    conversation_id=conversation_id,
+                )
             except Exception:
                 pass
 

--- a/tests/test_single_agent_rag_v2_conversation_scope.py
+++ b/tests/test_single_agent_rag_v2_conversation_scope.py
@@ -1,0 +1,91 @@
+"""Regression tests for conversation-scoped retrieval in SingleAgentRAGStrategyV2.
+
+Covers the fix for Azure/GPT-RAG#478: uploaded documents (tagged with the chat
+conversation id by the ingestion service) must be included in the AI Search
+retrieval filter. The keystone bug was that the strategy never propagated the
+conversation id into the search request context, so the filter fell back to the
+shared corpus only and uploaded chunks were never retrieved.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Import a strategies module at top level so the dependencies/connectors import
+# graph is initialized in the correct order before the test imports the strategy
+# (mirrors the other strategy test modules and avoids a circular import).
+from strategies.agent_strategies import AgentStrategies  # noqa: F401
+
+
+class TestSingleAgentRagV2ConversationScope:
+    @pytest.fixture(autouse=True)
+    def _patch(self, patch_dependencies, mock_config):
+        with patch(
+            "strategies.single_agent_rag_strategy_v2.get_config",
+            return_value=mock_config,
+        ):
+            yield
+
+    def _make_strategy(self):
+        from strategies.single_agent_rag_strategy_v2 import SingleAgentRAGStrategyV2
+
+        # get_search_client()/get_genai_client() reach out to App Config/Azure at
+        # construction time; patch them so __init__ stays offline. We assert on
+        # the search client mock below.
+        with patch(
+            "strategies.single_agent_rag_strategy_v2.get_search_client",
+            return_value=MagicMock(),
+        ), patch(
+            "strategies.single_agent_rag_strategy_v2.get_genai_client",
+            return_value=MagicMock(),
+        ):
+            s = SingleAgentRAGStrategyV2()
+        # Ensure a clean mock search client for per-request context assertions.
+        s.search_client = MagicMock()
+        return s
+
+    def test_set_context_stores_conversation_id(self):
+        s = self._make_strategy()
+        assert s.conversation_id is None
+        s.set_context("conv-123")
+        assert s.conversation_id == "conv-123"
+
+    def test_set_context_ignores_empty(self):
+        s = self._make_strategy()
+        s.set_context("conv-123")
+        s.set_context(None)
+        s.set_context("")
+        # An empty/None update must not clobber a previously set id.
+        assert s.conversation_id == "conv-123"
+
+    def test_resolve_prefers_conversation_dict_id(self):
+        s = self._make_strategy()
+        s.set_context("from-set-context")
+        s.conversation = {"id": "from-dict", "thread_id": "agent-thread"}
+        # The conversation dict id wins over set_context, and thread_id is never used.
+        assert s._resolve_conversation_id() == "from-dict"
+
+    def test_resolve_falls_back_to_set_context(self):
+        s = self._make_strategy()
+        s.set_context("from-set-context")
+        s.conversation = {}  # no id in the dict
+        assert s._resolve_conversation_id() == "from-set-context"
+
+    def test_resolve_never_uses_thread_id(self):
+        s = self._make_strategy()
+        s.conversation = {"thread_id": "agent-thread"}  # only thread_id present
+        assert s._resolve_conversation_id() is None
+
+    def test_apply_context_passes_conversation_id_to_search_client(self):
+        s = self._make_strategy()
+        s.conversation = {"id": "conv-abc"}
+        s._apply_search_request_context()
+
+        s.search_client.set_request_context.assert_called_once()
+        kwargs = s.search_client.set_request_context.call_args.kwargs
+        assert kwargs["conversation_id"] == "conv-abc"
+
+    def test_apply_context_noop_without_search_client(self):
+        s = self._make_strategy()
+        s.search_client = None
+        # Must not raise when retrieval is disabled.
+        s._apply_search_request_context()


### PR DESCRIPTION
## Summary
Fixes the keystone cause of [Azure/GPT-RAG#478](https://github.com/Azure/GPT-RAG/issues/478) (document upload not used by the model).

SingleAgentRAGStrategyV2 never propagated the chat `conversation_id` into the AI Search request context, so `build_conversation_filter` fell back to the shared corpus only (`conversationId eq 'NaN'`) and per-conversation uploaded chunks were filtered out.

## Changes
- Add `set_context(conversation_id)` for parity with sibling strategies (maf_lite / maf_agent_service / multimodal).
- Initialize `self.conversation_id` in `__init__`.
- In `_stream_agent`, pass `conversation_id` (from `self.conversation['id']`, fallback `set_context`) into `set_request_context`. Never use `thread_id` (agent thread != chat id).

## Companion PRs
- Azure/gpt-rag-ingestion `fix/document-upload-rag-478` (optional ACL stamping)
- Azure/gpt-rag-ui `fix/document-upload-rag-478` (forward uploader oid)

## Validation
Full pytest suite green (157 passed). End-to-end validated on Azure (see issue comment).