### PR TITLE
Add custom_metadata to LLM context, config-gated (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Optional `custom_metadata` in the LLM context block (refs [Azure/GPT-RAG#506](https://github.com/Azure/GPT-RAG/issues/506)):** Retrieval can now surface the already-indexed `custom_metadata` field (from [Azure/GPT-RAG#487](https://github.com/Azure/GPT-RAG/issues/487)) into each document's context, behind a default-off flag. When `SEARCH_INCLUDE_METADATA_IN_CONTEXT` is `true`, the connector path (`search_knowledge_base`) and both context providers (`SearchContextProvider`, `MultimodalSearchContextProvider`) select the field and prepend a compact, deterministic `[Document metadata]` block (sorted `key: value` lines) before the document content. `SEARCH_METADATA_MAX_CHARS` (default `500`) caps the block size and `SEARCH_METADATA_ALLOWED_KEYS` (CSV, default empty = all keys) restricts which keys are shown. The change is additive and orchestrator-only — no ingestion, embedding, or vector changes. When the flag is off, `custom_metadata` is not added to the select and retrieval behavior is byte-for-byte unchanged; this is required because pre-#487 indexes lack the field and selecting a missing field makes Azure AI Search reject the whole query.
+
 ## [v2.8.7] - 2026-06-18
 
 ### Changed

--- a/src/connectors/search.py
+++ b/src/connectors/search.py
@@ -4,9 +4,10 @@ import json
 import time
 import hashlib
 from typing import Optional, Any, Dict, List
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from dependencies import get_config
+from util.metadata import format_custom_metadata, parse_allowed_keys
 
 # Standardized log markers for retrieval/auth failure paths. Operators can grep
 # these to spot swallowed errors that would otherwise return empty results
@@ -116,6 +117,13 @@ class SearchResult(BaseModel):
     title: str
     link: str
     content: str
+    # Raw custom_metadata carried for in-process consumers/tests only. It is
+    # excluded from serialization on purpose: the formatted metadata block is
+    # prepended into ``content`` (the text the LLM reads), so emitting the raw
+    # value as a separate JSON key would duplicate it and waste tokens. When the
+    # SEARCH_INCLUDE_METADATA_IN_CONTEXT flag is off this stays None and the
+    # serialized output is byte-for-byte unchanged.
+    custom_metadata: Optional[Any] = Field(default=None, exclude=True)
 
 
 def _odata_escape_string(value: Optional[str]) -> str:
@@ -168,6 +176,14 @@ class SearchClient:
         self.use_semantic = self.cfg.get('SEARCH_USE_SEMANTIC', 'false').lower() == 'true'
         self.index_name = self.cfg.get("SEARCH_RAG_INDEX_NAME", "ragindex")
         self.index_empty_cache_ttl_seconds = int(self.cfg.get("SEARCH_EMPTY_CACHE_TTL_SECONDS", 60, type=int))
+
+        # Custom metadata in LLM context (default OFF). When OFF the field is not
+        # selected, keeping the query byte-for-byte unchanged. This guard matters
+        # because pre-#487 indexes lack the custom_metadata field and selecting a
+        # missing field makes Azure AI Search reject the whole query with 400.
+        self.include_metadata_in_context = self.cfg.get("SEARCH_INCLUDE_METADATA_IN_CONTEXT", False, type=bool)
+        self.metadata_max_chars = int(self.cfg.get("SEARCH_METADATA_MAX_CHARS", 500, type=int))
+        self.metadata_allowed_keys = parse_allowed_keys(self.cfg.get("SEARCH_METADATA_ALLOWED_KEYS", "", type=str))
 
         # Per-request context (kept in memory only)
         self._request_api_access_token: Optional[str] = None
@@ -583,9 +599,14 @@ class SearchClient:
         try:
             logging.info("[Retrieval] Using Azure AI Search for document retrieval")
 
-            # Build search body according to search approach
+            # Build search body according to search approach. custom_metadata is
+            # only added to the select when the flag is on; otherwise the select
+            # string stays exactly as before so pre-#487 indexes keep working.
+            select_fields = "title,content,url,filepath,chunk_id"
+            if self.include_metadata_in_context:
+                select_fields += ",custom_metadata"
             search_body: Dict[str, Any] = {
-                "select": "title,content,url,filepath,chunk_id",
+                "select": select_fields,
                 "top": self.search_top_k
             }
 
@@ -639,6 +660,19 @@ class SearchClient:
                 link = result.get('filepath') or result.get('url', '') or ''
                 content = result.get('content', '')
 
+                # Prepend the formatted metadata block before content when enabled.
+                # Read defensively: the field may be absent or null on a result.
+                raw_metadata = None
+                if self.include_metadata_in_context:
+                    raw_metadata = result.get("custom_metadata") or []
+                    metadata_block = format_custom_metadata(
+                        raw_metadata,
+                        self.metadata_max_chars,
+                        self.metadata_allowed_keys,
+                    )
+                    if metadata_block:
+                        content = f"{metadata_block}\n\n{content}"
+
                 # Debug log each document with formatted output (remove line breaks)
                 content_preview = content[:200] if len(content) > 200 else content
                 content_preview = ' '.join(content_preview.split())  # Replace all whitespace/newlines with single space
@@ -647,7 +681,8 @@ class SearchClient:
                 search_result = SearchResult(
                     title=title,
                     link=link,
-                    content=content
+                    content=content,
+                    custom_metadata=raw_metadata,
                 )
                 results_list.append(search_result.model_dump())
 

--- a/src/strategies/multimodal_search_context_provider.py
+++ b/src/strategies/multimodal_search_context_provider.py
@@ -32,6 +32,8 @@ from azure.storage.blob.aio import BlobClient as AzureBlobClient
 
 from connectors.multimodal_chat_client import MULTIMODAL_PREFIX
 from connectors.search import _classify_retrieval_error, build_conversation_filter
+from dependencies import get_config
+from util.metadata import format_custom_metadata, parse_allowed_keys
 
 logger = logging.getLogger(__name__)
 
@@ -260,13 +262,24 @@ class MultimodalSearchContextProvider(ContextProvider):
         )
 
         # ---- Build search parameters ----
+        # Custom metadata in context (default OFF). Only select the field when
+        # enabled so pre-#487 indexes (which lack it) are not 400'd by Search.
+        cfg = get_config()
+        include_metadata = cfg.get("SEARCH_INCLUDE_METADATA_IN_CONTEXT", False, type=bool)
+        metadata_max_chars = int(cfg.get("SEARCH_METADATA_MAX_CHARS", 500, type=int))
+        metadata_allowed_keys = parse_allowed_keys(cfg.get("SEARCH_METADATA_ALLOWED_KEYS", "", type=str))
+
+        select_fields = [
+            "id", "content", "title", "filepath", "url",
+            "relatedImages", "imageCaptions",
+        ]
+        if include_metadata:
+            select_fields = select_fields + ["custom_metadata"]
+
         search_params: dict[str, Any] = {
             "search_text": query,
             "top": self._top_k,
-            "select": [
-                "id", "content", "title", "filepath", "url",
-                "relatedImages", "imageCaptions",
-            ],
+            "select": select_fields,
         }
 
         # Conversation scoping: only this conversation + shared/global chunks.
@@ -501,6 +514,16 @@ class MultimodalSearchContextProvider(ContextProvider):
             # Build content: header + text interleaved with images at original positions
             header = f"### [{title}]({link})" if link else f"### {title}"
             content_parts.append({"type": "text", "text": f"\n\n---\n\n{header}"})
+
+            # Prepend the formatted metadata block before the document content.
+            if include_metadata:
+                metadata_block = format_custom_metadata(
+                    doc.get("custom_metadata") or [],
+                    metadata_max_chars,
+                    metadata_allowed_keys,
+                )
+                if metadata_block:
+                    content_parts.append({"type": "text", "text": f"\n{metadata_block}"})
 
             # Inline pass: figures whose <figure> tag falls within the display text
             inline_matches = list(_FIGURE_RE.finditer(display_text))

--- a/src/strategies/search_context_provider.py
+++ b/src/strategies/search_context_provider.py
@@ -20,6 +20,8 @@ from azure.search.documents.aio import SearchClient
 from azure.search.documents.models import VectorizedQuery, QueryType, QueryCaptionType
 
 from connectors.search import _classify_retrieval_error, build_conversation_filter
+from dependencies import get_config
+from util.metadata import format_custom_metadata, parse_allowed_keys
 logger = logging.getLogger(__name__)
 
 _CONTEXT_PROMPT = (
@@ -90,10 +92,21 @@ class SearchContextProvider(ContextProvider):
         search_start = time.time()
         logger.info("[SearchContextProvider] Query: %r (top_k=%d, hybrid=%s)", query[:120], self._top_k, bool(self._embed_fn))
 
+        # Custom metadata in context (default OFF). Only select the field when
+        # enabled so pre-#487 indexes (which lack it) are not 400'd by Search.
+        cfg = get_config()
+        include_metadata = cfg.get("SEARCH_INCLUDE_METADATA_IN_CONTEXT", False, type=bool)
+        metadata_max_chars = int(cfg.get("SEARCH_METADATA_MAX_CHARS", 500, type=int))
+        metadata_allowed_keys = parse_allowed_keys(cfg.get("SEARCH_METADATA_ALLOWED_KEYS", "", type=str))
+
+        select_fields = ["id", "content", "title", "filepath", "url"]
+        if include_metadata:
+            select_fields = select_fields + ["custom_metadata"]
+
         search_params: dict[str, Any] = {
             "search_text": query,
             "top": self._top_k,
-            "select": ["id", "content", "title", "filepath", "url"],
+            "select": select_fields,
         }
 
         # Conversation scoping: only this conversation + shared/global chunks.
@@ -151,6 +164,14 @@ class SearchContextProvider(ContextProvider):
                         continue
                     if len(content) > self._max_content_chars:
                         content = content[:self._max_content_chars] + "..."
+                    if include_metadata:
+                        metadata_block = format_custom_metadata(
+                            doc.get("custom_metadata") or [],
+                            metadata_max_chars,
+                            metadata_allowed_keys,
+                        )
+                        if metadata_block:
+                            content = f"{metadata_block}\n\n{content}"
                     header = f"### [{title}]({link})" if link else f"### {title}"
                     parts.append(f"{header}\n{content}")
         except Exception as e:

--- a/src/util/metadata.py
+++ b/src/util/metadata.py
@@ -1,0 +1,125 @@
+"""Formatting helpers for surfacing indexed ``custom_metadata`` into context.
+
+The ``custom_metadata`` field is populated during ingestion (see
+Azure/GPT-RAG#487) and already lives in the AI Search index. These helpers turn
+that raw field into a compact, deterministic text block that retrieval paths can
+prepend to each document's content before it reaches the LLM (Azure/GPT-RAG#506).
+
+This module is intentionally dependency-free: it imports only the standard
+library so it can be reused by connectors and strategies without creating import
+cycles.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, List, Optional, Tuple
+
+# Header used to delimit the metadata block inside a document's context text.
+METADATA_HEADER = "[Document metadata]"
+
+
+def parse_allowed_keys(raw: Optional[str]) -> List[str]:
+    """Parse a comma-separated allow-list of metadata keys.
+
+    An empty or missing value yields an empty list, which callers treat as
+    "allow all keys".
+    """
+    if not raw:
+        return []
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _coerce_to_pairs(raw: Any) -> List[Tuple[str, str]]:
+    """Normalize a raw ``custom_metadata`` value into (key, value) string pairs.
+
+    Accepts the shapes AI Search may return the field as:
+    - a JSON string (parsed defensively; unparseable strings yield nothing),
+    - a list of ``{"key": ..., "value": ...}`` dicts (the indexed shape),
+    - a list of plain ``{key: value}`` dicts,
+    - a plain ``{key: value}`` dict.
+
+    Empty keys and empty/None values are skipped. Internal whitespace and
+    newlines in values are collapsed to single spaces so the block stays compact
+    and single-line per entry.
+    """
+    if raw is None:
+        return []
+
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return []
+        try:
+            raw = json.loads(text)
+        except (ValueError, TypeError):
+            return []
+
+    raw_items: Iterable[Tuple[Any, Any]]
+    if isinstance(raw, dict):
+        raw_items = list(raw.items())
+    elif isinstance(raw, (list, tuple)):
+        collected: List[Tuple[Any, Any]] = []
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            if "key" in entry:
+                collected.append((entry.get("key"), entry.get("value")))
+            else:
+                collected.extend(entry.items())
+        raw_items = collected
+    else:
+        return []
+
+    pairs: List[Tuple[str, str]] = []
+    for key, value in raw_items:
+        if key is None:
+            continue
+        key_str = str(key).strip()
+        if not key_str:
+            continue
+        if value is None:
+            continue
+        value_str = " ".join(str(value).split())
+        if not value_str:
+            continue
+        pairs.append((key_str, value_str))
+    return pairs
+
+
+def format_custom_metadata(
+    raw: Any,
+    max_chars: int = 500,
+    allowed_keys: Optional[Iterable[str]] = None,
+) -> str:
+    """Render ``custom_metadata`` as a compact text block for LLM context.
+
+    :param raw: The raw ``custom_metadata`` field from a search result.
+    :param max_chars: Hard cap on the rendered block length; non-positive
+        disables truncation.
+    :param allowed_keys: Optional iterable of keys to keep; when empty/None all
+        keys are kept.
+    :return: A ``[Document metadata]`` block with sorted ``key: value`` lines, or
+        ``""`` when there is nothing usable so callers can no-op.
+    """
+    pairs = _coerce_to_pairs(raw)
+    if not pairs:
+        return ""
+
+    if allowed_keys:
+        allow = {k.strip() for k in allowed_keys if k and str(k).strip()}
+        if allow:
+            pairs = [(k, v) for k, v in pairs if k in allow]
+            if not pairs:
+                return ""
+
+    pairs.sort(key=lambda kv: kv[0])
+
+    lines = [METADATA_HEADER]
+    lines.extend(f"{k}: {v}" for k, v in pairs)
+    block = "\n".join(lines)
+
+    if max_chars and max_chars > 0 and len(block) > max_chars:
+        block = block[:max_chars].rstrip()
+
+    return block

--- a/tests/test_metadata_context.py
+++ b/tests/test_metadata_context.py
@@ -1,0 +1,243 @@
+"""Tests for surfacing indexed ``custom_metadata`` into the LLM context.
+
+Covers Azure/GPT-RAG#506:
+
+- The pure formatting helper (``format_custom_metadata`` / ``parse_allowed_keys``).
+- The default-off flag wiring in the connector path (``search_knowledge_base``):
+  when off, ``custom_metadata`` is not selected and the output is unchanged;
+  when on, the formatted block is prepended to each document's content.
+- Parity in one context provider (``SearchContextProvider``).
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from util.metadata import format_custom_metadata, parse_allowed_keys, METADATA_HEADER
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+def test_list_of_dicts_input_renders_sorted_block():
+    raw = [
+        {"key": "author", "value": "Jane Doe"},
+        {"key": "department", "value": "Finance"},
+    ]
+    out = format_custom_metadata(raw, max_chars=500, allowed_keys=None)
+    assert out == f"{METADATA_HEADER}\nauthor: Jane Doe\ndepartment: Finance"
+
+
+def test_json_string_input_is_parsed():
+    raw = json.dumps([{"key": "author", "value": "Jane"}])
+    out = format_custom_metadata(raw, max_chars=500, allowed_keys=None)
+    assert out == f"{METADATA_HEADER}\nauthor: Jane"
+
+
+def test_plain_dict_input_supported():
+    out = format_custom_metadata({"b": "2", "a": "1"}, max_chars=500, allowed_keys=None)
+    assert out == f"{METADATA_HEADER}\na: 1\nb: 2"
+
+
+def test_empty_and_none_values_skipped():
+    raw = [
+        {"key": "author", "value": "Jane"},
+        {"key": "empty", "value": ""},
+        {"key": "missing", "value": None},
+        {"key": "", "value": "no-key"},
+    ]
+    out = format_custom_metadata(raw, max_chars=500, allowed_keys=None)
+    assert out == f"{METADATA_HEADER}\nauthor: Jane"
+
+
+def test_sorting_is_deterministic():
+    raw = [
+        {"key": "zeta", "value": "z"},
+        {"key": "alpha", "value": "a"},
+        {"key": "mid", "value": "m"},
+    ]
+    out = format_custom_metadata(raw, max_chars=500, allowed_keys=None)
+    assert out == f"{METADATA_HEADER}\nalpha: a\nmid: m\nzeta: z"
+
+
+def test_internal_newlines_collapsed():
+    raw = [{"key": "note", "value": "line one\nline two   spaced"}]
+    out = format_custom_metadata(raw, max_chars=500, allowed_keys=None)
+    assert out == f"{METADATA_HEADER}\nnote: line one line two spaced"
+
+
+def test_truncation_to_max_chars():
+    raw = [{"key": "k", "value": "x" * 1000}]
+    out = format_custom_metadata(raw, max_chars=50, allowed_keys=None)
+    assert len(out) <= 50
+
+
+def test_allowlist_filters_keys():
+    raw = [
+        {"key": "author", "value": "Jane"},
+        {"key": "secret", "value": "hidden"},
+    ]
+    out = format_custom_metadata(raw, max_chars=500, allowed_keys=["author"])
+    assert out == f"{METADATA_HEADER}\nauthor: Jane"
+
+
+def test_allowlist_with_no_matches_returns_empty():
+    raw = [{"key": "author", "value": "Jane"}]
+    assert format_custom_metadata(raw, max_chars=500, allowed_keys=["nope"]) == ""
+
+
+def test_empty_inputs_return_empty_string():
+    assert format_custom_metadata(None, 500, None) == ""
+    assert format_custom_metadata([], 500, None) == ""
+    assert format_custom_metadata("", 500, None) == ""
+    assert format_custom_metadata("not json", 500, None) == ""
+    assert format_custom_metadata(123, 500, None) == ""
+
+
+def test_parse_allowed_keys():
+    assert parse_allowed_keys("") == []
+    assert parse_allowed_keys(None) == []
+    assert parse_allowed_keys("a, b ,c") == ["a", "b", "c"]
+    assert parse_allowed_keys(" , ,") == []
+
+
+# ---------------------------------------------------------------------------
+# Connector path: search_knowledge_base
+# ---------------------------------------------------------------------------
+
+def _make_search_client(mock_config, extra_cfg, patch_dependencies):
+    from connectors.search import SearchClient
+
+    base = {
+        "SEARCH_SERVICE_QUERY_ENDPOINT": "https://fake-search.search.windows.net",
+        "SEARCH_RAG_INDEX_NAME": "ragindex",
+        "SEARCH_APPROACH": "term",
+        "ALLOW_ANONYMOUS": "true",
+    }
+    base.update(extra_cfg)
+    mock_config.get.side_effect = lambda key, default=None, type=str: base.get(key, default)
+    with patch("connectors.search.get_config", return_value=mock_config):
+        client = SearchClient()
+    client._get_search_user_token_for_trimming = AsyncMock(return_value=None)
+    return client
+
+
+_DOC = {
+    "title": "Doc A",
+    "content": "Body text",
+    "filepath": "doc-a.pdf",
+    "custom_metadata": [
+        {"key": "author", "value": "Jane"},
+        {"key": "department", "value": "Finance"},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_flag_off_does_not_select_metadata_and_output_unchanged(patch_dependencies, mock_config):
+    client = _make_search_client(mock_config, {}, patch_dependencies)
+
+    search_mock = AsyncMock(return_value={"value": [dict(_DOC)]})
+    with patch.object(client, "search", search_mock):
+        result_json = await client.search_knowledge_base("hello")
+
+    # Select must be byte-for-byte the original string (no custom_metadata).
+    body = search_mock.call_args.kwargs["body"]
+    assert body["select"] == "title,content,url,filepath,chunk_id"
+    assert "custom_metadata" not in body["select"]
+
+    # Content is unchanged: no metadata block prepended, and no extra JSON key.
+    results = json.loads(result_json)["results"]
+    assert results[0]["content"] == "Body text"
+    assert "custom_metadata" not in results[0]
+    assert METADATA_HEADER not in result_json
+
+
+@pytest.mark.asyncio
+async def test_flag_on_selects_metadata_and_prepends_block(patch_dependencies, mock_config):
+    client = _make_search_client(
+        mock_config,
+        {
+            "SEARCH_INCLUDE_METADATA_IN_CONTEXT": True,
+            "SEARCH_METADATA_MAX_CHARS": 500,
+            "SEARCH_METADATA_ALLOWED_KEYS": "",
+        },
+        patch_dependencies,
+    )
+
+    search_mock = AsyncMock(return_value={"value": [dict(_DOC)]})
+    with patch.object(client, "search", search_mock):
+        result_json = await client.search_knowledge_base("hello")
+
+    body = search_mock.call_args.kwargs["body"]
+    assert body["select"] == "title,content,url,filepath,chunk_id,custom_metadata"
+
+    content = json.loads(result_json)["results"][0]["content"]
+    expected_block = f"{METADATA_HEADER}\nauthor: Jane\ndepartment: Finance"
+    assert content == f"{expected_block}\n\nBody text"
+
+
+# ---------------------------------------------------------------------------
+# Provider parity: SearchContextProvider
+# ---------------------------------------------------------------------------
+
+class _AsyncDocs:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def __aiter__(self):
+        async def gen():
+            for d in self._docs:
+                yield d
+        return gen()
+
+
+class _FakeAzureSearchClient:
+    """Stands in for azure.search.documents.aio.SearchClient."""
+
+    last_select = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def search(self, **kwargs):
+        type(self).last_select = kwargs.get("select")
+        return _AsyncDocs([dict(_DOC)])
+
+
+@pytest.mark.asyncio
+async def test_provider_flag_on_prepends_block(mock_config):
+    from strategies.search_context_provider import SearchContextProvider
+    from agent_framework import ChatMessage, Role
+
+    mock_config.get.side_effect = lambda key, default=None, type=str: {
+        "SEARCH_INCLUDE_METADATA_IN_CONTEXT": True,
+        "SEARCH_METADATA_MAX_CHARS": 500,
+        "SEARCH_METADATA_ALLOWED_KEYS": "",
+    }.get(key, default)
+
+    provider = SearchContextProvider(
+        endpoint="https://fake.search.windows.net",
+        index_name="ragindex",
+        credential=AsyncMock(),
+    )
+
+    with (
+        patch("strategies.search_context_provider.get_config", return_value=mock_config),
+        patch("strategies.search_context_provider.SearchClient", _FakeAzureSearchClient),
+    ):
+        ctx = await provider.invoking([ChatMessage(role=Role.USER, text="hello")])
+
+    assert "custom_metadata" in _FakeAzureSearchClient.last_select
+    text = ctx.messages[0].text
+    assert METADATA_HEADER in text
+    assert "author: Jane" in text
+    assert "department: Finance" in text


### PR DESCRIPTION
## Summary

Surfaces the already-indexed `custom_metadata` field into the per-document LLM context block across all three active retrieval paths, behind a default-off config flag. The approach is **additive and orchestrator-only** — no ingestion, embedding, or vector changes. Retrieval-influencing metadata stays out of scope (that is served by filters).

When `SEARCH_INCLUDE_METADATA_IN_CONTEXT` is on, a new pure helper (`src/util/metadata.py`) renders a sorted, size-capped `[Document metadata]` block and prepends it before each document's content in:

- `search_knowledge_base()` (default `single_agent_rag` path) in `src/connectors/search.py`
- `SearchContextProvider` in `src/strategies/search_context_provider.py`
- `MultimodalSearchContextProvider` in `src/strategies/multimodal_search_context_provider.py`

Closes #506

## Backward-compatibility note (important)

Pre-#487 indexes do **not** contain the `custom_metadata` field, and Azure AI Search returns a 400 for the entire query if a selected field is missing. To stay safe, the field is added to the search `select` **only when the flag is on**. With the default (off), the select string is byte-for-byte unchanged and there is zero risk to existing indexes. The raw value is also carried on the `SearchResult` model with `exclude=True` so serialized output is unchanged when the flag is off.

## Tests

New `tests/test_metadata_context.py`: helper unit tests (list input, JSON-string input, empty/None skipped, sorting, truncation, allow-list, empty -> ""), a flag-OFF test asserting `custom_metadata` is not selected and output is unchanged, and flag-ON tests asserting the block is prepended in the connector path and one provider. Full suite: **199 passed**.

## Docs follow-up for Steve

Not written here. Docs should cover:

- **New config keys:**
  - `SEARCH_INCLUDE_METADATA_IN_CONTEXT` (bool, default `false`) — master switch for the feature.
  - `SEARCH_METADATA_MAX_CHARS` (int, default `500`) — caps the rendered metadata block size per document.
  - `SEARCH_METADATA_ALLOWED_KEYS` (CSV, default empty = all keys) — optional allow-list of metadata keys to include.
- **Pre-#487 index requirement:** the index must contain the `custom_metadata` field (added in #487). Enabling the flag against an older index that lacks the field will cause Azure AI Search to reject queries with a 400. Re-index or confirm the field exists before turning the flag on.
- **Token-cost trade-off:** enabling this injects metadata into every retrieved document's context, increasing prompt token usage. `SEARCH_METADATA_MAX_CHARS` and `SEARCH_METADATA_ALLOWED_KEYS` exist to bound that cost.