### PR TITLE
ci: soft-fail dev Azure deployment connectivity

### DIFF
--- a/.github/workflows/cicd_pipeline.yaml
+++ b/.github/workflows/cicd_pipeline.yaml
@@ -26,18 +26,57 @@ jobs:
 
       - name: Verify azd version
         run: |
-          azd version 
+          azd version
 
       - name: Login to Azure CLI
+        id: azure_login
         uses: azure/login@v2
+        continue-on-error: true
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Warn when dev Azure login is unavailable
+        if: steps.azure_login.outcome != 'success'
+        run: |
+          echo "::warning title=Dev deployment skipped::Azure login failed for the dev environment. Build/test signals are still valid, but deployment was skipped until AZURE_CREDENTIALS/RBAC/subscription access is fixed."
+          {
+            echo "## Dev deployment skipped"
+            echo
+            echo "Azure login failed for the GitHub environment \`dev\`."
+            echo
+            echo "This workflow is temporarily configured to soft-fail Azure connectivity/authentication problems in dev so repository builds are not marked red while credentials are being repaired."
+            echo
+            echo "Fix \`AZURE_CREDENTIALS\`, RBAC/subscription access, and \`APP_CONFIG_ENDPOINT\`, then rerun this workflow to perform the deployment."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Setup Python 3.12
+        if: steps.azure_login.outcome == 'success'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Deploy to Azure
+        if: steps.azure_login.outcome == 'success'
         run: |
-          ./scripts/deploy.sh
+          set +e
+          ./scripts/deploy.sh 2>&1 | tee deploy.log
+          deploy_status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$deploy_status" -eq 0 ]; then
+            exit 0
+          fi
+
+          if grep -Eiq 'No subscriptions found|AuthorizationFailed|does not have authorization|Forbidden|AADSTS|az login|login failed|credential|authentication|subscription|could not resolve host|name or service not known|temporary failure in name resolution|connection timed out|connection refused|TLS|SSL|App Configuration|appcs-' deploy.log; then
+            echo "::warning title=Dev deployment skipped::Azure deployment failed because dev Azure authentication, authorization, subscription access, DNS, or App Configuration connectivity is unavailable. Build/test signals are still valid."
+            {
+              echo "## Dev deployment skipped"
+              echo
+              echo "The deployment script failed with an Azure authentication, authorization, subscription, DNS, or App Configuration connectivity error."
+              echo
+              echo "This dev-only workaround keeps the workflow green while the environment configuration is repaired. Non-Azure deploy failures still fail the job."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          exit "$deploy_status"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Dev CI/CD pipeline now soft-fails Azure environment connectivity failures.**
+  The `develop` deployment workflow now reports a GitHub Actions warning and
+  skips the `dev` deployment when Azure login, subscription/RBAC access, DNS, or
+  App Configuration connectivity is unavailable. Build/test failures and
+  non-Azure deployment failures still fail the job. This is a temporary
+  dev-only workaround until the `dev` environment credentials and
+  `APP_CONFIG_ENDPOINT` are repaired.
+
 ### Removed
 
 - Standalone `evaluations/` harness (scripts and pinned `requirements.txt`).


### PR DESCRIPTION
## Summary

Temporarily makes the `dev` deployment workflow fail gracefully when Azure environment access is unavailable.

## Behavior

- `azure/login` failures in the `dev` GitHub environment now emit a clear warning and skip deployment instead of making the whole workflow red.
- `scripts/deploy.sh` failures that match Azure authentication, authorization, subscription, DNS, TLS, or App Configuration connectivity problems also emit a warning and skip the deployment.
- Non-Azure deployment failures still fail the job.
- This is intentionally limited to `.github/workflows/cicd_pipeline.yaml`, which only runs on `develop` and targets the `dev` environment.

## Why

The current `dev` deployment is failing before deploy because `AZURE_CREDENTIALS` cannot access any subscription. Paulo asked to avoid configuring Azure credentials/RBAC right now and let the pipeline continue with a warning when Azure connectivity is unavailable.

## Validation

- Parsed `.github/workflows/cicd_pipeline.yaml` with Python/PyYAML successfully.
- Reviewed the workflow diff to ensure only the dev CI/CD deployment path is changed.
