### PR TITLE
ci: avoid red annotations for dev Azure login

### DIFF
--- a/.github/workflows/cicd_pipeline.yaml
+++ b/.github/workflows/cicd_pipeline.yaml
@@ -30,15 +30,35 @@ jobs:
 
       - name: Login to Azure CLI
         id: azure_login
-        uses: azure/login@v2
-        continue-on-error: true
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+        shell: bash
+        run: |
+          set +e
+          login_output=$(az login \
+            --service-principal \
+            --username "$AZURE_CLIENT_ID" \
+            --password "$AZURE_CLIENT_SECRET" \
+            --tenant "$AZURE_TENANT_ID" \
+            --output none 2>&1)
+          login_status=$?
+          set -e
+
+          if [ "$login_status" -eq 0 ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "available=false"
+            echo "reason<<EOF"
+            echo "$login_output"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::warning title=Dev deployment skipped::Azure login failed for the dev environment. Build/test signals are still valid, but deployment was skipped until AZURE_CREDENTIALS/RBAC/subscription access is fixed."
 
       - name: Warn when dev Azure login is unavailable
-        if: steps.azure_login.outcome != 'success'
+        if: steps.azure_login.outputs.available != 'true'
         run: |
-          echo "::warning title=Dev deployment skipped::Azure login failed for the dev environment. Build/test signals are still valid, but deployment was skipped until AZURE_CREDENTIALS/RBAC/subscription access is fixed."
           {
             echo "## Dev deployment skipped"
             echo
@@ -50,13 +70,13 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Setup Python 3.12
-        if: steps.azure_login.outcome == 'success'
+        if: steps.azure_login.outputs.available == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Deploy to Azure
-        if: steps.azure_login.outcome == 'success'
+        if: steps.azure_login.outputs.available == 'true'
         run: |
           set +e
           ./scripts/deploy.sh 2>&1 | tee deploy.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
   The `develop` deployment workflow now reports a GitHub Actions warning and
   skips the `dev` deployment when Azure login, subscription/RBAC access, DNS, or
   App Configuration connectivity is unavailable. Build/test failures and
-  non-Azure deployment failures still fail the job. This is a temporary
-  dev-only workaround until the `dev` environment credentials and
-  `APP_CONFIG_ENDPOINT` are repaired.
+  non-Azure deployment failures still fail the job. The Azure login step is
+  handled by the workflow shell so expected dev credential failures do not emit
+  extra red `azure/login` annotations. This is a temporary dev-only workaround
+  until the `dev` environment credentials and `APP_CONFIG_ENDPOINT` are
+  repaired.
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Removes the noisy red `azure/login` annotations from the temporary dev deployment soft-fail path.

## Behavior

- Replaces `azure/login@v2` in the dev workflow with a controlled `az login` shell step.
- Azure login failure now emits only a GitHub Actions warning and job summary.
- Deployment remains skipped when dev Azure credentials/RBAC/subscription access are unavailable.
- Non-Azure deployment failures still fail the job.

## Validation

- Parsed `.github/workflows/cicd_pipeline.yaml` with Python/PyYAML successfully.
