### PR TITLE
fix: Foundry IQ azureBlob snippet mapping + RBAC source-auth token forwarding (closes #508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Fixed
 
+- **Foundry IQ knowledge base retrieve: forward Search-audience token as
+  `x-ms-query-source-authorization` when no OBO token is available.** When a
+  knowledge base has `permissionFilterOption=enabled` and its knowledge source
+  uses `ingestionPermissionOptions=["rbacScope"]`, the retrieve action requires
+  a Search-audience token in `x-ms-query-source-authorization` to evaluate the
+  per-document RBAC filter — without it the service responds 502 ("Failed to
+  query search index"). `FoundryIQClient.retrieve` now falls back to the
+  service managed-identity token (acquired for `https://search.azure.com/.default`)
+  when no per-user OBO token is present, so anonymous chat against an
+  RBAC-filtered knowledge base no longer fails. The behavior is gated by the
+  new `FOUNDRY_IQ_FORWARD_SOURCE_AUTH` flag (default `true`) so operators can
+  disable it. This closes the orchestrator-side gap behind Azure/GPT-RAG#508
+  ("Orchestrator API does not work when RBAC is enabled") for the Foundry IQ
+  retrieval backend.
+
 - **Foundry IQ knowledge base retrieve: parse `azureBlob` reference shape
   correctly.** `FoundryIQClient._normalize_references` previously read
   `sourceData.content`, `sourceData.filepath`, and `sourceData.url`. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Foundry IQ knowledge base retrieve: parse `azureBlob` reference shape
+  correctly.** `FoundryIQClient._normalize_references` previously read
+  `sourceData.content`, `sourceData.filepath`, and `sourceData.url`. The
+  Foundry IQ `azureBlob` knowledge source returns `sourceData.snippet` and
+  `sourceData.blob_url` instead (true for both `contentExtractionMode=minimal`
+  and `standard`/OCR), with no `title` field, so every reference was being
+  dropped as empty. The parser now accepts both shapes with explicit priority
+  (`snippet` → `content` → `text`; `blob_url` → `url` → `filepath` → `path` →
+  reference-level `blobUrl`) and derives a human-readable title from the
+  blob/file name when `sourceData.title` is absent. This restores grounding
+  for scanned PDFs ingested via the Content Understanding skill and keeps the
+  Pattern B `searchIndex` path working unchanged.
+
 ## [v3.0.1] - 2026-06-26
 
 ### Added

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -223,20 +223,54 @@ class FoundryIQClient:
     def _normalize_references(payload: Dict[str, Any]) -> List[Dict[str, str]]:
         """Map a retrieve response into ``[{title, link, content}]`` records.
 
-        The knowledge base retrieve response carries a ``references`` array; each
-        reference exposes a ``sourceData`` object with the configured source
-        fields. We map defensively into the same ``title``/``link``/``content``
-        contract the Azure AI Search path emits so downstream citation handling
-        is identical across backends.
+        The knowledge base retrieve response carries a ``references`` array;
+        each reference exposes a ``sourceData`` object with the configured
+        source fields. Field names vary by knowledge source kind and content
+        extraction mode:
+
+        - ``azureBlob`` native sources (both ``minimal`` and ``standard``
+          content extraction) return ``sourceData.snippet`` and
+          ``sourceData.blob_url`` and do not include ``title``.
+        - ``searchIndex`` Pattern B sources return whatever the index
+          projects (typically ``content``, ``filepath``/``url``, ``title``).
+
+        We accept the union with explicit priority so the downstream
+        ``{title, link, content}`` contract is identical across backends,
+        and so a future small rename does not silently drop references.
+        Title falls back to the link's filename when the source does not
+        carry one (true for ``azureBlob`` references).
         """
         records: List[Dict[str, str]] = []
         for ref in payload.get("references", []) or []:
             source = ref.get("sourceData") or {}
-            title = source.get("title") or ref.get("docKey") or source.get("id") or "reference"
-            link = source.get("filepath") or source.get("url") or ""
-            content = source.get("content") or ""
+
+            content = (
+                source.get("snippet")
+                or source.get("content")
+                or source.get("text")
+                or ""
+            )
             if not content:
                 continue
+
+            link = (
+                source.get("blob_url")
+                or source.get("url")
+                or source.get("filepath")
+                or source.get("path")
+                or ref.get("blobUrl")
+                or ""
+            )
+
+            title = source.get("title") or ref.get("docKey") or source.get("id")
+            if not title and link:
+                # Derive a human-friendly title from the blob/file name so the
+                # citation surface is not an opaque uid.
+                tail = link.rsplit("/", 1)[-1]
+                title = tail.split("?", 1)[0] or None
+            if not title:
+                title = "reference"
+
             records.append({"title": title, "link": link, "content": content})
         return records
 

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -46,6 +46,7 @@ FOUNDRY_IQ_PATTERN_KEY = "FOUNDRY_IQ_PATTERN"
 FOUNDRY_IQ_FILTER_ADD_ON_ENABLED_KEY = "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED"
 FOUNDRY_IQ_SECURITY_FIELD_NAME_KEY = "FOUNDRY_IQ_SECURITY_FIELD_NAME"
 FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS_KEY = "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS"
+FOUNDRY_IQ_FORWARD_SOURCE_AUTH_KEY = "FOUNDRY_IQ_FORWARD_SOURCE_AUTH"
 
 # Search-audience scope used for the service token.
 _SEARCH_SCOPE = "https://search.azure.com/.default"
@@ -184,6 +185,17 @@ class FoundryIQClient:
         self.max_output_documents = _as_optional_int(
             self.cfg.get(FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS_KEY, None)
         )
+        # When true (default), and no per-user OBO token is available, the
+        # service managed-identity Search-audience token is forwarded as
+        # ``x-ms-query-source-authorization`` so Foundry IQ can evaluate
+        # RBAC-scoped permission filters on the bound knowledge source. This
+        # is required by knowledge bases whose index has
+        # ``permissionFilterOption=enabled`` and whose knowledge source uses
+        # ``ingestionPermissionOptions=["rbacScope"]`` — without it the
+        # retrieve action returns 502 ("Failed to query search index").
+        self.forward_source_auth = _as_bool(
+            self.cfg.get(FOUNDRY_IQ_FORWARD_SOURCE_AUTH_KEY, True, type=bool)
+        )
         self.credential = self.cfg.aiocredential
 
         # Shared aiohttp session — reuses TCP connections across calls.
@@ -314,9 +326,28 @@ class FoundryIQClient:
         if obo_token:
             # Per-user document-level security (query-time ACL/RBAC enforcement).
             headers["x-ms-query-source-authorization"] = obo_token
-            logging.info("[FoundryIQClient][Trimming] Using x-ms-query-source-authorization (OBO)")
+            logging.info(
+                "[FoundryIQClient][Trimming] x-ms-query-source-authorization=present "
+                "token_audience=%s source=obo",
+                _SEARCH_SCOPE,
+            )
+        elif self.forward_source_auth:
+            # Anonymous/unauth chat path: forward the service MI Search-audience
+            # token so Foundry IQ can evaluate RBAC-scope permission filters on
+            # the bound knowledge source. The MI itself must hold the relevant
+            # data-plane role on the storage container (or other source) for
+            # the filter to admit documents.
+            headers["x-ms-query-source-authorization"] = token
+            logging.info(
+                "[FoundryIQClient][Trimming] x-ms-query-source-authorization=present "
+                "token_audience=%s source=managed_identity",
+                _SEARCH_SCOPE,
+            )
         else:
-            logging.info("[FoundryIQClient][Trimming] Not sending x-ms-query-source-authorization")
+            logging.info(
+                "[FoundryIQClient][Trimming] x-ms-query-source-authorization=absent "
+                "reason=FOUNDRY_IQ_FORWARD_SOURCE_AUTH=false and no OBO token"
+            )
 
         if conversation_id:
             logging.debug("[FoundryIQClient] conversation_id=%s", conversation_id)

--- a/tests/test_foundry_iq.py
+++ b/tests/test_foundry_iq.py
@@ -71,6 +71,7 @@ def _build_client(payload, status=200, config_overrides=None):
         "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED": False,
         "FOUNDRY_IQ_SECURITY_FIELD_NAME": "metadata_security_id",
         "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": None,
+        "FOUNDRY_IQ_FORWARD_SOURCE_AUTH": True,
     }
     values.update(config_overrides or {})
     cfg = MagicMock()
@@ -229,9 +230,27 @@ async def test_pattern_b_filter_add_on_requires_preview_api():
 
 @pytest.mark.asyncio
 async def test_retrieve_omits_obo_header_when_no_token():
-    client, session = _build_client(_SAMPLE_PAYLOAD)
+    """When forwarding is disabled and no OBO token is supplied, the
+    ``x-ms-query-source-authorization`` header must be omitted entirely."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={"FOUNDRY_IQ_FORWARD_SOURCE_AUTH": False},
+    )
     await client.retrieve("hello")
     assert "x-ms-query-source-authorization" not in session.captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_forwards_managed_identity_token_when_no_obo():
+    """Anonymous chat path: the service MI Search-audience token must be
+    forwarded as ``x-ms-query-source-authorization`` so RBAC-scoped permission
+    filters on the bound knowledge source can be evaluated."""
+    client, session = _build_client(_SAMPLE_PAYLOAD)
+    await client.retrieve("hello")
+    headers = session.captured["headers"]
+    assert headers["Authorization"] == "Bearer svc-token"
+    # MI token reused as the source-auth token when no OBO token is present.
+    assert headers["x-ms-query-source-authorization"] == "svc-token"
 
 
 @pytest.mark.asyncio

--- a/tests/test_foundry_iq.py
+++ b/tests/test_foundry_iq.py
@@ -241,6 +241,54 @@ async def test_retrieve_raises_on_http_error():
         await client.retrieve("hello")
 
 
+@pytest.mark.asyncio
+async def test_retrieve_normalizes_azure_blob_snippet_shape():
+    """Real azureBlob payloads (both minimal and standard extraction modes)
+    return ``sourceData.snippet`` and ``sourceData.blob_url`` and do not
+    include ``title``; the parser must map those to the shared contract."""
+    payload = {
+        "references": [
+            {
+                "type": "azureBlob",
+                "id": "0",
+                "sourceData": {
+                    "uid": "abc_pages_0",
+                    "blob_url": "https://acct.blob.core.windows.net/documents/vw-fuel-system.pdf",
+                    "snippet": "# Fuel System\n\nThe fuel system, as covered...",
+                },
+                "blobUrl": "https://acct.blob.core.windows.net/documents/vw-fuel-system.pdf",
+            },
+            {
+                "type": "azureBlob",
+                "id": "1",
+                "sourceData": {
+                    "uid": "def_pages_0",
+                    "blob_url": "https://acct.blob.core.windows.net/documents/foundry-iq-validation.txt",
+                    "snippet": "Foundry IQ validation marker.",
+                },
+            },
+            {
+                # Empty snippet is dropped (matches the empty-content rule).
+                "sourceData": {"blob_url": "https://x/empty.txt", "snippet": ""},
+            },
+        ]
+    }
+    client, _ = _build_client(payload)
+    records = await client.retrieve("fuel system")
+    assert records == [
+        {
+            "title": "vw-fuel-system.pdf",
+            "link": "https://acct.blob.core.windows.net/documents/vw-fuel-system.pdf",
+            "content": "# Fuel System\n\nThe fuel system, as covered...",
+        },
+        {
+            "title": "foundry-iq-validation.txt",
+            "link": "https://acct.blob.core.windows.net/documents/foundry-iq-validation.txt",
+            "content": "Foundry IQ validation marker.",
+        },
+    ]
+
+
 # ---------------------------------------------------------------------------
 # FoundryIQContextProvider.invoking
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes to make Foundry IQ KB retrieval work end-to-end against RBAC-filtered indexes in GPT-RAG v3.0.2.

### 1. Snippet/blob_url mapping (original commit)

Fix the Foundry IQ knowledge base `retrieve` response parser so it correctly handles the `azureBlob` knowledge source shape. Previously, `FoundryIQClient._normalize_references` read `sourceData.content`, `sourceData.filepath`, and `sourceData.url`, but the live `azureBlob` response returns `sourceData.snippet` and `sourceData.blob_url` with no `title` — so every reference was dropped as empty and the user saw no grounding.

This is true for both `contentExtractionMode=minimal` and `standard` (OCR via the Content Understanding skill), so the same fix unblocks scanned PDFs (e.g. 28-page `vw-fuel-system.pdf`) and small text files alike.

### 2. Forward managed-identity Search token as `x-ms-query-source-authorization` (commit b2f9cf7) — closes #508

When the bound knowledge source has `ingestionPermissionOptions=["rbacScope"]` and the index has `permissionFilterOption=enabled`, Foundry IQ `POST /knowledgebases/{kb}/retrieve` returns **502 ("Failed to query search index")** unless the request also carries `x-ms-query-source-authorization` with a Search-audience (`https://search.azure.com/.default`) token.

The connector already forwarded the per-user OBO token when chat auth was on, but for anonymous chat (and for system flows where no OBO token is available) the header was dropped — which is exactly the failure mode reported in **Azure/GPT-RAG#508 — Orchestrator API does not work when RBAC is enabled**.

This change keeps OBO-first behavior and adds a managed-identity fallback so the orchestrator continues to work against RBAC-filtered indexes when no user token is present:

- `FOUNDRY_IQ_FORWARD_SOURCE_AUTH` (default `True`) — env flag gating the MI fallback, so operators can disable it.
- When OBO is present: forward it as `x-ms-query-source-authorization` (existing behavior).
- When OBO is absent and the flag is on: acquire the same MI Search-audience token used for `Authorization` and send it as the source-auth header.
- When OBO is absent and the flag is off: omit the header and log the explicit reason.
- Secret-safe logs only — token audience and source (`obo`/`managed_identity`) are logged, never the token.

## Change

- `src/connectors/foundry_iq.py`
  - **Snippet/blob_url mapping**: accept multiple field names with explicit priority:
    - content: `snippet` -> `content` -> `text`
    - link: `blob_url` -> `url` -> `filepath` -> `path` -> reference-level `blobUrl`
    - title: `sourceData.title` -> `ref.docKey` -> `sourceData.id` -> derived from blob filename -> `"reference"`
  - **Source-auth fallback**: `FOUNDRY_IQ_FORWARD_SOURCE_AUTH_KEY` config, `self.forward_source_auth` flag, MI Search-audience token forwarded when no OBO token; secret-safe logging.
- `tests/test_foundry_iq.py`
  - `test_retrieve_normalizes_azure_blob_snippet_shape` (real-world `azureBlob` payload).
  - `test_retrieve_omits_obo_header_when_no_token` updated to set `FOUNDRY_IQ_FORWARD_SOURCE_AUTH: False`.
  - New `test_retrieve_forwards_managed_identity_token_when_no_obo` asserts MI fallback path.
- `CHANGELOG.md` — `Unreleased > Fixed` entries for both fixes, referencing #508.

## Validation

- `pytest` — **262 passed** (was 261 before the source-auth tests).
- Image `crrf6um4jqd4h3o.azurecr.io/azure-gpt-rag/orchestrator:b2f9cf7-foundryiq-sourceauth` built via `az acr build`, deployed as revision `ca-rf6um4jqd4h3o-orchestrator--0000006` (Healthy).
- App Config flipped to v3 (`KNOWLEDGE_BASE_NAME=ragindex-rf6um4jqd4h3o-rag-kb-v3`, `FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME=ragindex-rf6um4jqd4h3o-blob-ks-v3`).
- **Live end-to-end against the standard / OCR KB**:
  - Q: *"What does the Foundry IQ validation marker text say in vw-fuel-system.pdf? Quote it exactly."* -> A correctly quotes `"Foundry IQ validation marker: native blob retrieval works for GPT-RAG v3.0.2."` with citation `[foundry-iq-validation.txt]`.
  - Q: *"From vw-fuel-system.pdf, summarize the fuel pump pressure specification."* -> A grounds with `Maximum delivery pressure: 3.0-5.0 psi (0.20-0.35 kg/cm2) for single-carburetor engines, 5.0 psi (0.35 kg/cm2) for dual-carburetor engines` and cites `vw-fuel-system.pdf`.
  - Container logs confirm `[FoundryIQClient][Trimming] x-ms-query-source-authorization=present token_audience=https://search.azure.com/.default source=managed_identity` followed by `Retrieved N references` (no more 502).
- Orchestrator MI RBAC already covers `Search Index Data Reader`, `Storage Blob Data Reader`, and the rest. No new role assignments needed.

## Closes

- Closes Azure/GPT-RAG#508 — Orchestrator API does not work when RBAC is enabled.

## Target branch

`develop` (feature branch, per repo `.github/copilot-instructions.md`).
