### PR TITLE
fix: use MCR base images for orchestrator builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **MCR-hosted base images replace Docker Hub.** The Dockerfile now uses
+  MCR-hosted Node.js and Python dev container images for the frontend build and
+  orchestrator runtime stages, avoiding Docker Hub base-image pulls during local
+  Docker builds and remote ACR builds. Remote `az acr build` deployment now has
+  bounded, visible retries so transient registry or base-image availability
+  failures show attempt counts before ending with actionable troubleshooting
+  guidance.
+
 ## [v3.0.2] - 2026-06-26
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: build the dashboard SPA. The output is copied into the Python
 # image below and served by FastAPI when ENABLE_DASHBOARD is true.
 # ---------------------------------------------------------------------------
-FROM node:20-slim AS frontend-build
+FROM mcr.microsoft.com/devcontainers/javascript-node:20-bookworm AS frontend-build
 WORKDIR /build
 COPY frontend/package*.json ./frontend/
 RUN cd frontend && npm install --no-audit --no-fund
@@ -13,8 +13,8 @@ RUN cd frontend && npm run build
 # ---------------------------------------------------------------------------
 # Stage 2: orchestrator runtime
 # ---------------------------------------------------------------------------
-# Use the official slim Python 3.12 image
-FROM python:3.12-slim
+# Use an MCR-hosted Python 3.12 image to avoid Docker Hub pulls in local and ACR builds.
+FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm
 
 # 1. Install OS prerequisites used to add external APT repositories and verify packages
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The data comes from the existing conversation/history Cosmos DB container used b
 
 **Token scope.** The frontend must request an access token with the orchestrator's own API scope (`api://<client_id>/...`), not a Microsoft Graph scope. App roles are issued in the `roles` claim of an access token only when the token is requested for the application that defines those roles, so a Graph-scoped token will not surface the `Admin` role and every dashboard call will return 403.
 
-**Building the dashboard bundle.** Production builds happen automatically as part of the `Dockerfile` (a `node:20-slim` stage runs `npm run build` and copies the static assets into `src/static`). For local development you can run the Vite dev server with hot reload:
+**Building the dashboard bundle.** Production builds happen automatically as part of the `Dockerfile` (an MCR base image stage using Node.js 20 runs `npm run build` and copies the static assets into `src/static`). For local development you can run the Vite dev server with hot reload:
 
 ```bash
 cd frontend

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -37,6 +37,36 @@ function Invoke-ExternalCommand {
     return $output
 }
 
+function Invoke-ExternalCommandWithRetry {
+    param(
+        [Parameter(Mandatory=$true)][string]$FilePath,
+        [Parameter()][string[]]$Arguments = @(),
+        [Parameter(Mandatory=$true)][string]$What,
+        [Parameter()][int]$MaxAttempts = 3,
+        [Parameter()][int]$DelaySeconds = 15
+    )
+
+    $finalExitCode = 1
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        Write-Blue ("{0} attempt {1}/{2}..." -f $What, $attempt, $MaxAttempts)
+        $output = & $FilePath @Arguments 2>&1
+        $finalExitCode = $LASTEXITCODE
+        if ($finalExitCode -eq 0) {
+            return $output
+        }
+
+        Write-Yellow ("{0} attempt {1}/{2} failed (exit {3})." -f $What, $attempt, $MaxAttempts, $finalExitCode)
+        if ($output) { Write-Host ($output | Out-String) }
+        if ($attempt -lt $MaxAttempts) {
+            Write-Yellow ("Retrying {0} in {1} seconds..." -f $What, $DelaySeconds)
+            Start-Sleep -Seconds $DelaySeconds
+        }
+    }
+
+    Write-ErrorColored ("Failed: {0} after {1} attempts. Verify ACR network access, MCR base image availability, registry permissions, and ACR task agent pool settings if configured." -f $What, $MaxAttempts)
+    exit $finalExitCode
+}
+
 function Get-CliOutputValue {
     param(
         [Parameter(Mandatory=$true)][AllowEmptyCollection()][object[]]$Output,
@@ -344,7 +374,7 @@ if ($buildMode -eq 'local') {
         $acrBuildArgs += @('--agent-pool',$env:ACR_TASK_AGENT_POOL)
     }
     $acrBuildArgs += '.'
-    Invoke-ExternalCommand -FilePath 'az' -Arguments $acrBuildArgs -What 'ACR remote build' | Out-Null
+    Invoke-ExternalCommandWithRetry -FilePath 'az' -Arguments $acrBuildArgs -What 'ACR remote build' | Out-Null
     Write-Green 'Remote build completed.'
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,6 +22,35 @@ success() { echo -e "${GREEN}$*${NC}" >&2; }
 warn() { echo -e "${YELLOW}$*${NC}" >&2; }
 error() { echo -e "${RED}$*${NC}" >&2; }
 
+run_with_retry() {
+  local description="$1"
+  local max_attempts="$2"
+  local delay_seconds="$3"
+  shift 3
+
+  local attempt status=1
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    info "${description} attempt ${attempt}/${max_attempts}..."
+    set +e
+    "$@"
+    status=$?
+    set -e
+
+    if [[ $status -eq 0 ]]; then
+      return 0
+    fi
+
+    warn "${description} attempt ${attempt}/${max_attempts} failed (exit ${status})."
+    if (( attempt < max_attempts )); then
+      warn "Retrying ${description} in ${delay_seconds} seconds..."
+      sleep "$delay_seconds"
+    fi
+  done
+
+  error "Failed: ${description} after ${max_attempts} attempts. Verify ACR network access, MCR base image availability, registry permissions, and ACR task agent pool settings if configured."
+  exit "$status"
+}
+
 select_cli_value() {
   local expected="${1:-}"
   local line trimmed fallback=""
@@ -303,7 +332,7 @@ else
     acr_build_args+=(--agent-pool "$ACR_TASK_AGENT_POOL")
   fi
   acr_build_args+=(.)
-  az "${acr_build_args[@]}"
+  run_with_retry "ACR remote build" 3 15 az "${acr_build_args[@]}"
   success "Remote build completed."
 fi
 


### PR DESCRIPTION
## Purpose
Replace Docker Hub base images in the orchestrator Dockerfile with verified MCR-hosted images and make remote ACR builds more resilient to transient registry/base-image availability failures.

## Changes
- Replaced the frontend build stage base image with mcr.microsoft.com/devcontainers/javascript-node:20-bookworm.
- Replaced the Python runtime base image with mcr.microsoft.com/devcontainers/python:3.12-bookworm.
- Added bounded, visible retry handling around remote z acr build in both PowerShell and Bash deploy scripts.
- Updated README and CHANGELOG under Unreleased.

## Validation
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check
- PowerShell parser validation for scripts/deploy.ps1
- C:\Program Files\Git\bin\bash.exe -n scripts/deploy.sh
- Static Dockerfile parse check for stages and COPY --from
- docker manifest inspect for both new MCR base images
- 
pm --prefix frontend run build

## Not run
- Live docker buildx build --check / Docker build: Docker Desktop Linux engine was not running in this environment.
- Live ACR build: skipped to avoid consuming Azure build resources without an explicitly selected validation environment.