### PR TITLE
fix: harden NL2SQL read-only validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **NL2SQL read-only enforcement:** Hardened NL2SQL SQL execution so only a
+  single read-only `SELECT` query is accepted before execution. Operators should
+  also ensure every configured SQL Server, Azure SQL, or Fabric SQL datasource
+  uses a least-privilege read-only principal with access only to approved
+  schemas, tables, or views.
+
 ## [v3.0.3] - 2026-06-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The **GPT-RAG Orchestrator** service is an agentic orchestration layer built on 
 | `mcp` | MCP | Model Context Protocol strategy using Semantic Kernel. |
 | `nl2sql` | NL2SQL | Natural language to SQL translation strategy for structured data queries. |
 
+### NL2SQL datasource security
+
+> [!IMPORTANT]
+> When using the `nl2sql` strategy, configure every SQL Server, Azure SQL, or Fabric SQL datasource with a least-privilege read-only principal. Grant only the `SELECT` permissions needed for approved schemas, tables, or views, and do not use admin, owner, contributor, ingestion, or write-capable identities for NL2SQL query execution. The orchestrator validates generated SQL before execution, but database permissions remain the primary security boundary.
+
 ## Documentation
 
 For comprehensive information about GPT-RAG, including architecture details, configuration guides, best practices, troubleshooting resources, deployment guidance, customization options, and advanced usage scenarios, please refer to the [official project documentation](https://azure.github.io/GPT-RAG/).

--- a/src/plugins/nl2sql/plugin.py
+++ b/src/plugins/nl2sql/plugin.py
@@ -17,6 +17,7 @@ from .nl2sql_types import (
     TablesRetrievalResult,
     ValidateSQLQueryResult,
 )
+from .sql_validation import validate_single_read_only_select
 
 from connectors import (
     get_cosmosdb_client,
@@ -299,15 +300,8 @@ class NL2SQLPlugin:
         self,
         query: Annotated[str, "SQL Query"]
     ) -> ValidateSQLQueryResult:
-        try:
-            import sqlparse
-            parsed = sqlparse.parse(query)
-            if parsed and len(parsed) > 0:
-                return ValidateSQLQueryResult(is_valid=True)
-            else:
-                return ValidateSQLQueryResult(is_valid=False, error="Query could not be parsed.")
-        except Exception as e:
-            return ValidateSQLQueryResult(is_valid=False, error=str(e))
+        validation = validate_single_read_only_select(query)
+        return ValidateSQLQueryResult(is_valid=validation.is_valid, error=validation.error)
 
     async def execute_dax_query(
         self,
@@ -345,6 +339,11 @@ class NL2SQLPlugin:
         # log entry and parameters
         logging.info(f"execute_sql_query called with datasource={datasource}, query={query}")
         try:
+            validation = validate_single_read_only_select(query)
+            if not validation.is_valid:
+                logging.error(f"Rejected SQL query: {validation.error}")
+                return ExecuteQueryResult(error=validation.error)
+
             cosmosdb = self.cosmos
             datasource_config = await cosmosdb.get_document(self.container_name, datasource)
             logging.debug(f"Datasource config fetched: {datasource_config}")
@@ -386,11 +385,6 @@ class NL2SQLPlugin:
             logging.info("Creating SQL connection")
             connection = await sql_client.create_connection()
             cursor = connection.cursor()
-
-            # only SELECT allowed
-            if not query.strip().lower().startswith('select'):
-                logging.error("Rejected non-SELECT statement")
-                return ExecuteQueryResult(error="Only SELECT statements are allowed.")
 
             logging.info("Executing SQL query")
             cursor.execute(query)

--- a/src/plugins/nl2sql/sql_validation.py
+++ b/src/plugins/nl2sql/sql_validation.py
@@ -1,0 +1,132 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import sqlparse
+from sqlparse import tokens as T
+from sqlparse.sql import Statement, Token, TokenList
+
+
+@dataclass(frozen=True)
+class SQLReadOnlyValidation:
+    is_valid: bool
+    error: Optional[str] = None
+
+
+_MUTATING_KEYWORDS = {
+    "ALTER",
+    "BACKUP",
+    "BEGIN",
+    "COMMIT",
+    "CREATE",
+    "DELETE",
+    "DENY",
+    "DROP",
+    "EXEC",
+    "EXECUTE",
+    "GRANT",
+    "INSERT",
+    "MERGE",
+    "RESTORE",
+    "REVOKE",
+    "ROLLBACK",
+    "TRUNCATE",
+    "UPDATE",
+    "USE",
+    "WAITFOR",
+}
+
+_PASS_THROUGH_FUNCTIONS = {
+    "OPENDATASOURCE",
+    "OPENQUERY",
+    "OPENROWSET",
+}
+
+
+def validate_single_read_only_select(query: str) -> SQLReadOnlyValidation:
+    if not query or not query.strip():
+        return SQLReadOnlyValidation(False, "Query is empty.")
+
+    statements = sqlparse.parse(query)
+    if not statements:
+        return SQLReadOnlyValidation(False, "Query could not be parsed.")
+
+    if len(statements) != 1:
+        return SQLReadOnlyValidation(
+            False,
+            "Only one SQL statement is allowed.",
+        )
+
+    statement = statements[0]
+    first_token = _first_significant_token(statement)
+    if not first_token or first_token.normalized.upper() not in {"SELECT", "WITH"}:
+        return SQLReadOnlyValidation(False, "Only SELECT statements are allowed.")
+
+    if statement.get_type() != "SELECT":
+        return SQLReadOnlyValidation(False, "Only SELECT statements are allowed.")
+
+    pass_through_function = _find_pass_through_function(statement)
+    if pass_through_function:
+        return SQLReadOnlyValidation(
+            False,
+            f"Function '{pass_through_function}' is not allowed in NL2SQL queries.",
+        )
+
+    mutating_keyword = _find_mutating_keyword(statement)
+    if mutating_keyword:
+        return SQLReadOnlyValidation(
+            False,
+            f"Keyword '{mutating_keyword}' is not allowed in NL2SQL queries.",
+        )
+
+    if _contains_select_into(statement):
+        return SQLReadOnlyValidation(
+            False,
+            "SELECT INTO statements are not allowed.",
+        )
+
+    return SQLReadOnlyValidation(True)
+
+
+def _first_significant_token(statement: Statement) -> Optional[Token]:
+    for token in statement.tokens:
+        if _is_ignorable_token(token):
+            continue
+        return token
+    return None
+
+
+def _find_mutating_keyword(token_list: TokenList) -> Optional[str]:
+    for token in token_list.flatten():
+        if _is_ignorable_token(token):
+            continue
+        keyword = token.normalized.upper()
+        if keyword in _MUTATING_KEYWORDS:
+            return keyword
+    return None
+
+
+def _find_pass_through_function(token_list: TokenList) -> Optional[str]:
+    for token in token_list.flatten():
+        if _is_ignorable_token(token):
+            continue
+        function = token.normalized.upper()
+        if function in _PASS_THROUGH_FUNCTIONS:
+            return function
+    return None
+
+
+def _contains_select_into(token_list: TokenList) -> bool:
+    for token in token_list.flatten():
+        if _is_ignorable_token(token):
+            continue
+        if token.normalized.upper() == "INTO" and token.ttype in T.Keyword:
+            return True
+    return False
+
+
+def _is_ignorable_token(token: Token) -> bool:
+    if token.is_whitespace or token.ttype in T.Comment:
+        return True
+
+    value = str(token).lstrip()
+    return value.startswith("--") or value.startswith("/*")

--- a/src/strategies/nl2sql_strategy.py
+++ b/src/strategies/nl2sql_strategy.py
@@ -161,7 +161,7 @@ class NL2SQLStrategy(BaseAgentStrategy):
             if fenced:
                 query = fenced.group(1)
         if not query:
-            select_match = re.search(r"\bselect\b.*?(?:;|$)", response, flags=re.IGNORECASE | re.DOTALL)
+            select_match = re.search(r"\bselect\b.*", response, flags=re.IGNORECASE | re.DOTALL)
             if select_match:
                 query = select_match.group(0)
         if not query:

--- a/tests/test_nl2sql_sql_validation.py
+++ b/tests/test_nl2sql_sql_validation.py
@@ -1,0 +1,119 @@
+import pytest
+
+from plugins.nl2sql.plugin import NL2SQLPlugin
+from plugins.nl2sql.sql_validation import validate_single_read_only_select
+from strategies.nl2sql_strategy import NL2SQLStrategy
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1; UPDATE dbo.Orders SET Amount = 0; COMMIT",
+        "SELECT 1; DELETE FROM dbo.Orders",
+        "SELECT 1; DROP TABLE dbo.Orders",
+        "SELECT 1; EXEC dbo.RefreshOrders",
+        "  SELECT 1;\n/* hidden write */\nUPDATE dbo.Orders SET Amount = 0",
+        "SELECT 1;\n-- hidden write\nDELETE FROM dbo.Orders",
+        "SELECT 1; ; DROP TABLE dbo.Orders",
+        "SELECT * INTO dbo.OrderSnapshot FROM dbo.Orders",
+        "SELECT * FROM OPENQUERY([linked], 'UPDATE dbo.Orders SET Amount = 0')",
+        "SELECT * FROM OPENROWSET('SQLNCLI', 'Server=server;', 'DELETE FROM dbo.Orders')",
+        "SELECT * FROM OPENDATASOURCE('SQLNCLI', 'Data Source=server').db.dbo.Orders",
+        "UPDATE dbo.Orders SET Amount = 0",
+    ],
+)
+def test_validate_single_read_only_select_rejects_unsafe_queries(query):
+    result = validate_single_read_only_select(query)
+
+    assert result.is_valid is False
+    assert result.error
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1",
+        "SELECT 1;",
+        """
+        /* dashboard summary */
+        SELECT TOP (10)
+            o.OrderId,
+            c.Name AS CustomerName,
+            SUM(o.Amount) AS TotalAmount
+        FROM dbo.Orders AS o
+        INNER JOIN dbo.Customers AS c
+            ON c.CustomerId = o.CustomerId
+        WHERE o.CreatedAt >= '2026-01-01'
+            AND o.Status IN ('Open', 'Closed')
+        GROUP BY o.OrderId, c.Name
+        HAVING SUM(o.Amount) > 100
+        ORDER BY TotalAmount DESC;
+        """,
+        """
+        SELECT
+            p.ProductId,
+            p.Name
+        FROM dbo.Products p
+        WHERE p.IsActive = 1
+        ORDER BY p.Name
+        OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY
+        """,
+        """
+        WITH regional_orders AS (
+            SELECT
+                Region,
+                COUNT(*) AS OrderCount
+            FROM dbo.Orders
+            GROUP BY Region
+        )
+        SELECT Region, OrderCount
+        FROM regional_orders
+        WHERE OrderCount > 10
+        ORDER BY OrderCount DESC;
+        """,
+        """
+        SELECT
+            Region,
+            COUNT(*) AS OrderCount
+        FROM dbo.Orders
+        GROUP BY Region
+        ORDER BY OrderCount DESC
+        LIMIT 10
+        """,
+    ],
+)
+def test_validate_single_read_only_select_allows_normal_select_queries(query):
+    result = validate_single_read_only_select(query)
+
+    assert result.is_valid is True
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_validate_sql_query_uses_read_only_validation():
+    plugin = NL2SQLPlugin.__new__(NL2SQLPlugin)
+
+    result = await plugin.validate_sql_query("SELECT 1; DROP TABLE dbo.Orders")
+
+    assert result.is_valid is False
+    assert result.error == "Only one SQL statement is allowed."
+
+
+@pytest.mark.asyncio
+async def test_execute_sql_query_rejects_unsafe_query_before_datasource_access():
+    plugin = NL2SQLPlugin.__new__(NL2SQLPlugin)
+
+    result = await plugin.execute_sql_query("sales", "SELECT 1; DELETE FROM dbo.Orders")
+
+    assert result.results is None
+    assert result.error == "Only one SQL statement is allowed."
+
+
+def test_extract_sql_query_preserves_stacked_statement_for_validation():
+    strategy = NL2SQLStrategy.__new__(NL2SQLStrategy)
+
+    query = strategy._extract_sql_query(
+        "Generated SQL:\nSELECT 1;\n/* hidden write */\nDROP TABLE dbo.Orders;"
+    )
+
+    assert query == "SELECT 1;\n/* hidden write */\nDROP TABLE dbo.Orders"


### PR DESCRIPTION
## Purpose

Harden the NL2SQL SQL execution path so generated SQL must pass structural read-only validation before any datasource connection executes it.

## Changes

- Adds shared NL2SQL SQL validation requiring exactly one read-only `SELECT` statement.
- Rejects stacked SQL batches, mutating statements, `SELECT INTO`, and SQL pass-through functions before `cursor.execute`.
- Preserves extracted stacked SQL so validation can reject it instead of truncating trailing statements.
- Adds NL2SQL datasource security guidance for least-privilege read-only SQL/Fabric principals.
- Adds an Unreleased changelog entry for the security hardening.

## Validation

- `pytest tests\test_nl2sql_sql_validation.py tests\test_nl2sql_strategy.py -q` — 23 passed.
- `pytest -q` — 283 passed.
- Security review pass — no blocking findings after follow-up hardening.