### PR TITLE
Fix Foundry IQ conversation upload filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Foundry IQ conversation upload filter compatibility:** Changed the
+  conversational upload sidecar to send the Foundry IQ accepted
+  `filterAddOn` format `conversationId eq '<conversation-id>'` instead of the
+  compound Pattern B security and shared-corpus filter. This restores chat
+  retrieval for documents uploaded into a conversation while keeping the native
+  Blob source unchanged and continuing to forward source authorization for
+  Foundry IQ permission enforcement.
+
+- **Configuration allowlist import:** Restored the missing
+  `SEARCH_RETRIEVAL_ENABLED` setting wrapper in the dashboard configuration
+  allowlist so the settings module imports cleanly and the full test suite can
+  run against the patch.
+
 ## [v3.1.0] - 2026-07-02
 
 ### Added

--- a/src/api/config_settings.py
+++ b/src/api/config_settings.py
@@ -375,10 +375,11 @@ SECTIONS: List[SettingSection] = [
                     "source is the native azureBlob corpus, also query a second "
                     "searchIndex source built over the existing GPT-RAG index so "
                     "files uploaded in the chat UI are grounded alongside the "
-                    "shared corpus. The upload source is always trimmed by a "
-                    "security + conversationId filterAddOn, so uploads stay "
-                    "scoped to the conversation that created them. No effect for "
-                    "Pattern B, which already scopes by conversationId."
+                    "shared corpus. The upload source is trimmed by a simple "
+                    "conversationId filterAddOn accepted by Foundry IQ, so "
+                    "uploads stay scoped to the conversation that created them. "
+                    "No effect for Pattern B, which already scopes by "
+                    "conversationId."
                 ),
             ),
             SettingSpec(
@@ -394,6 +395,8 @@ SECTIONS: List[SettingSection] = [
                     "deployment set it."
                 ),
             ),
+            SettingSpec(
+                key="SEARCH_RETRIEVAL_ENABLED",
                 type="bool",
                 default=True,
                 label="Enable Azure AI Search retrieval",

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -51,8 +51,8 @@ FOUNDRY_IQ_FORWARD_SOURCE_AUTH_KEY = "FOUNDRY_IQ_FORWARD_SOURCE_AUTH"
 # primary knowledge source is the native azureBlob corpus, the retrieve action
 # also queries a second searchIndex knowledge source built over the existing
 # GPT-RAG index (SEARCH_RAG_INDEX_NAME). That second source carries the runtime
-# uploads and is trimmed by a security + conversationId filterAddOn so a user's
-# uploaded files are only visible inside their own conversation. Off by default.
+# uploads and is trimmed by a conversationId filterAddOn so uploaded files are
+# only visible inside the conversation that created them. Off by default.
 FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED_KEY = "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED"
 FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME_KEY = (
     "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME"
@@ -156,6 +156,11 @@ def build_pattern_b_filter_add_on(
     if conversation_clause:
         return f"({security_clause}) and {conversation_clause}"
     return security_clause
+
+
+def build_conversation_upload_filter_add_on(conversation_id: str) -> str:
+    """Build the Foundry IQ sidecar filter for runtime conversation uploads."""
+    return f"conversationId eq '{_odata_escape_string(conversation_id)}'"
 
 
 class FoundryIQClient:
@@ -321,11 +326,10 @@ class FoundryIQClient:
         - no conversation knowledge source name was provisioned.
 
         When it does apply, the source is a ``searchIndex`` knowledge source over
-        the existing GPT-RAG index, always trimmed by a security +
-        conversationId ``filterAddOn`` so a user's uploads stay scoped to their
-        own conversation. ``failOnError`` is ``false`` so an empty or missing
-        upload index degrades gracefully to the shared corpus instead of failing
-        the whole retrieve.
+        the existing GPT-RAG index, always trimmed by a simple conversationId
+        ``filterAddOn`` accepted by Foundry IQ. ``failOnError`` is ``false`` so
+        an empty or missing upload index degrades gracefully to the shared corpus
+        instead of failing the whole retrieve.
         """
         if not self.conversation_upload_enabled:
             return None
@@ -340,6 +344,13 @@ class FoundryIQClient:
                 "file-upload sidecar source."
             )
             return None
+        cid = (conversation_id or "").strip()
+        if not cid:
+            logging.warning(
+                "[FoundryIQClient] FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED=true but "
+                "conversation_id is empty; skipping the file-upload sidecar source."
+            )
+            return None
         if self.api_version != DEFAULT_FOUNDRY_IQ_API_VERSION:
             raise ValueError(
                 "Foundry IQ conversation-upload filterAddOn requires "
@@ -352,11 +363,7 @@ class FoundryIQClient:
             "includeReferences": True,
             "includeReferenceSourceData": True,
             "failOnError": False,
-            "filterAddOn": build_pattern_b_filter_add_on(
-                conversation_id=conversation_id,
-                user_context=user_context,
-                security_field_name=self.security_field_name,
-            ),
+            "filterAddOn": build_conversation_upload_filter_add_on(cid),
         }
         logging.info(
             "[FoundryIQClient][Upload] Adding conversation-upload source %s "

--- a/tests/test_foundry_iq.py
+++ b/tests/test_foundry_iq.py
@@ -160,6 +160,19 @@ def test_pattern_b_filter_add_on_uses_security_fields_and_conversation_scope():
     assert "conversationId eq 'NaN'" in filter_add_on
 
 
+def test_conversation_upload_filter_add_on_uses_simple_conversation_filter():
+    from connectors.foundry_iq import build_conversation_upload_filter_add_on
+
+    assert (
+        build_conversation_upload_filter_add_on("conv-1")
+        == "conversationId eq 'conv-1'"
+    )
+    assert (
+        build_conversation_upload_filter_add_on("o'brien")
+        == "conversationId eq 'o''brien'"
+    )
+
+
 @pytest.mark.asyncio
 async def test_retrieve_uses_native_blob_knowledge_source_by_default():
     client, session = _build_client(
@@ -305,20 +318,19 @@ async def test_conversation_upload_adds_second_source_in_pattern_a():
         "includeReferences": True,
         "includeReferenceSourceData": True,
     }
-    # Sidecar is a searchIndex source, degrades gracefully, and is scoped.
+    # Sidecar is a searchIndex source, degrades gracefully, and is scoped with
+    # the simple filter format Foundry IQ accepts for the conversation upload KS.
     assert sidecar["knowledgeSourceName"] == "ragindex-conv-ks"
     assert sidecar["kind"] == "searchIndex"
     assert sidecar["failOnError"] is False
-    assert "conversationId eq 'conv-1'" in sidecar["filterAddOn"]
-    assert "metadata_security_id/any(g:search.in(g, 'user-1'))" in sidecar["filterAddOn"]
+    assert sidecar["filterAddOn"] == "conversationId eq 'conv-1'"
+    assert "metadata_security_id" not in sidecar["filterAddOn"]
 
 
 @pytest.mark.asyncio
-async def test_conversation_upload_sidecar_always_carries_filter_add_on():
+async def test_conversation_upload_sidecar_skipped_without_conversation_id():
     """CONTRACT: the runtime-upload sidecar source must never be queried without
-    a filterAddOn, even when there is no conversation and no user context. A bare
-    security-only filter (public-or-owned) is still applied, so uploads can never
-    leak across users or conversations."""
+    the conversationId filter that scopes uploaded chunks to their chat."""
     client, session = _build_client(
         _SAMPLE_PAYLOAD,
         config_overrides=_conv_upload_overrides(),
@@ -326,9 +338,9 @@ async def test_conversation_upload_sidecar_always_carries_filter_add_on():
 
     await client.retrieve("hello")
 
-    sidecar = session.captured["json"]["knowledgeSourceParams"][1]
-    assert sidecar["knowledgeSourceName"] == "ragindex-conv-ks"
-    assert sidecar["filterAddOn"], "sidecar upload source must always be filtered"
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    assert len(sources) == 1
+    assert sources[0]["knowledgeSourceName"] == "documents-blob-ks"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose
Fix the Foundry IQ conversational upload retrieval blocker found during GPT-RAG v3.2.0 Azure validation.

## What changed
- The conversation-upload sidecar now sends a Foundry IQ accepted `filterAddOn`: `conversationId eq '<conversation-id>'`.
- The sidecar is skipped when no conversation id is available, instead of issuing an unscoped or security-only filter.
- Restored the missing `SEARCH_RETRIEVAL_ENABLED` dashboard config setting wrapper so the settings module imports and tests run.
- Updated tests and `CHANGELOG.md` under `Unreleased`.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests/test_foundry_iq.py tests/test_dashboard_config.py` - 33 passed, 13 warnings.
- `.\.venv\Scripts\python.exe -m pytest` - 290 passed, 13 warnings.

## Follow-up
Release preparation and publishing for v3.1.1 are separate tasks.