### PR TITLE
feat: MSAL sign-in for admin dashboard SPA (#546)

### DIFF
--- a/.azure/deployment-plan.md
+++ b/.azure/deployment-plan.md
@@ -1,0 +1,193 @@
+# Azure Deployment Preparation Plan
+
+## Status
+
+Ready for Validation
+
+## Scope
+
+Prepare real Microsoft Entra tenant validation for PR #260, which adds MSAL sign-in and `Admin` app-role authorization to the orchestrator admin dashboard.
+
+This plan does not authorize deployment, merge, release, deletion, or Azure/Entra mutation. The next step is explicit validation approval, then `azure-validate`, then `azure-deploy`.
+
+## Azure context
+
+- Subscription: `9788a92c-2f71-4629-8173-7ad449cb50e1` (`mcaps-paulolacerda`)
+- Tenant: `16b3c013-d300-468d-ac64-7eda0820b6d3`
+- Preferred validation location: `australiaeast`, matching the existing Entra redirect URI and prior validation endpoint.
+
+## Safety constraints
+
+- No resource-group deletion is authorized by this plan.
+- Before any future deletion consideration, run:
+  - `az group show --subscription 9788a92c-2f71-4629-8173-7ad449cb50e1 --name <rg> --query tags`
+- Never delete a resource group tagged `keep=true`.
+- Never delete resource groups by substring matching such as `gpt-rag` or `gptrag`.
+- Only delete a validation environment by exact resource group name after explicit approval.
+
+## Workspace analysis
+
+- Repository: `Azure/gpt-rag-orchestrator`
+- Branch: `feature/dashboard-msal-signin`
+- PR: `Azure/gpt-rag-orchestrator#260`
+- Base branch: `develop`
+- Application: Python 3.12 FastAPI orchestrator with a Vite/React admin dashboard served from `/dashboard/`.
+- Deployment artifacts already present:
+  - `Dockerfile` builds the dashboard bundle in a Node 20 stage and copies it into the Python runtime image.
+  - `azure.yaml` exists and points to azd hooks/scripts, but this repository does not carry standalone `infra/` files. Full GPT-RAG environment creation is owned by the main GPT-RAG infrastructure repository.
+- Preparation mode: MODIFY existing application and validate a PR image against a real tenant.
+- Recipe: use existing GPT-RAG deployment flow for environment provisioning, then deploy the orchestrator container image/revision from this branch. If no reusable environment exists, recreate a controlled validation environment from the main GPT-RAG infrastructure instead of modifying unrelated resource groups.
+
+## Current environment inventory
+
+The previously planned resource group `rg-gptrag-546val` is not present in subscription `mcaps-paulolacerda` as of this preparation pass:
+
+- `az group show --name rg-gptrag-546val` returned `ResourceGroupNotFound`.
+- No matching Container Apps or App Configuration stores were found by read-only resource listing in this subscription.
+
+Candidate GPT-RAG resource groups found in the subscription:
+
+| Resource group | Location | Tags | Read-only finding |
+| --- | --- | --- | --- |
+| `rg-gptrag-fiqzt2-sdc06291745` | `swedencentral` | `azd-env-name=gptrag-fiqzt2-sdc06291745` | Candidate only, not selected. |
+| `rg-gptrag-az700-zta-063014` | `swedencentral` | `azd-env-name=gptrag-az700-zta-063014` | Candidate only, not selected. |
+| `rg-gptrag-fiqzt2-06290951` | `switzerlandnorth` | `azd-env-name=gptrag-fiqzt2-06290951` | Candidate only, not selected. |
+| `rg-gptrag-fiqzt-aue-06291815` | `australiaeast` | `azd-env-name=gptrag-fiqzt-aue-06291815` | Contains only `srch-2sud2hrjnye46`; not a complete orchestrator validation environment. |
+| `rg-gptragv342val` | `australiaeast` | `azd-env-name=gptragv342val` | Contains network/search resources; no Container App/App Configuration inventory was found in this pass. |
+
+Conclusion: do not assume the old validation environment is available. Validation should either:
+
+1. Recreate a new exact validation environment, for example `rg-gptrag-546val2`, from the main GPT-RAG infrastructure, or
+2. Use a user-approved existing environment only after confirming it has the orchestrator Container App, ACR, App Configuration, managed identity, Cosmos, and required GPT-RAG dependencies.
+
+## Entra application inventory
+
+Use the existing single-tenant app registration:
+
+- Display name: `gpt-rag-546val-dashboard`
+- Application (client) id: `b621d3a9-03e7-4cf1-80f6-47a263b751c1`
+- Application object id: `1c50cdd8-d331-4916-9279-80336bef98d2`
+- Enterprise application object id: `737526d9-dbae-4e28-934c-c582005cce94`
+- Tenant: `16b3c013-d300-468d-ac64-7eda0820b6d3`
+- Supported accounts: single tenant
+- Application ID URI: `api://b621d3a9-03e7-4cf1-80f6-47a263b751c1`
+- Scope: `access_as_user`
+- App role: value `Admin`, case-sensitive, users/groups, enabled
+- Enterprise Application `Assignment required?`: `No`
+- Known redirect URI:
+  - `https://ca-5hhmdzbxo4x4q-orchestrator.thankfulwave-c9aba52a.australiaeast.azurecontainerapps.io/dashboard/`
+
+Before E2E, update the SPA redirect URI if the recreated Container App gets a different FQDN. The redirect URI must exactly match the browser URL and include the trailing slash.
+
+## Runtime configuration required
+
+Set these Azure App Configuration key-values under label `gpt-rag-orchestrator` in the selected validation environment:
+
+| Key | Value |
+| --- | --- |
+| `ENABLE_DASHBOARD` | `true` |
+| `OAUTH_AZURE_AD_TENANT_ID` | `16b3c013-d300-468d-ac64-7eda0820b6d3` |
+| `OAUTH_AZURE_AD_CLIENT_ID` | `b621d3a9-03e7-4cf1-80f6-47a263b751c1` |
+| `OAUTH_AZURE_AD_API_SCOPE` | `api://b621d3a9-03e7-4cf1-80f6-47a263b751c1/access_as_user` |
+
+Also confirm the orchestrator Container App has:
+
+- `APP_CONFIG_ENDPOINT=https://<store>.azconfig.io`
+- `AZURE_CLIENT_ID=<uami-client-id>` if a user-assigned managed identity is used
+- Managed identity permission to read App Configuration
+- If testing dashboard Configuration writes, managed identity permission equivalent to App Configuration Data Owner
+
+Important: check whether the legacy label `orchestrator` contains any of the same keys. If it does, remove or align those values only with explicit approval, because legacy label precedence can override `gpt-rag-orchestrator`.
+
+Restart or create a new Container App revision after changing `ENABLE_DASHBOARD`, because the dashboard route registration is evaluated at startup.
+
+## Validation deployment approach
+
+1. Confirm the target environment choice with Paulo:
+   - Recreate a new validation environment from GPT-RAG infrastructure, or
+   - Use an existing complete environment after read-only inventory confirms it is safe.
+2. Build an orchestrator image from the rebased PR branch.
+3. Push the image to the environment ACR.
+4. Deploy a new orchestrator Container App revision using that image.
+5. Set or verify the App Configuration key-values above.
+6. Update the Entra SPA redirect URI to the final `/dashboard/` URL if needed.
+7. Run E2E checks below.
+
+## E2E test matrix
+
+### Baseline auth opt-out
+
+Temporarily omit `OAUTH_AZURE_AD_TENANT_ID` in a non-production validation revision.
+
+Expected:
+
+- `/dashboard/` loads without MSAL sign-in.
+- `GET /api/dashboard/auth-config` returns `auth_enabled:false` or equivalent disabled state.
+
+### Admin user
+
+Use Paulo's tenant account with the `Admin` app role assigned.
+
+Expected:
+
+- Sign-in redirects back to `/dashboard/`.
+- `/api/dashboard/overview`, `/api/dashboard/conversations`, and `/api/dashboard/config` send `Authorization: Bearer <token>` and return 200.
+- Local JWT inspection shows:
+  - `aud` is `b621d3a9-03e7-4cf1-80f6-47a263b751c1` or `api://b621d3a9-03e7-4cf1-80f6-47a263b751c1`
+  - `scp` contains `access_as_user`
+  - `roles` contains `Admin`
+- Sign out clears the session and returns to the sign-in state.
+
+Do not paste tokens into external sites. Decode locally only.
+
+### Non-admin user
+
+Use Gonzalo Becerra or another test user without the `Admin` app role. If Gonzalo currently has `Admin`, remove the assignment only for the test and restore it afterward with explicit approval.
+
+Expected with Enterprise Application `Assignment required? = No`:
+
+- Entra sign-in succeeds.
+- The first protected dashboard API call returns 403.
+- The SPA shows `Access denied`, the signed-in account, and `Sign out and try another account`.
+- No administrative dashboard data is rendered.
+
+### Optional 401 path
+
+Expire or invalidate the MSAL session and call a protected endpoint.
+
+Expected:
+
+- The SPA shows session-expired/sign-in-again behavior or redirects through MSAL.
+- The app never downgrades to an anonymous dashboard API call.
+
+## Documentation updates included in this PR
+
+README dashboard guidance now explains:
+
+- The required single App Registration model for SPA and API.
+- Where to define app roles: App registrations > application > App roles.
+- Where to assign app roles: Enterprise applications > application > Users and groups.
+- Why only `Admin` exists and why the value is case-sensitive.
+- Why `Assignment required? = No` is needed to test the app-level 403 path.
+- Why users must fully sign out and sign in after role assignment changes.
+
+## Merge and release sequence after validation
+
+1. Complete Azure E2E validation and record results in PR #260.
+2. Mark PR #260 ready for review if validation passes.
+3. Merge PR #260 into `develop`.
+4. Prepare the next `Azure/gpt-rag-orchestrator` release branch from `develop`, following this repository's `AGENTS.md` release rules.
+5. Tag and publish the orchestrator release with the GitHub Release title exactly equal to the tag, for example `vX.Y.Z`.
+6. If the parent `Azure/gpt-rag` repository pins or consumes the orchestrator version, update it in a follow-up PR/release after the orchestrator release is available.
+
+## Planning checklist
+
+- [x] Analyze workspace and deployment recipe.
+- [x] Inspect Azure context and prior environment read-only.
+- [x] Inventory reusable resources, tags, configuration, identity, and endpoints where available.
+- [x] Define Entra SPA/API and Admin-role prerequisites.
+- [x] Define admin, non-admin, and optional 401 E2E scenarios.
+- [x] Incorporate operator documentation improvements.
+- [x] Confirm that the prior `rg-gptrag-546val` environment is not currently available.
+- [x] Draft merge and release sequence.
+- [x] Finalize this plan for explicit approval before validation/deployment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
   `tenantId`, `authority`, and `apiScope` it needs to bootstrap MSAL. The
   SPA acquires an access token via `acquireTokenSilent` and falls back to
   `acquireTokenRedirect` on `InteractionRequiredAuthError`. MSAL tokens
-  are kept in `sessionStorage` (not `localStorage`).
+  are kept in `sessionStorage` (not `localStorage`). The verified token's
+  `Admin` app role is enforced by the API, and incomplete tenant/client
+  configuration now fails closed instead of skipping audience validation.
+  Operator setup is documented in the
+  [Admin Dashboard Sign-in guide](https://azure.github.io/GPT-RAG/howto_dashboard_signin/).
 
 ### Changed
 
@@ -22,29 +26,6 @@
   explicitly-passed `Authorization` header on a request still wins,
   which preserves the scripted-test workflow (`api.request(url, {
   headers: { Authorization: "Bearer <token>" } })`).
-
-### Operator prerequisites
-
-To enable auth on the dashboard SPA, an operator needs to:
-
-1. Create (or reuse) a single Microsoft Entra ID app registration for the
-   orchestrator API.
-2. Add a **SPA** platform redirect URI pointing at the deployed dashboard,
-   for example `https://<host>/dashboard/`.
-3. Expose an `access_as_user` scope on the API.
-4. Define an `Admin` app role and assign it to every user who should see
-   the dashboard.
-5. Set the following App Configuration keys (read by the orchestrator's
-   existing App Config connector):
-   - `OAUTH_AZURE_AD_TENANT_ID`
-   - `OAUTH_AZURE_AD_CLIENT_ID`
-   - `OAUTH_AZURE_AD_API_SCOPE` (optional; defaults to
-     `api://<clientId>/access_as_user`)
-
-If any of `OAUTH_AZURE_AD_TENANT_ID` / `OAUTH_AZURE_AD_CLIENT_ID` are
-unset, `auth-config` reports `authEnabled: false` and the SPA renders
-as before, matching the existing developer / air-gapped deployment
-story.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@
 
 ### Added
 
+- **MSAL sign-in for the admin dashboard SPA.** The dashboard SPA served
+  under `/dashboard/` now authenticates admins with Microsoft Entra ID
+  using the Authorization Code + PKCE flow (`loginRedirect`). A new
+  unauthenticated `GET /api/dashboard/auth-config` endpoint tells the SPA
+  whether auth is enabled and, when it is, returns the `clientId`,
+  `tenantId`, `authority`, and `apiScope` it needs to bootstrap MSAL. The
+  SPA acquires an access token via `acquireTokenSilent` and falls back to
+  `acquireTokenRedirect` on `InteractionRequiredAuthError`. MSAL tokens
+  are kept in `sessionStorage` (not `localStorage`).
+
+### Changed
+
+- **Dashboard bearer token source.** The dashboard SPA no longer reads
+  `localStorage["dashboard.bearer"]` by default. Requests get their
+  bearer from the MSAL token provider registered at bootstrap. An
+  explicitly-passed `Authorization` header on a request still wins,
+  which preserves the scripted-test workflow (`api.request(url, {
+  headers: { Authorization: "Bearer <token>" } })`).
+
+### Operator prerequisites
+
+To enable auth on the dashboard SPA, an operator needs to:
+
+1. Create (or reuse) a single Microsoft Entra ID app registration for the
+   orchestrator API.
+2. Add a **SPA** platform redirect URI pointing at the deployed dashboard,
+   for example `https://<host>/dashboard/`.
+3. Expose an `access_as_user` scope on the API.
+4. Define an `Admin` app role and assign it to every user who should see
+   the dashboard.
+5. Set the following App Configuration keys (read by the orchestrator's
+   existing App Config connector):
+   - `OAUTH_AZURE_AD_TENANT_ID`
+   - `OAUTH_AZURE_AD_CLIENT_ID`
+   - `OAUTH_AZURE_AD_API_SCOPE` (optional; defaults to
+     `api://<clientId>/access_as_user`)
+
+If any of `OAUTH_AZURE_AD_TENANT_ID` / `OAUTH_AZURE_AD_CLIENT_ID` are
+unset, `auth-config` reports `authEnabled: false` and the SPA renders
+as before, matching the existing developer / air-gapped deployment
+story.
+
 ### Fixed
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ For comprehensive information about GPT-RAG, including architecture details, con
 
 ## Dashboard
 
-The orchestrator ships with an optional admin dashboard mounted at `/dashboard`. It exposes two tabs:
+The orchestrator ships with an optional admin dashboard mounted at `/dashboard`. It exposes three tabs:
 
 - **Overview**: conversation counts for today, the last 7 days, and the last 30 days; a conversations-over-time chart; average user turns per conversation; and the number of active users.
 - **Conversations**: a paginated, newest-first list of conversations across all users, with a detail view that renders the full message history.
+- **Configuration**: an allowlisted editor for supported orchestrator settings in Azure App Configuration.
 
 The data comes from the existing conversation/history Cosmos DB container used by the orchestrator (`CONVERSATIONS_DATABASE_CONTAINER` in `DATABASE_NAME`). The dashboard is read-only.
 
@@ -73,6 +74,8 @@ The data comes from the existing conversation/history Cosmos DB container used b
 | `OAUTH_AZURE_AD_API_SCOPE` | Optional | Override for the scope the SPA requests. Defaults to `api://<OAUTH_AZURE_AD_CLIENT_ID>/access_as_user`. |
 
 The App Registration also needs a **Single-page application** redirect URI pointing at `https://<host>/dashboard/` (trailing slash), an exposed `access_as_user` scope, and an `Admin` app role assigned to every user who should see the dashboard. Full step-by-step in the GPT-RAG docs: [Admin Dashboard Sign-in](https://azure.github.io/GPT-RAG/howto_dashboard_signin/).
+
+Setting only `OAUTH_AZURE_AD_TENANT_ID` is rejected as a server misconfiguration. The dashboard never skips audience validation or silently falls back to unauthenticated mode when auth is partially configured.
 
 **Token scope.** The frontend must request an access token with the orchestrator's own API scope (`api://<client_id>/access_as_user` by default), not a Microsoft Graph scope. App roles are issued in the `roles` claim of an access token only when the token is requested for the application that defines those roles, so a Graph-scoped token will not surface the `Admin` role and every dashboard call will return 403.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ The data comes from the existing conversation/history Cosmos DB container used b
 | `OAUTH_AZURE_AD_CLIENT_ID` | Yes when tenant is set | Application (client) id of the orchestrator API app registration. |
 | `OAUTH_AZURE_AD_API_SCOPE` | Optional | Override for the scope the SPA requests. Defaults to `api://<OAUTH_AZURE_AD_CLIENT_ID>/access_as_user`. |
 
+Use a single Microsoft Entra app registration for both the dashboard SPA and the orchestrator API. The same application (client) id is the MSAL `clientId`, the backend token audience, and the `<client-id>` segment in the default scope `api://<client-id>/access_as_user`. Using separate SPA and API app registrations requires a different configuration model.
+
 The App Registration also needs a **Single-page application** redirect URI pointing at `https://<host>/dashboard/` (trailing slash), an exposed `access_as_user` scope, and an `Admin` app role assigned to every user who should see the dashboard. Full step-by-step in the GPT-RAG docs: [Admin Dashboard Sign-in](https://azure.github.io/GPT-RAG/howto_dashboard_signin/).
+
+Define the role under **Microsoft Entra ID > App registrations > <your app> > App roles**. Create exactly one app role with value `Admin` and allowed member type `Users/Groups`. The backend checks the token's `roles` claim for the exact case-sensitive value `Admin`; other role names or casing are rejected. Assign users under **Enterprise applications > <your app> > Users and groups** by selecting the `Admin` role.
+
+Keep the Enterprise Application setting **Assignment required?** set to **No** when validating the app-level 403 path. With **No**, a signed-in user without the `Admin` app role reaches the dashboard API and receives the dashboard's access-denied state. With **Yes**, Entra blocks the sign-in earlier with `AADSTS50105`, which is useful for strict production gating but does not validate the dashboard's own 403 handling.
+
+After adding or removing the `Admin` role assignment, sign out completely and sign in again. Existing access tokens do not gain or lose `roles` claims retroactively.
 
 Setting only `OAUTH_AZURE_AD_TENANT_ID` is rejected as a server misconfiguration. The dashboard never skips audience validation or silently falls back to unauthenticated mode when auth is partially configured.
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,19 @@ The data comes from the existing conversation/history Cosmos DB container used b
 
 **Enabling the dashboard.** It is disabled by default. Set the App Configuration value `ENABLE_DASHBOARD=true` to mount it. When `ENABLE_DASHBOARD=false` (the default), the `/dashboard` HTML page and every `/api/dashboard/*` route are not registered at all.
 
-**Access control.** When authentication is on (`OAUTH_AZURE_AD_TENANT_ID` is configured), the entire `/api/dashboard/*` surface — except the small `/api/dashboard/version` endpoint used for the header chip — requires the caller's bearer token to include the `Admin` app role. The `/dashboard` HTML page itself is served openly so the SPA can load and render its own access-denied state on a 403 response. When authentication is off, the dashboard is open like the rest of the app in development.
+**Access control.** When authentication is on (`OAUTH_AZURE_AD_TENANT_ID` is configured), the entire `/api/dashboard/*` surface — except the small `/api/dashboard/version` and `/api/dashboard/auth-config` endpoints used by the SPA at bootstrap — requires the caller's bearer token to include the `Admin` app role. The `/dashboard` HTML page itself is served openly so the SPA can load, call `/api/dashboard/auth-config`, and either sign the user in via MSAL (Authorization Code + PKCE) or render an access-denied state on a 403 response. When authentication is off, the dashboard is open like the rest of the app in development.
 
-**Token scope.** The frontend must request an access token with the orchestrator's own API scope (`api://<client_id>/...`), not a Microsoft Graph scope. App roles are issued in the `roles` claim of an access token only when the token is requested for the application that defines those roles, so a Graph-scoped token will not surface the `Admin` role and every dashboard call will return 403.
+**Sign-in configuration.** The SPA reads its runtime auth configuration from `GET /api/dashboard/auth-config`, which is derived from these App Configuration keys under the `gpt-rag-orchestrator` label:
+
+| Key | Required | Purpose |
+| --- | --- | --- |
+| `OAUTH_AZURE_AD_TENANT_ID` | Yes, to enable the gate | Entra tenant id. When unset, the SPA renders without MSAL and `require_admin` is a no-op. |
+| `OAUTH_AZURE_AD_CLIENT_ID` | Yes when tenant is set | Application (client) id of the orchestrator API app registration. |
+| `OAUTH_AZURE_AD_API_SCOPE` | Optional | Override for the scope the SPA requests. Defaults to `api://<OAUTH_AZURE_AD_CLIENT_ID>/access_as_user`. |
+
+The App Registration also needs a **Single-page application** redirect URI pointing at `https://<host>/dashboard/` (trailing slash), an exposed `access_as_user` scope, and an `Admin` app role assigned to every user who should see the dashboard. Full step-by-step in the GPT-RAG docs: [Admin Dashboard Sign-in](https://azure.github.io/GPT-RAG/howto_dashboard_signin/).
+
+**Token scope.** The frontend must request an access token with the orchestrator's own API scope (`api://<client_id>/access_as_user` by default), not a Microsoft Graph scope. App roles are issued in the `roles` claim of an access token only when the token is requested for the application that defines those roles, so a Graph-scoped token will not surface the `Admin` role and every dashboard call will return 403.
 
 **Building the dashboard bundle.** Production builds happen automatically as part of the `Dockerfile` (an MCR base image stage using Node.js 20 runs `npm run build` and copies the static assets into `src/static`). For local development you can run the Vite dev server with hot reload:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "gpt-rag-orchestrator-dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "@azure/msal-browser": "^3.28.1",
+        "@azure/msal-react": "^2.2.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.6",
@@ -49,6 +51,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.30.0.tgz",
+      "integrity": "sha512-I0XlIGVdM4E9kYP5eTjgW8fgATdzwxJvQ6bm2PNiHaZhEuUz47NYw1xHthC9R+lXz4i9zbShS0VdLyxd7n0GGA==",
+      "dependencies": {
+        "@azure/msal-common": "14.16.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.1.tgz",
+      "integrity": "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-2.2.0.tgz",
+      "integrity": "sha512-2V+9JXeXyyjYNF92y5u0tU4el9px/V1+vkRuN+DtoxyiMHCtYQpJoaFdGWArh43zhz5aqQqiGW/iajPDSu3QsQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.27.0",
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/@babel/runtime": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@azure/msal-browser": "^3.28.1",
+    "@azure/msal-react": "^2.2.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.6",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type KeyboardEvent } from "react";
 import { ThemeProvider } from "next-themes";
 import { useMsal } from "@azure/msal-react";
 import { LayoutDashboard, LogOut, MessageSquare, Settings, User } from "lucide-react";
@@ -11,6 +11,7 @@ import { SignInGate } from "./components/SignInGate";
 import { fetchVersion, type AuthConfig } from "./lib/api";
 
 type Tab = "overview" | "conversations" | "configuration";
+const TAB_ORDER: Tab[] = ["overview", "conversations", "configuration"];
 
 interface AppProps {
   authConfig: AuthConfig;
@@ -24,7 +25,7 @@ interface AppProps {
  */
 function UserChip() {
   const { instance, accounts } = useMsal();
-  const account = accounts[0] ?? null;
+  const account = instance.getActiveAccount() ?? accounts[0] ?? null;
   if (!account) return null;
   return (
     <div className="flex items-center gap-2 rounded-full border border-border bg-muted/40 py-1 pl-2 pr-1 text-xs">
@@ -34,7 +35,7 @@ function UserChip() {
       </span>
       <button
         type="button"
-        onClick={() => void instance.logoutRedirect()}
+        onClick={() => void instance.logoutRedirect({ account })}
         className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-muted-foreground transition hover:bg-background hover:text-foreground"
         title="Sign out"
       >
@@ -52,6 +53,26 @@ function Dashboard({ authConfig }: { authConfig: AuthConfig }) {
   useEffect(() => {
     fetchVersion().then(setVersion).catch(() => setVersion(""));
   }, []);
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    let nextTab: Tab | undefined;
+    const currentIndex = TAB_ORDER.indexOf(tab);
+    if (event.key === "ArrowRight") {
+      nextTab = TAB_ORDER[(currentIndex + 1) % TAB_ORDER.length];
+    } else if (event.key === "ArrowLeft") {
+      nextTab = TAB_ORDER[(currentIndex - 1 + TAB_ORDER.length) % TAB_ORDER.length];
+    } else if (event.key === "Home") {
+      nextTab = TAB_ORDER[0];
+    } else if (event.key === "End") {
+      nextTab = TAB_ORDER[TAB_ORDER.length - 1];
+    }
+
+    if (nextTab) {
+      event.preventDefault();
+      setTab(nextTab);
+      document.getElementById(`dashboard-tab-${nextTab}`)?.focus();
+    }
+  }
 
   return (
     <div className="mx-auto min-h-screen max-w-7xl px-4 py-6">
@@ -72,8 +93,15 @@ function Dashboard({ authConfig }: { authConfig: AuthConfig }) {
       </header>
 
       <SignInGate authConfig={authConfig}>
-        <nav className="mb-4 flex gap-1 border-b">
+        <nav className="mb-4 flex gap-1 border-b" role="tablist" aria-label="Dashboard sections">
           <button
+            id="dashboard-tab-overview"
+            type="button"
+            role="tab"
+            aria-selected={tab === "overview"}
+            aria-controls="dashboard-tabpanel"
+            tabIndex={tab === "overview" ? 0 : -1}
+            onKeyDown={handleTabKeyDown}
             onClick={() => setTab("overview")}
             className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
               tab === "overview"
@@ -85,6 +113,13 @@ function Dashboard({ authConfig }: { authConfig: AuthConfig }) {
             Overview
           </button>
           <button
+            id="dashboard-tab-conversations"
+            type="button"
+            role="tab"
+            aria-selected={tab === "conversations"}
+            aria-controls="dashboard-tabpanel"
+            tabIndex={tab === "conversations" ? 0 : -1}
+            onKeyDown={handleTabKeyDown}
             onClick={() => setTab("conversations")}
             className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
               tab === "conversations"
@@ -96,6 +131,13 @@ function Dashboard({ authConfig }: { authConfig: AuthConfig }) {
             Conversations
           </button>
           <button
+            id="dashboard-tab-configuration"
+            type="button"
+            role="tab"
+            aria-selected={tab === "configuration"}
+            aria-controls="dashboard-tabpanel"
+            tabIndex={tab === "configuration" ? 0 : -1}
+            onKeyDown={handleTabKeyDown}
             onClick={() => setTab("configuration")}
             className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
               tab === "configuration"
@@ -108,9 +150,15 @@ function Dashboard({ authConfig }: { authConfig: AuthConfig }) {
           </button>
         </nav>
 
-        {tab === "overview" && <OverviewTab />}
-        {tab === "conversations" && <ConversationsTab />}
-        {tab === "configuration" && <ConfigurationTab />}
+        <div
+          id="dashboard-tabpanel"
+          role="tabpanel"
+          aria-labelledby={`dashboard-tab-${tab}`}
+        >
+          {tab === "overview" && <OverviewTab />}
+          {tab === "conversations" && <ConversationsTab />}
+          {tab === "configuration" && <ConfigurationTab />}
+        </div>
       </SignInGate>
     </div>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,56 @@
 import { useEffect, useState } from "react";
 import { ThemeProvider } from "next-themes";
+import { useMsal } from "@azure/msal-react";
+import { LayoutDashboard, LogOut, MessageSquare, Settings, User } from "lucide-react";
+
 import { ThemeToggle } from "./components/ThemeToggle";
 import { OverviewTab } from "./components/OverviewTab";
 import { ConversationsTab } from "./components/ConversationsTab";
 import { ConfigurationTab } from "./components/ConfigurationTab";
-import { fetchVersion } from "./lib/api";
-import { LayoutDashboard, MessageSquare, Settings } from "lucide-react";
+import { SignInGate } from "./components/SignInGate";
+import { fetchVersion, type AuthConfig } from "./lib/api";
 
 type Tab = "overview" | "conversations" | "configuration";
 
-function Dashboard() {
+interface AppProps {
+  authConfig: AuthConfig;
+}
+
+/**
+ * User chip in the header. Rendered only when auth is enabled -- when the
+ * dashboard is served without auth there is nothing meaningful to display.
+ * When rendered, it exposes the signed-in account name and a Sign out
+ * button that calls MSAL `logoutRedirect`.
+ */
+function UserChip() {
+  const { instance, accounts } = useMsal();
+  const account = accounts[0] ?? null;
+  if (!account) return null;
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-border bg-muted/40 py-1 pl-2 pr-1 text-xs">
+      <User className="h-3.5 w-3.5 text-muted-foreground" />
+      <span className="max-w-[16rem] truncate font-medium text-foreground">
+        {account.name || account.username}
+      </span>
+      <button
+        type="button"
+        onClick={() => void instance.logoutRedirect()}
+        className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-muted-foreground transition hover:bg-background hover:text-foreground"
+        title="Sign out"
+      >
+        <LogOut className="h-3.5 w-3.5" />
+        <span>Sign out</span>
+      </button>
+    </div>
+  );
+}
+
+function Dashboard({ authConfig }: { authConfig: AuthConfig }) {
   const [tab, setTab] = useState<Tab>("overview");
   const [version, setVersion] = useState("");
 
   useEffect(() => {
-    fetchVersion().then(setVersion);
+    fetchVersion().then(setVersion).catch(() => setVersion(""));
   }, []);
 
   return (
@@ -29,56 +65,61 @@ function Dashboard() {
             )}
           </div>
         </div>
-        <ThemeToggle />
+        <div className="flex items-center gap-3">
+          {authConfig.authEnabled && <UserChip />}
+          <ThemeToggle />
+        </div>
       </header>
 
-      <nav className="mb-4 flex gap-1 border-b">
-        <button
-          onClick={() => setTab("overview")}
-          className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-            tab === "overview"
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <LayoutDashboard className="h-4 w-4" />
-          Overview
-        </button>
-        <button
-          onClick={() => setTab("conversations")}
-          className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-            tab === "conversations"
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <MessageSquare className="h-4 w-4" />
-          Conversations
-        </button>
-        <button
-          onClick={() => setTab("configuration")}
-          className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-            tab === "configuration"
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <Settings className="h-4 w-4" />
-          Configuration
-        </button>
-      </nav>
+      <SignInGate authConfig={authConfig}>
+        <nav className="mb-4 flex gap-1 border-b">
+          <button
+            onClick={() => setTab("overview")}
+            className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+              tab === "overview"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <LayoutDashboard className="h-4 w-4" />
+            Overview
+          </button>
+          <button
+            onClick={() => setTab("conversations")}
+            className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+              tab === "conversations"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <MessageSquare className="h-4 w-4" />
+            Conversations
+          </button>
+          <button
+            onClick={() => setTab("configuration")}
+            className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+              tab === "configuration"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Settings className="h-4 w-4" />
+            Configuration
+          </button>
+        </nav>
 
-      {tab === "overview" && <OverviewTab />}
-      {tab === "conversations" && <ConversationsTab />}
-      {tab === "configuration" && <ConfigurationTab />}
+        {tab === "overview" && <OverviewTab />}
+        {tab === "conversations" && <ConversationsTab />}
+        {tab === "configuration" && <ConfigurationTab />}
+      </SignInGate>
     </div>
   );
 }
 
-export default function App() {
+export default function App({ authConfig }: AppProps) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <Dashboard />
+      <Dashboard authConfig={authConfig} />
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/AccessDeniedState.tsx
+++ b/frontend/src/components/AccessDeniedState.tsx
@@ -1,0 +1,28 @@
+import { ShieldOff } from "lucide-react";
+
+interface AccessDeniedStateProps {
+  username?: string | null;
+}
+
+/**
+ * Rendered when the signed-in user reaches the dashboard but does not have
+ * the `Admin` app role assigned in the orchestrator API app registration.
+ *
+ * The message is deliberately explicit about which registration and role
+ * the operator needs to update, because non-admin viewers seeing this
+ * panel usually cannot self-serve the fix.
+ */
+export function AccessDeniedState({ username }: AccessDeniedStateProps) {
+  const who = username ? `signed in as ${username}` : "signed in";
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3 p-8 text-center">
+      <ShieldOff className="h-10 w-10 text-destructive" />
+      <h1 className="text-xl font-semibold text-foreground">Access denied</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        You are {who} but the <span className="font-medium">Admin</span> app role is not assigned
+        to your account. Ask your operator to assign the <span className="font-medium">Admin</span>{" "}
+        app role to your user in the orchestrator API app registration in Microsoft Entra ID.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/AccessDeniedState.tsx
+++ b/frontend/src/components/AccessDeniedState.tsx
@@ -1,7 +1,9 @@
-import { ShieldOff } from "lucide-react";
+import { useState } from "react";
+import { useMsal } from "@azure/msal-react";
+import { LogOut, ShieldOff } from "lucide-react";
 
 interface AccessDeniedStateProps {
-  username?: string | null;
+  accountName?: string | null;
 }
 
 /**
@@ -12,17 +14,50 @@ interface AccessDeniedStateProps {
  * the operator needs to update, because non-admin viewers seeing this
  * panel usually cannot self-serve the fix.
  */
-export function AccessDeniedState({ username }: AccessDeniedStateProps) {
-  const who = username ? `signed in as ${username}` : "signed in";
+export function AccessDeniedState({ accountName }: AccessDeniedStateProps) {
+  const { instance, accounts } = useMsal();
+  const account = instance.getActiveAccount() ?? accounts[0] ?? null;
+  const [signingOut, setSigningOut] = useState(false);
+  const [signOutError, setSignOutError] = useState("");
+  const who = accountName ? `signed in as ${accountName}` : "signed in";
+
+  async function signOut() {
+    setSigningOut(true);
+    setSignOutError("");
+    try {
+      await instance.logoutRedirect(account ? { account } : undefined);
+    } catch {
+      setSigningOut(false);
+      setSignOutError("Sign out could not be started. Try again.");
+    }
+  }
+
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3 p-8 text-center">
+    <div
+      className="flex min-h-[60vh] flex-col items-center justify-center gap-3 p-8 text-center"
+      role="alert"
+    >
       <ShieldOff className="h-10 w-10 text-destructive" />
-      <h1 className="text-xl font-semibold text-foreground">Access denied</h1>
+      <h2 className="text-xl font-semibold text-foreground">Access denied</h2>
       <p className="max-w-md text-sm text-muted-foreground">
         You are {who} but the <span className="font-medium">Admin</span> app role is not assigned
         to your account. Ask your operator to assign the <span className="font-medium">Admin</span>{" "}
         app role to your user in the orchestrator API app registration in Microsoft Entra ID.
       </p>
+      <button
+        type="button"
+        className="mt-2 inline-flex items-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-wait disabled:opacity-70"
+        disabled={signingOut}
+        onClick={() => void signOut()}
+      >
+        <LogOut className="h-4 w-4" />
+        {signingOut ? "Signing out..." : "Sign out and try another account"}
+      </button>
+      {signOutError && (
+        <p className="max-w-md text-sm text-destructive" role="alert">
+          {signOutError}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/BootstrapError.tsx
+++ b/frontend/src/components/BootstrapError.tsx
@@ -1,0 +1,23 @@
+interface BootstrapErrorProps {
+  title: string;
+  message: string;
+}
+
+export function BootstrapError({ title, message }: BootstrapErrorProps) {
+  return (
+    <div
+      className="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center gap-3 p-8 text-center text-sm"
+      role="alert"
+    >
+      <h1 className="text-lg font-semibold">{title}</h1>
+      <p className="text-muted-foreground">{message}</p>
+      <button
+        type="button"
+        className="rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={() => window.location.reload()}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/SignInGate.tsx
+++ b/frontend/src/components/SignInGate.tsx
@@ -27,22 +27,28 @@ interface SignInGateProps {
  *    `<AccessDeniedState>`. This centralises the "missing Admin role"
  *    experience instead of repeating it per-tab.
  *
- * The 403 signal is delivered by `setAuthErrorHandler` in `lib/api.ts`,
- * which fires for every request the SPA makes. 401s are intentionally
- * ignored here: msal-react handles interactive reauth via the token
- * provider, and a 401 usually means "token expired mid-flight" rather
- * than "wrong role".
+ * The auth signal is delivered by `setAuthErrorHandler` in `lib/api.ts`,
+ * which fires for every request the SPA makes. A 401 replaces the dashboard
+ * with a reauthentication action, while a 403 shows the role-specific
+ * access-denied state.
  */
 export function SignInGate({ authConfig, children }: SignInGateProps) {
   const { instance, accounts } = useMsal();
-  const account = accounts[0] ?? null;
+  const account = instance.getActiveAccount() ?? accounts[0] ?? null;
   const [accessDenied, setAccessDenied] = useState(false);
+  const [reauthenticationRequired, setReauthenticationRequired] = useState(false);
+  const [authActionPending, setAuthActionPending] = useState(false);
+  const [authActionError, setAuthActionError] = useState("");
 
   useEffect(() => {
     if (!authConfig.authEnabled) return;
     setAuthErrorHandler((kind) => {
       if (kind === "forbidden") {
         setAccessDenied(true);
+        setReauthenticationRequired(false);
+      } else {
+        setAccessDenied(false);
+        setReauthenticationRequired(true);
       }
     });
     return () => setAuthErrorHandler(null);
@@ -54,18 +60,42 @@ export function SignInGate({ authConfig, children }: SignInGateProps) {
   // object reference so we do not re-fire on every render.
   const accountKey = account?.homeAccountId;
   useEffect(() => {
-    if (accountKey) setAccessDenied(false);
+    if (accountKey) {
+      setAccessDenied(false);
+      setReauthenticationRequired(false);
+      setAuthActionError("");
+    }
   }, [accountKey]);
+
+  async function startAuthentication(forceReauthentication = false) {
+    const scope = authConfig.apiScope;
+    setAuthActionPending(true);
+    setAuthActionError("");
+    try {
+      if (forceReauthentication && account && scope) {
+        await instance.acquireTokenRedirect({
+          account,
+          scopes: [scope],
+        });
+      } else {
+        await instance.loginRedirect(scope ? { scopes: [scope] } : { scopes: [] });
+      }
+    } catch {
+      setAuthActionPending(false);
+      setAuthActionError(
+        "Microsoft Entra ID sign-in could not be started. Try again or contact your operator.",
+      );
+    }
+  }
 
   if (!authConfig.authEnabled) {
     return <>{children}</>;
   }
 
   if (!account) {
-    const scope = authConfig.apiScope;
     return (
       <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
-        <h1 className="text-2xl font-semibold text-foreground">Admin dashboard</h1>
+        <h2 className="text-2xl font-semibold text-foreground">Admin dashboard</h2>
         <p className="max-w-md text-sm text-muted-foreground">
           Sign in with your Microsoft Entra ID account. You need the{" "}
           <span className="font-medium">Admin</span> app role assigned in the orchestrator API app
@@ -73,20 +103,53 @@ export function SignInGate({ authConfig, children }: SignInGateProps) {
         </p>
         <button
           type="button"
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          onClick={() => {
-            void instance.loginRedirect(scope ? { scopes: [scope] } : { scopes: [] });
-          }}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-wait disabled:opacity-70"
+          disabled={authActionPending}
+          onClick={() => void startAuthentication()}
         >
           <LogIn className="h-4 w-4" />
-          Sign in
+          {authActionPending ? "Signing in..." : "Sign in"}
         </button>
+        {authActionError && (
+          <p className="max-w-md text-sm text-destructive" role="alert">
+            {authActionError}
+          </p>
+        )}
       </div>
     );
   }
 
   if (accessDenied) {
-    return <AccessDeniedState username={account.username} />;
+    return <AccessDeniedState accountName={account.name || account.username} />;
+  }
+
+  if (reauthenticationRequired) {
+    return (
+      <div
+        className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center"
+        role="alert"
+      >
+        <h2 className="text-xl font-semibold text-foreground">Session expired</h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          Your dashboard session is no longer authorized. Sign in again to request a fresh
+          access token for the orchestrator API.
+        </p>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-wait disabled:opacity-70"
+          disabled={authActionPending}
+          onClick={() => void startAuthentication(true)}
+        >
+          <LogIn className="h-4 w-4" />
+          {authActionPending ? "Signing in..." : "Sign in again"}
+        </button>
+        {authActionError && (
+          <p className="max-w-md text-sm text-destructive" role="alert">
+            {authActionError}
+          </p>
+        )}
+      </div>
+    );
   }
 
   return <>{children}</>;

--- a/frontend/src/components/SignInGate.tsx
+++ b/frontend/src/components/SignInGate.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { useMsal } from "@azure/msal-react";
+import { LogIn } from "lucide-react";
+
+import { setAuthErrorHandler, type AuthConfig } from "../lib/api";
+import { AccessDeniedState } from "./AccessDeniedState";
+
+interface SignInGateProps {
+  authConfig: AuthConfig;
+  children: ReactNode;
+}
+
+/**
+ * Top-level gate that owns the "is the current viewer allowed to see the
+ * dashboard" question.
+ *
+ * Three states:
+ *
+ * 1. Auth disabled -- render children unchanged. This preserves the
+ *    developer / air-gapped deployment story where the SPA is served
+ *    without an app registration.
+ * 2. Auth enabled, no signed-in account -- render a hero panel with a
+ *    real Sign In button that calls `loginRedirect` with the configured
+ *    API scope so the returned token is directly usable by the API.
+ * 3. Auth enabled, signed in -- render children, unless any downstream
+ *    API call surfaces a 403, in which case swap the tree for
+ *    `<AccessDeniedState>`. This centralises the "missing Admin role"
+ *    experience instead of repeating it per-tab.
+ *
+ * The 403 signal is delivered by `setAuthErrorHandler` in `lib/api.ts`,
+ * which fires for every request the SPA makes. 401s are intentionally
+ * ignored here: msal-react handles interactive reauth via the token
+ * provider, and a 401 usually means "token expired mid-flight" rather
+ * than "wrong role".
+ */
+export function SignInGate({ authConfig, children }: SignInGateProps) {
+  const { instance, accounts } = useMsal();
+  const account = accounts[0] ?? null;
+  const [accessDenied, setAccessDenied] = useState(false);
+
+  useEffect(() => {
+    if (!authConfig.authEnabled) return;
+    setAuthErrorHandler((kind) => {
+      if (kind === "forbidden") {
+        setAccessDenied(true);
+      }
+    });
+    return () => setAuthErrorHandler(null);
+  }, [authConfig.authEnabled]);
+
+  // A fresh sign-in should clear a stale access-denied state (for example
+  // if the operator has just assigned the role and the user re-signs in).
+  // We key on homeAccountId (a stable identifier) rather than the account
+  // object reference so we do not re-fire on every render.
+  const accountKey = account?.homeAccountId;
+  useEffect(() => {
+    if (accountKey) setAccessDenied(false);
+  }, [accountKey]);
+
+  if (!authConfig.authEnabled) {
+    return <>{children}</>;
+  }
+
+  if (!account) {
+    const scope = authConfig.apiScope;
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+        <h1 className="text-2xl font-semibold text-foreground">Admin dashboard</h1>
+        <p className="max-w-md text-sm text-muted-foreground">
+          Sign in with your Microsoft Entra ID account. You need the{" "}
+          <span className="font-medium">Admin</span> app role assigned in the orchestrator API app
+          registration to see dashboard data.
+        </p>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={() => {
+            void instance.loginRedirect(scope ? { scopes: [scope] } : { scopes: [] });
+          }}
+        >
+          <LogIn className="h-4 w-4" />
+          Sign in
+        </button>
+      </div>
+    );
+  }
+
+  if (accessDenied) {
+    return <AccessDeniedState username={account.username} />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -61,8 +61,9 @@ let tokenProvider: AuthTokenProvider | null = null;
  *
  * `main.tsx` wires this to MSAL after `handleRedirectPromise`. The provider
  * is called on every request so token refresh / interaction fallback stays
- * inside MSAL and out of the request path. Passing `null` unregisters it,
- * which is useful in tests.
+ * inside MSAL and out of the request path. Token-acquisition failures are
+ * propagated rather than converted into unauthenticated API calls. Passing
+ * `null` unregisters the provider, which is useful in tests.
  */
 export function setAuthTokenProvider(fn: AuthTokenProvider | null): void {
   tokenProvider = fn;
@@ -109,14 +110,8 @@ async function request<T>(
   const callerSetAuth = hasHeader(init.headers, "authorization");
   const authHeader: Record<string, string> = {};
   if (!callerSetAuth && tokenProvider) {
-    try {
-      const token = await tokenProvider();
-      if (token) authHeader.Authorization = `Bearer ${token}`;
-    } catch {
-      // Token acquisition failure -> proceed unauthenticated; the API will
-      // 401 and the UI will route to the sign-in gate. Swallowing keeps
-      // request() free of MSAL types.
-    }
+    const token = await tokenProvider();
+    if (token) authHeader.Authorization = `Bearer ${token}`;
   }
 
   const res = await fetch(path, {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,16 +4,21 @@
  * The dashboard is mounted under the orchestrator's own origin, so every
  * request is same-origin and uses relative `/api/dashboard/*` URLs. This
  * file is the single place that knows the URL shape, the response types,
- * and the `Authorization` header convention — components only import named
+ * and the `Authorization` header convention -- components only import named
  * helpers.
  *
- * Auth: when the orchestrator runs with auth enabled (Entra ID), `require_admin`
- * expects a bearer token. The dashboard is currently designed for the same
- * tenant and lets the browser session forward whatever cookie/header the
- * gateway injects, so this module does not manage tokens directly. If a token
- * is ever stashed under `localStorage["dashboard.bearer"]` we forward it; this
- * preserves the existing manual-testing flow without committing to a long-term
- * auth model in the dashboard.
+ * Auth: when the orchestrator runs with auth enabled (Entra ID),
+ * `require_admin` expects a bearer token whose `roles` claim contains
+ * `Admin`. The SPA obtains that token via MSAL and registers a token
+ * provider through `setAuthTokenProvider`; `request()` awaits the provider
+ * on every call and attaches the Authorization header when one is returned.
+ * A caller that passes its own `Authorization` header in `init.headers`
+ * (for scripted tests) wins and the provider is skipped.
+ *
+ * The response side of the wrapper distinguishes 401 (needs sign-in /
+ * silent-refresh failure) from 403 (signed in but the Admin app role is
+ * not assigned) so the UI can render a real reauth flow vs an
+ * access-denied panel instead of blurring both into one error.
  */
 
 export class ApiError extends Error {
@@ -27,15 +32,70 @@ export class ApiError extends Error {
   }
 }
 
-function authHeaders(): HeadersInit {
-  try {
-    const token = typeof window !== "undefined"
-      ? window.localStorage?.getItem("dashboard.bearer")
-      : null;
-    return token ? { Authorization: `Bearer ${token}` } : {};
-  } catch {
-    return {};
+/** 401 from the API: caller must (re)authenticate. */
+export class UnauthorizedError extends ApiError {
+  constructor(message: string, body?: unknown) {
+    super(message, 401, body);
+    this.name = "UnauthorizedError";
   }
+}
+
+/**
+ * 403 from the API: caller is signed in but not entitled. Do NOT trigger a
+ * sign-in redirect -- the fix is an operator granting the Admin app role,
+ * not another token.
+ */
+export class ForbiddenError extends ApiError {
+  constructor(message: string, body?: unknown) {
+    super(message, 403, body);
+    this.name = "ForbiddenError";
+  }
+}
+
+type AuthTokenProvider = () => Promise<string | null>;
+
+let tokenProvider: AuthTokenProvider | null = null;
+
+/**
+ * Register a function that returns a fresh access token for the API scope.
+ *
+ * `main.tsx` wires this to MSAL after `handleRedirectPromise`. The provider
+ * is called on every request so token refresh / interaction fallback stays
+ * inside MSAL and out of the request path. Passing `null` unregisters it,
+ * which is useful in tests.
+ */
+export function setAuthTokenProvider(fn: AuthTokenProvider | null): void {
+  tokenProvider = fn;
+}
+
+/** Kind of auth error the app should react to. */
+export type AuthErrorKind = "unauthorized" | "forbidden";
+
+type AuthErrorHandler = (kind: AuthErrorKind, err: ApiError) => void;
+
+let authErrorHandler: AuthErrorHandler | null = null;
+
+/**
+ * Register a handler that fires whenever any API call returns 401 or 403.
+ *
+ * Used by `SignInGate` to lift access-denied and sign-in-required states out
+ * of individual tabs so the entire dashboard shell can react consistently.
+ * Passing `null` clears the handler.
+ */
+export function setAuthErrorHandler(fn: AuthErrorHandler | null): void {
+  authErrorHandler = fn;
+}
+
+function hasHeader(headers: HeadersInit | undefined, name: string): boolean {
+  if (!headers) return false;
+  const target = name.toLowerCase();
+  if (headers instanceof Headers) {
+    return headers.has(name);
+  }
+  if (Array.isArray(headers)) {
+    return headers.some(([k]) => k.toLowerCase() === target);
+  }
+  return Object.keys(headers).some((k) => k.toLowerCase() === target);
 }
 
 async function request<T>(
@@ -43,12 +103,28 @@ async function request<T>(
   init: RequestInit = {},
   signal?: AbortSignal,
 ): Promise<T> {
+  // Explicit Authorization in init.headers always wins (scripted tests,
+  // curl-style debugging). Only fall back to the MSAL provider when the
+  // caller did not set one itself.
+  const callerSetAuth = hasHeader(init.headers, "authorization");
+  const authHeader: Record<string, string> = {};
+  if (!callerSetAuth && tokenProvider) {
+    try {
+      const token = await tokenProvider();
+      if (token) authHeader.Authorization = `Bearer ${token}`;
+    } catch {
+      // Token acquisition failure -> proceed unauthenticated; the API will
+      // 401 and the UI will route to the sign-in gate. Swallowing keeps
+      // request() free of MSAL types.
+    }
+  }
+
   const res = await fetch(path, {
     ...init,
     signal,
     headers: {
       Accept: "application/json",
-      ...authHeaders(),
+      ...authHeader,
       ...(init.body ? { "Content-Type": "application/json" } : {}),
       ...(init.headers ?? {}),
     },
@@ -73,6 +149,16 @@ async function request<T>(
     } catch {
       // body was not JSON
     }
+    if (res.status === 401) {
+      const err = new UnauthorizedError(message, body);
+      authErrorHandler?.("unauthorized", err);
+      throw err;
+    }
+    if (res.status === 403) {
+      const err = new ForbiddenError(message, body);
+      authErrorHandler?.("forbidden", err);
+      throw err;
+    }
     throw new ApiError(message, res.status, body);
   }
   if (res.status === 204) return undefined as T;
@@ -80,7 +166,56 @@ async function request<T>(
 }
 
 // ---------------------------------------------------------------------------
-// Existing endpoints (pre-PR #236 surface — restored here because lib/api.ts
+// Auth config (unauthenticated bootstrap)
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime auth configuration returned by `GET /api/dashboard/auth-config`.
+ *
+ * Fields are surfaced in camelCase for idiomatic TS while the backend keeps
+ * snake_case in the wire format; `fetchAuthConfig` handles the mapping.
+ * When `authEnabled` is false the rest of the fields are undefined and the
+ * SPA must not bootstrap MSAL.
+ */
+export interface AuthConfig {
+  authEnabled: boolean;
+  clientId?: string;
+  tenantId?: string;
+  authority?: string;
+  apiScope?: string;
+}
+
+interface AuthConfigWire {
+  auth_enabled: boolean;
+  client_id?: string | null;
+  tenant_id?: string | null;
+  authority?: string | null;
+  api_scope?: string | null;
+}
+
+/**
+ * Fetch the SPA's MSAL bootstrap configuration.
+ *
+ * Called once at startup before any protected endpoint, so it does NOT go
+ * through the token provider (the endpoint is unauth by design).
+ */
+export async function fetchAuthConfig(signal?: AbortSignal): Promise<AuthConfig> {
+  const wire = await request<AuthConfigWire>(
+    "/api/dashboard/auth-config",
+    {},
+    signal,
+  );
+  return {
+    authEnabled: wire.auth_enabled,
+    clientId: wire.client_id ?? undefined,
+    tenantId: wire.tenant_id ?? undefined,
+    authority: wire.authority ?? undefined,
+    apiScope: wire.api_scope ?? undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Existing endpoints (pre-PR #236 surface -- restored here because lib/api.ts
 // was missing from that PR and the rest of the SPA imports from it).
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,149 @@
+/**
+ * MSAL bootstrap for the admin dashboard SPA.
+ *
+ * Design notes:
+ *
+ * * The `PublicClientApplication` is a module-level singleton so that React
+ *   StrictMode's double-invocation of effects does not create two MSAL
+ *   instances, which is a documented cause of "interaction_in_progress"
+ *   errors from `msal-browser`.
+ * * We use the default `sessionStorage` cache. `localStorage` would survive
+ *   browser restarts and increase the blast radius if the box is shared;
+ *   the dashboard's usage pattern (a single admin session) does not need
+ *   cross-tab or cross-restart persistence.
+ * * The Authorization Code + PKCE flow is used implicitly by
+ *   `loginRedirect` / `acquireTokenSilent` -- that is the msal-browser
+ *   default for SPAs and matches the "SPA" platform type on the app
+ *   registration.
+ * * `acquireAdminToken` centralises the silent-then-redirect fallback so
+ *   that every request path calls a single helper. The redirect swaps out
+ *   the whole SPA context, so callers should treat a redirect as
+ *   terminating this async operation.
+ */
+
+import {
+  InteractionRequiredAuthError,
+  PublicClientApplication,
+  type AccountInfo,
+  type Configuration,
+} from "@azure/msal-browser";
+
+import type { AuthConfig } from "./api";
+
+let msalInstance: PublicClientApplication | null = null;
+
+/**
+ * Build the MSAL instance for a given `AuthConfig`.
+ *
+ * Idempotent: subsequent calls with the same effective config return the
+ * cached instance. Passing a different tenant / client id resets the
+ * singleton -- useful in tests, but never expected in production because
+ * the config is fetched once at bootstrap.
+ */
+export function createMsalInstance(config: AuthConfig): PublicClientApplication {
+  if (!config.authEnabled || !config.clientId || !config.authority) {
+    throw new Error(
+      "createMsalInstance called with auth disabled or incomplete config; " +
+        "the caller should have gated on authEnabled first.",
+    );
+  }
+
+  if (
+    msalInstance &&
+    msalInstance.getConfiguration().auth.clientId === config.clientId &&
+    msalInstance.getConfiguration().auth.authority === config.authority
+  ) {
+    return msalInstance;
+  }
+
+  const msalConfig: Configuration = {
+    auth: {
+      clientId: config.clientId,
+      authority: config.authority,
+      // The SPA is served from the same origin as the API and is a single
+      // page at `/dashboard/`, so the redirect target is the current
+      // location. Using window.location.origin + /dashboard/ keeps the
+      // registration in sync with the Vite `base` and the FastAPI mount
+      // point.
+      redirectUri: `${window.location.origin}/dashboard/`,
+      postLogoutRedirectUri: `${window.location.origin}/dashboard/`,
+      navigateToLoginRequestUrl: false,
+    },
+    cache: {
+      // Deliberately session-scoped: see file docstring.
+      cacheLocation: "sessionStorage",
+      storeAuthStateInCookie: false,
+    },
+  };
+
+  msalInstance = new PublicClientApplication(msalConfig);
+  return msalInstance;
+}
+
+/**
+ * Return the singleton MSAL instance, or throw if it has not been created.
+ *
+ * Used by React components that live under `<MsalProvider>` and therefore
+ * know MSAL was bootstrapped; anything outside that subtree should call
+ * `createMsalInstance` directly with an `AuthConfig`.
+ */
+export function getMsalInstance(): PublicClientApplication {
+  if (!msalInstance) {
+    throw new Error("MSAL instance has not been created; call createMsalInstance first.");
+  }
+  return msalInstance;
+}
+
+/**
+ * Acquire an access token for the API scope, falling back to a redirect
+ * when silent acquisition needs interaction (consent, MFA, expired refresh
+ * token, etc).
+ *
+ * Returns `null` when no account is signed in yet -- the caller should
+ * render the sign-in gate rather than force a redirect from a random API
+ * call, because a background redirect can lose in-progress UI state.
+ */
+export async function acquireAdminToken(
+  msal: PublicClientApplication,
+  scope: string,
+): Promise<string | null> {
+  const account = pickAccount(msal);
+  if (!account) return null;
+
+  try {
+    const result = await msal.acquireTokenSilent({
+      account,
+      scopes: [scope],
+    });
+    return result.accessToken || null;
+  } catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+      // acquireTokenRedirect returns Promise<void>: the browser navigates
+      // away before the promise resolves. Callers treat this as a
+      // terminating condition.
+      await msal.acquireTokenRedirect({ scopes: [scope], account });
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Pick the "current" account for the SPA.
+ *
+ * msal-react updates its own active account in response to login events,
+ * but a fresh page load after redirect may briefly see multiple accounts
+ * cached in sessionStorage. Prefer the explicitly-active account and fall
+ * back to the first known one so admins do not have to re-sign-in after a
+ * refresh.
+ */
+export function pickAccount(msal: PublicClientApplication): AccountInfo | null {
+  const active = msal.getActiveAccount();
+  if (active) return active;
+  const [first] = msal.getAllAccounts();
+  if (first) {
+    msal.setActiveAccount(first);
+    return first;
+  }
+  return null;
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -31,6 +31,12 @@ import {
 import type { AuthConfig } from "./api";
 
 let msalInstance: PublicClientApplication | null = null;
+let inFlightTokenRequest:
+  | {
+      key: string;
+      promise: Promise<string | null>;
+    }
+  | null = null;
 
 /**
  * Build the MSAL instance for a given `AuthConfig`.
@@ -103,13 +109,32 @@ export function getMsalInstance(): PublicClientApplication {
  * render the sign-in gate rather than force a redirect from a random API
  * call, because a background redirect can lose in-progress UI state.
  */
-export async function acquireAdminToken(
+export function acquireAdminToken(
   msal: PublicClientApplication,
   scope: string,
 ): Promise<string | null> {
   const account = pickAccount(msal);
-  if (!account) return null;
+  if (!account) return Promise.resolve(null);
 
+  const requestKey = `${account.homeAccountId}:${scope}`;
+  if (inFlightTokenRequest?.key === requestKey) {
+    return inFlightTokenRequest.promise;
+  }
+
+  const promise = acquireTokenForAccount(msal, account, scope).finally(() => {
+    if (inFlightTokenRequest?.promise === promise) {
+      inFlightTokenRequest = null;
+    }
+  });
+  inFlightTokenRequest = { key: requestKey, promise };
+  return promise;
+}
+
+async function acquireTokenForAccount(
+  msal: PublicClientApplication,
+  account: AccountInfo,
+  scope: string,
+): Promise<string | null> {
   try {
     const result = await msal.acquireTokenSilent({
       account,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { MsalProvider } from "@azure/msal-react";
 
 import "./index.css";
 import App from "./App";
+import { BootstrapError } from "./components/BootstrapError";
 import {
   fetchAuthConfig,
   setAuthTokenProvider,
@@ -33,18 +34,13 @@ async function bootstrap() {
   let authConfig: AuthConfig;
   try {
     authConfig = await fetchAuthConfig();
-  } catch (err) {
+  } catch {
     root.render(
       <StrictMode>
-        <div className="mx-auto max-w-xl p-8 text-center text-sm">
-          <h1 className="mb-2 text-lg font-semibold">Dashboard failed to load</h1>
-          <p className="text-muted-foreground">
-            Could not fetch auth configuration from the orchestrator API.
-          </p>
-          <pre className="mt-3 whitespace-pre-wrap text-left text-xs opacity-70">
-            {(err as Error).message}
-          </pre>
-        </div>
+        <BootstrapError
+          title="Dashboard failed to load"
+          message="Could not fetch authentication configuration from the orchestrator API. Refresh the page, and check the service logs if the problem persists."
+        />
       </StrictMode>,
     );
     return;
@@ -62,15 +58,10 @@ async function bootstrap() {
   if (!authConfig.clientId || !authConfig.authority || !authConfig.apiScope) {
     root.render(
       <StrictMode>
-        <div className="mx-auto max-w-xl p-8 text-center text-sm">
-          <h1 className="mb-2 text-lg font-semibold">Dashboard misconfigured</h1>
-          <p className="text-muted-foreground">
-            Auth is enabled but the server did not return a complete configuration
-            (clientId, authority, apiScope). Ask an operator to check the
-            OAUTH_AZURE_AD_TENANT_ID and OAUTH_AZURE_AD_CLIENT_ID App Config
-            entries.
-          </p>
-        </div>
+        <BootstrapError
+          title="Dashboard misconfigured"
+          message="Authentication is enabled, but the server returned an incomplete MSAL configuration. Check the orchestrator service logs."
+        />
       </StrictMode>,
     );
     return;
@@ -78,13 +69,28 @@ async function bootstrap() {
 
   const msal = createMsalInstance(authConfig);
 
-  // msal-browser 3.x requires initialize() before any other API call.
-  await msal.initialize();
+  try {
+    // msal-browser 3.x requires initialize() before any other API call.
+    await msal.initialize();
 
-  // Complete any in-flight redirect (post-loginRedirect callback) before
-  // we mount, so `<MsalProvider>` sees the resulting account state on
-  // first render and the sign-in gate does not flash.
-  await msal.handleRedirectPromise();
+    // Complete any in-flight redirect before mounting so the provider sees
+    // the resulting account on first render. Explicitly select that account
+    // so a stale cached account cannot win after an account switch.
+    const redirectResult = await msal.handleRedirectPromise();
+    if (redirectResult?.account) {
+      msal.setActiveAccount(redirectResult.account);
+    }
+  } catch {
+    root.render(
+      <StrictMode>
+        <BootstrapError
+          title="Sign-in could not start"
+          message="Microsoft Entra ID authentication could not be initialized. Refresh the page, and check the app registration and service logs if the problem persists."
+        />
+      </StrictMode>,
+    );
+    return;
+  }
 
   const scope = authConfig.apiScope;
   setAuthTokenProvider(() => acquireAdminToken(msal, scope));

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,101 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { MsalProvider } from "@azure/msal-react";
+
 import "./index.css";
 import App from "./App";
+import {
+  fetchAuthConfig,
+  setAuthTokenProvider,
+  type AuthConfig,
+} from "./lib/api";
+import { acquireAdminToken, createMsalInstance } from "./lib/auth";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+/**
+ * Boot the dashboard SPA.
+ *
+ * The bootstrap is async because auth configuration lives on the server
+ * (single source of truth) and must be fetched before we can decide
+ * whether to build an MSAL instance and mount `<MsalProvider>`. Rendering
+ * before this decision would cause the whole tree to see a null MSAL
+ * context and either flicker or crash when hooks like `useMsal()` fire.
+ *
+ * If bootstrap fails -- typically because the auth-config endpoint is
+ * unreachable -- we fail loudly by rendering an inline error. Silently
+ * degrading to an unauthenticated view would be misleading and might
+ * expose the dashboard when auth is expected to be on.
+ */
+async function bootstrap() {
+  const container = document.getElementById("root");
+  if (!container) throw new Error("Missing #root element in dashboard HTML.");
+  const root = createRoot(container);
+
+  let authConfig: AuthConfig;
+  try {
+    authConfig = await fetchAuthConfig();
+  } catch (err) {
+    root.render(
+      <StrictMode>
+        <div className="mx-auto max-w-xl p-8 text-center text-sm">
+          <h1 className="mb-2 text-lg font-semibold">Dashboard failed to load</h1>
+          <p className="text-muted-foreground">
+            Could not fetch auth configuration from the orchestrator API.
+          </p>
+          <pre className="mt-3 whitespace-pre-wrap text-left text-xs opacity-70">
+            {(err as Error).message}
+          </pre>
+        </div>
+      </StrictMode>,
+    );
+    return;
+  }
+
+  if (!authConfig.authEnabled) {
+    root.render(
+      <StrictMode>
+        <App authConfig={authConfig} />
+      </StrictMode>,
+    );
+    return;
+  }
+
+  if (!authConfig.clientId || !authConfig.authority || !authConfig.apiScope) {
+    root.render(
+      <StrictMode>
+        <div className="mx-auto max-w-xl p-8 text-center text-sm">
+          <h1 className="mb-2 text-lg font-semibold">Dashboard misconfigured</h1>
+          <p className="text-muted-foreground">
+            Auth is enabled but the server did not return a complete configuration
+            (clientId, authority, apiScope). Ask an operator to check the
+            OAUTH_AZURE_AD_TENANT_ID and OAUTH_AZURE_AD_CLIENT_ID App Config
+            entries.
+          </p>
+        </div>
+      </StrictMode>,
+    );
+    return;
+  }
+
+  const msal = createMsalInstance(authConfig);
+
+  // msal-browser 3.x requires initialize() before any other API call.
+  await msal.initialize();
+
+  // Complete any in-flight redirect (post-loginRedirect callback) before
+  // we mount, so `<MsalProvider>` sees the resulting account state on
+  // first render and the sign-in gate does not flash.
+  await msal.handleRedirectPromise();
+
+  const scope = authConfig.apiScope;
+  setAuthTokenProvider(() => acquireAdminToken(msal, scope));
+
+  root.render(
+    <StrictMode>
+      <MsalProvider instance={msal}>
+        <App authConfig={authConfig} />
+      </MsalProvider>
+    </StrictMode>,
+  );
+}
+
+void bootstrap();

--- a/src/api/dashboard.py
+++ b/src/api/dashboard.py
@@ -32,6 +32,7 @@ from connectors.cosmosdb_admin import (
 )
 from dependencies import get_config, validate_access_token
 from schemas import (
+    DashboardAuthConfigResponse,
     DashboardConversationDetail,
     DashboardConversationListResponse,
     DashboardConversationSummary,
@@ -99,6 +100,54 @@ async def get_version() -> DashboardVersionResponse:
     except OSError:
         version = "unknown"
     return DashboardVersionResponse(version=version)
+
+
+@router.get("/auth-config", response_model=DashboardAuthConfigResponse)
+async def get_auth_config(
+    cfg: AppConfigClient = Depends(get_config),
+) -> DashboardAuthConfigResponse:
+    """Return the MSAL configuration the SPA needs to sign the user in.
+
+    Unauthenticated by design (mirrors ``/version``): the SPA calls this
+    before any protected endpoint so it can decide whether to bootstrap MSAL
+    and which tenant/client/scope to use. When
+    ``OAUTH_AZURE_AD_TENANT_ID`` is not set the response only carries
+    ``auth_enabled=false`` so no tenant/client information leaks in dev mode.
+
+    The full authority URL and the API scope are derived server-side so the
+    browser never has to concatenate values that must match the app
+    registration. ``OAUTH_AZURE_AD_API_SCOPE`` is honored when explicitly set
+    for tenants where the scope needs to differ from the default
+    ``api://<client-id>/access_as_user``.
+    """
+    tenant_id = cfg.get_value("OAUTH_AZURE_AD_TENANT_ID", default=None, allow_none=True)
+    if not tenant_id:
+        return DashboardAuthConfigResponse(auth_enabled=False)
+
+    client_id = cfg.get_value("OAUTH_AZURE_AD_CLIENT_ID", default=None, allow_none=True)
+    if not client_id:
+        # Auth is half-configured (tenant set, client id missing). Surface the
+        # misconfiguration to the SPA rather than pretending auth is off,
+        # which would silently let the dashboard load without a sign-in gate.
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "OAUTH_AZURE_AD_TENANT_ID is set but OAUTH_AZURE_AD_CLIENT_ID is "
+                "missing; the dashboard cannot bootstrap MSAL until both are configured."
+            ),
+        )
+
+    api_scope = cfg.get_value(
+        "OAUTH_AZURE_AD_API_SCOPE", default=None, allow_none=True
+    ) or f"api://{client_id}/access_as_user"
+
+    return DashboardAuthConfigResponse(
+        auth_enabled=True,
+        client_id=client_id,
+        tenant_id=tenant_id,
+        authority=f"https://login.microsoftonline.com/{tenant_id}",
+        api_scope=api_scope,
+    )
 
 
 _MAX_RANGE_DAYS = 365

--- a/src/api/dashboard.py
+++ b/src/api/dashboard.py
@@ -20,7 +20,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response
 
 from connectors.appconfig import AppConfigClient
 from connectors.cosmosdb_admin import (
@@ -49,6 +49,30 @@ router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 # Admin gate
 # ---------------------------------------------------------------------------
 
+def _get_dashboard_auth_registration(
+    cfg: AppConfigClient,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return the configured tenant/client pair, failing closed when incomplete."""
+    tenant_id = cfg.get_value(
+        "OAUTH_AZURE_AD_TENANT_ID", default=None, allow_none=True
+    )
+    if not tenant_id:
+        return None, None
+
+    client_id = cfg.get_value(
+        "OAUTH_AZURE_AD_CLIENT_ID", default=None, allow_none=True
+    )
+    if not client_id:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "OAUTH_AZURE_AD_TENANT_ID is set but OAUTH_AZURE_AD_CLIENT_ID is "
+                "missing; dashboard authentication requires both settings."
+            ),
+        )
+    return tenant_id, client_id
+
+
 async def require_admin(
     authorization: Optional[str] = Header(None),
     cfg: AppConfigClient = Depends(get_config),
@@ -60,7 +84,7 @@ async def require_admin(
     configured, a bearer token is required and the resolved claims must
     include ``Admin`` in the ``roles`` array.
     """
-    tenant_id = cfg.get_value("OAUTH_AZURE_AD_TENANT_ID", default=None, allow_none=True)
+    tenant_id, _ = _get_dashboard_auth_registration(cfg)
     if not tenant_id:
         return  # auth off, dashboard open like the rest of the app in dev
 
@@ -76,8 +100,8 @@ async def require_admin(
         logging.exception("[dashboard] token validation failed: %s", exc)
         raise HTTPException(status_code=401, detail="Invalid bearer token")
 
-    roles = claims.get("roles") or []
-    if "Admin" not in roles:
+    roles = claims.get("roles")
+    if not isinstance(roles, list) or "Admin" not in roles:
         raise HTTPException(status_code=403, detail="Admin role required")
 
 
@@ -104,6 +128,7 @@ async def get_version() -> DashboardVersionResponse:
 
 @router.get("/auth-config", response_model=DashboardAuthConfigResponse)
 async def get_auth_config(
+    response: Response,
     cfg: AppConfigClient = Depends(get_config),
 ) -> DashboardAuthConfigResponse:
     """Return the MSAL configuration the SPA needs to sign the user in.
@@ -120,22 +145,10 @@ async def get_auth_config(
     for tenants where the scope needs to differ from the default
     ``api://<client-id>/access_as_user``.
     """
-    tenant_id = cfg.get_value("OAUTH_AZURE_AD_TENANT_ID", default=None, allow_none=True)
+    response.headers["Cache-Control"] = "no-store"
+    tenant_id, client_id = _get_dashboard_auth_registration(cfg)
     if not tenant_id:
         return DashboardAuthConfigResponse(auth_enabled=False)
-
-    client_id = cfg.get_value("OAUTH_AZURE_AD_CLIENT_ID", default=None, allow_none=True)
-    if not client_id:
-        # Auth is half-configured (tenant set, client id missing). Surface the
-        # misconfiguration to the SPA rather than pretending auth is off,
-        # which would silently let the dashboard load without a sign-in gate.
-        raise HTTPException(
-            status_code=500,
-            detail=(
-                "OAUTH_AZURE_AD_TENANT_ID is set but OAUTH_AZURE_AD_CLIENT_ID is "
-                "missing; the dashboard cannot bootstrap MSAL until both are configured."
-            ),
-        )
 
     api_scope = cfg.get_value(
         "OAUTH_AZURE_AD_API_SCOPE", default=None, allow_none=True

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -299,7 +299,7 @@ def _force_refresh_jwks_cache(tenant_id: str, jwks_url: Optional[str] = None) ->
         logging.debug("[Auth] Failed to clear JWKS cache", exc_info=True)
 
 async def validate_access_token(token: str) -> Dict:
-    """Validate access token and extract user info (oid, preferred_username, name)."""
+    """Validate an API access token and return its trusted identity and role claims."""
     cfg = get_config()
 
     # Basic integrity / correlation without logging the token.
@@ -404,6 +404,17 @@ async def validate_access_token(token: str) -> Dict:
             status_code=500,
             detail="Authentication not configured (missing OAUTH_AZURE_AD_TENANT_ID)",
         )
+
+    if not client_id:
+        _log_app_config_state(cfg, keys_to_check=["OAUTH_AZURE_AD_CLIENT_ID"], prefix="[Auth]")
+        logging.error(
+            "[Auth] Missing client configuration in Azure App Configuration. "
+            "Audience validation cannot run without OAUTH_AZURE_AD_CLIENT_ID."
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Authentication not configured (missing OAUTH_AZURE_AD_CLIENT_ID)",
+        )
     
     # High-signal debug: which tenant/URLs are used to validate
     if logging.getLogger().isEnabledFor(logging.DEBUG):
@@ -413,15 +424,13 @@ async def validate_access_token(token: str) -> Dict:
             f"https://login.microsoftonline.com/{tenant_id}/v2.0",
             f"https://sts.windows.net/{tenant_id}/",
         ]
-        expected_audiences = None
-        if client_id:
-            expected_audiences = [client_id, f"api://{client_id}"]
+        expected_audiences = [client_id, f"api://{client_id}"]
         logging.debug(
             "[Auth] Validating token: tenant_id=%s jwks_url=%s oidc_config_url=%s expected_audiences=%s",
             tenant_id,
             jwks_url,
             oidc_config_url,
-            expected_audiences or "<not-configured>",
+            expected_audiences,
         )
         logging.debug("[Auth] Issuer candidates: %s", issuer_candidates)
 
@@ -511,7 +520,7 @@ async def validate_access_token(token: str) -> Dict:
                 if client_id:
                     logging.warning(
                         "[Auth] Incoming token audience indicates Microsoft Graph (aud=%s fp=%s). "
-                        "Frontend must request an access token for this API scope: api://%s/user_impersonation (not Graph scopes like User.Read).",
+                        "Frontend must request an access token for this API scope: api://%s/access_as_user (not Graph scopes like User.Read).",
                         graph_aud,
                         token_fp,
                         client_id,
@@ -542,9 +551,7 @@ async def validate_access_token(token: str) -> Dict:
             f"https://sts.windows.net/{tenant_id}/",
         ]
 
-        expected_audiences: list[str] | None = None
-        if client_id:
-            expected_audiences = [client_id, f"api://{client_id}"]
+        expected_audiences = [client_id, f"api://{client_id}"]
 
         # Decide which JWKS endpoint should be used based on the token issuer.
         token_iss = unverified.get("iss")
@@ -570,7 +577,7 @@ async def validate_access_token(token: str) -> Dict:
                             public_key_local,
                             algorithms=["RS256"],
                             options={
-                                "verify_aud": bool(expected_audiences),
+                                "verify_aud": True,
                                 "verify_iss": True,
                             },
                             issuer=issuer,
@@ -633,7 +640,7 @@ async def validate_access_token(token: str) -> Dict:
                         if client_id:
                             logging.warning(
                                 "[Auth] Token audience indicates Microsoft Graph (aud=%s). "
-                                "Frontend must request an API access token scope like api://%s/user_impersonation instead of Graph scopes (e.g., User.Read).",
+                                "Frontend must request an API access token scope like api://%s/access_as_user instead of Graph scopes (e.g., User.Read).",
                                 _unverified_aud,
                                 client_id,
                             )
@@ -652,6 +659,9 @@ async def validate_access_token(token: str) -> Dict:
         user_oid = decoded.get("oid")
         user_username = decoded.get("preferred_username")
         user_name = decoded.get("name")
+        roles = decoded.get("roles")
+        if not isinstance(roles, list):
+            roles = []
 
         if not user_username:
             logging.debug(
@@ -661,11 +671,7 @@ async def validate_access_token(token: str) -> Dict:
                 "set" if user_name else "missing",
             )
 
-        logging.info(
-            "[Auth] User token validated (oid=%s preferred_username=%s)",
-            user_oid,
-            user_username or "<missing>",
-        )
+        logging.info("[Auth] User token validated (oid=%s)", user_oid)
 
         if logging.getLogger().isEnabledFor(logging.DEBUG):
             # Log a compact allowlist snapshot of claims for troubleshooting.
@@ -678,7 +684,8 @@ async def validate_access_token(token: str) -> Dict:
         return {
             "oid": user_oid,
             "preferred_username": user_username,
-            "name": user_name
+            "name": user_name,
+            "roles": roles,
         }
         
     except HTTPException:

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -233,6 +233,41 @@ class DashboardVersionResponse(BaseModel):
     version: str
 
 
+class DashboardAuthConfigResponse(BaseModel):
+    """Runtime auth configuration for the dashboard SPA.
+
+    Returned by the unauthenticated ``GET /api/dashboard/auth-config`` endpoint
+    so the SPA can decide, at load time, whether to bootstrap MSAL and which
+    tenant/client/scope to sign the user in against. Values are computed
+    server-side so the browser never has to concatenate strings that must
+    match app-registration configuration.
+
+    When auth is off (``OAUTH_AZURE_AD_TENANT_ID`` unset) only ``auth_enabled``
+    is returned; when auth is on the full quartet is included.
+    """
+
+    auth_enabled: bool = Field(
+        ...,
+        description="Whether Entra ID auth is enabled for the orchestrator.",
+    )
+    client_id: Optional[str] = Field(
+        None,
+        description="Entra ID application (client) id for the API app registration.",
+    )
+    tenant_id: Optional[str] = Field(
+        None,
+        description="Entra ID tenant id.",
+    )
+    authority: Optional[str] = Field(
+        None,
+        description="Full MSAL authority URL (login.microsoftonline.com/<tenant>).",
+    )
+    api_scope: Optional[str] = Field(
+        None,
+        description="Delegated scope the SPA must request to call this API.",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Configuration tab (admin-only)
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -243,6 +243,110 @@ def test_version_endpoint_is_public(tmp_path, monkeypatch):
     assert isinstance(data["version"], str) and data["version"]
 
 
+# ---------------------------------------------------------------------------
+# /auth-config endpoint (#546 -- MSAL bootstrap)
+# ---------------------------------------------------------------------------
+
+def _auth_cfg(values: Dict[str, Any]) -> MagicMock:
+    """Build a mock AppConfigClient that returns ``values`` for get_value()."""
+    cfg = MagicMock()
+    cfg.get_value = MagicMock(side_effect=lambda key, **_: values.get(key))
+    return cfg
+
+
+def _install_cfg(app, cfg):
+    """Override the get_config dependency the auth-config endpoint depends on."""
+    from dependencies import get_config
+
+    app.dependency_overrides[get_config] = lambda: cfg
+
+
+def test_auth_config_returns_minimal_when_auth_off():
+    """When tenant id is not configured only ``auth_enabled=false`` is returned.
+
+    The SPA uses this to know it can skip MSAL entirely in dev/unauth mode
+    without leaking any client/tenant identifiers.
+    """
+    app = _make_app()  # /auth-config is unauthenticated by design
+    _install_cfg(app, _auth_cfg({}))
+    client = TestClient(app)
+    r = client.get("/api/dashboard/auth-config")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auth_enabled"] is False
+    # No tenant/client/scope leak when auth is off.
+    for absent in ("client_id", "tenant_id", "authority", "api_scope"):
+        assert body.get(absent) is None
+
+
+def test_auth_config_returns_msal_config_when_auth_on():
+    """With both tenant + client id set, return the full MSAL bootstrap payload.
+
+    ``authority`` and ``api_scope`` are derived server-side so the browser
+    never concatenates values that must match the app registration.
+    """
+    app = _make_app()
+    _install_cfg(
+        app,
+        _auth_cfg(
+            {
+                "OAUTH_AZURE_AD_TENANT_ID": "tenant-guid",
+                "OAUTH_AZURE_AD_CLIENT_ID": "client-guid",
+            }
+        ),
+    )
+    client = TestClient(app)
+    r = client.get("/api/dashboard/auth-config")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "auth_enabled": True,
+        "client_id": "client-guid",
+        "tenant_id": "tenant-guid",
+        "authority": "https://login.microsoftonline.com/tenant-guid",
+        "api_scope": "api://client-guid/access_as_user",
+    }
+
+
+def test_auth_config_honors_explicit_api_scope_override():
+    """Operators can override the default scope with OAUTH_AZURE_AD_API_SCOPE.
+
+    Useful for tenants where the exposed scope name differs from
+    ``access_as_user`` (for example, when the API app registration was
+    provisioned with a different scope value).
+    """
+    app = _make_app()
+    _install_cfg(
+        app,
+        _auth_cfg(
+            {
+                "OAUTH_AZURE_AD_TENANT_ID": "tenant-guid",
+                "OAUTH_AZURE_AD_CLIENT_ID": "client-guid",
+                "OAUTH_AZURE_AD_API_SCOPE": "api://client-guid/Dashboard.Access",
+            }
+        ),
+    )
+    client = TestClient(app)
+    r = client.get("/api/dashboard/auth-config")
+    assert r.status_code == 200
+    assert r.json()["api_scope"] == "api://client-guid/Dashboard.Access"
+
+
+def test_auth_config_500s_when_tenant_set_but_client_missing():
+    """Half-configured auth is surfaced as a 500, not silently as auth=off.
+
+    Otherwise an operator who set the tenant id but forgot the client id
+    would see the dashboard load without a sign-in gate, which would be a
+    silent auth downgrade.
+    """
+    app = _make_app()
+    _install_cfg(app, _auth_cfg({"OAUTH_AZURE_AD_TENANT_ID": "tenant-guid"}))
+    client = TestClient(app)
+    r = client.get("/api/dashboard/auth-config")
+    assert r.status_code == 500
+    assert "OAUTH_AZURE_AD_CLIENT_ID" in r.json()["detail"]
+
+
 def test_overview_endpoint_uses_cache(monkeypatch):
     from api import dashboard
     from connectors import cosmosdb_admin

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -66,10 +66,31 @@ async def test_require_admin_rejects_missing_token():
     from api.dashboard import require_admin
 
     cfg = MagicMock()
-    cfg.get_value = MagicMock(return_value="tenant-id")
+    cfg.get_value = MagicMock(
+        side_effect=lambda key, **_: {
+            "OAUTH_AZURE_AD_TENANT_ID": "tenant-id",
+            "OAUTH_AZURE_AD_CLIENT_ID": "client-id",
+        }.get(key)
+    )
     with pytest.raises(HTTPException) as exc:
         await require_admin(authorization=None, cfg=cfg)
     assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_require_admin_fails_closed_when_client_id_is_missing():
+    from api.dashboard import require_admin
+
+    cfg = MagicMock()
+    cfg.get_value = MagicMock(
+        side_effect=lambda key, **_: {
+            "OAUTH_AZURE_AD_TENANT_ID": "tenant-id",
+        }.get(key)
+    )
+    with pytest.raises(HTTPException) as exc:
+        await require_admin(authorization="Bearer token", cfg=cfg)
+    assert exc.value.status_code == 500
+    assert "OAUTH_AZURE_AD_CLIENT_ID" in exc.value.detail
 
 
 @pytest.mark.asyncio
@@ -77,7 +98,12 @@ async def test_require_admin_rejects_non_admin_role():
     from api import dashboard
 
     cfg = MagicMock()
-    cfg.get_value = MagicMock(return_value="tenant-id")
+    cfg.get_value = MagicMock(
+        side_effect=lambda key, **_: {
+            "OAUTH_AZURE_AD_TENANT_ID": "tenant-id",
+            "OAUTH_AZURE_AD_CLIENT_ID": "client-id",
+        }.get(key)
+    )
     with patch.object(dashboard, "validate_access_token", new=AsyncMock(return_value={"roles": ["User"]})):
         with pytest.raises(HTTPException) as exc:
             await dashboard.require_admin(authorization="Bearer abc", cfg=cfg)
@@ -89,10 +115,84 @@ async def test_require_admin_accepts_admin_role():
     from api import dashboard
 
     cfg = MagicMock()
-    cfg.get_value = MagicMock(return_value="tenant-id")
+    cfg.get_value = MagicMock(
+        side_effect=lambda key, **_: {
+            "OAUTH_AZURE_AD_TENANT_ID": "tenant-id",
+            "OAUTH_AZURE_AD_CLIENT_ID": "client-id",
+        }.get(key)
+    )
     with patch.object(dashboard, "validate_access_token", new=AsyncMock(return_value={"roles": ["Admin"]})):
         result = await dashboard.require_admin(authorization="Bearer abc", cfg=cfg)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_require_admin_rejects_malformed_roles_claim():
+    from api import dashboard
+
+    cfg = MagicMock()
+    cfg.get_value = MagicMock(
+        side_effect=lambda key, **_: {
+            "OAUTH_AZURE_AD_TENANT_ID": "tenant-id",
+            "OAUTH_AZURE_AD_CLIENT_ID": "client-id",
+        }.get(key)
+    )
+    with patch.object(
+        dashboard,
+        "validate_access_token",
+        new=AsyncMock(return_value={"roles": "SuperAdmin"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await dashboard.require_admin(authorization="Bearer token", cfg=cfg)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_validate_access_token_returns_verified_roles():
+    from dependencies import validate_access_token
+
+    cfg = MagicMock()
+    cfg.get_value = MagicMock(
+        side_effect=lambda key, **_: {
+            "OAUTH_AZURE_AD_TENANT_ID": "tenant-id",
+            "OAUTH_AZURE_AD_CLIENT_ID": "client-id",
+        }.get(key)
+    )
+    unverified_claims = {
+        "tid": "tenant-id",
+        "iss": "https://login.microsoftonline.com/tenant-id/v2.0",
+        "aud": "client-id",
+    }
+    verified_claims = {
+        **unverified_claims,
+        "oid": "user-id",
+        "preferred_username": "admin@example.com",
+        "name": "Admin User",
+        "roles": ["Admin"],
+    }
+
+    with (
+        patch("dependencies.get_config", return_value=cfg),
+        patch(
+            "dependencies._get_cached_public_keys",
+            new=AsyncMock(return_value={"keys": [{"kid": "key-id"}]}),
+        ),
+        patch(
+            "dependencies.jwt.get_unverified_header",
+            return_value={"kid": "key-id", "alg": "RS256"},
+        ),
+        patch(
+            "dependencies.jwt.algorithms.RSAAlgorithm.from_jwk",
+            return_value=object(),
+        ),
+        patch(
+            "dependencies.jwt.decode",
+            side_effect=[unverified_claims, verified_claims],
+        ),
+    ):
+        claims = await validate_access_token("header.payload.signature")
+
+    assert claims["roles"] == ["Admin"]
 
 
 # ---------------------------------------------------------------------------
@@ -272,6 +372,7 @@ def test_auth_config_returns_minimal_when_auth_off():
     client = TestClient(app)
     r = client.get("/api/dashboard/auth-config")
     assert r.status_code == 200
+    assert r.headers["cache-control"] == "no-store"
     body = r.json()
     assert body["auth_enabled"] is False
     # No tenant/client/scope leak when auth is off.


### PR DESCRIPTION
## Summary

Completes Microsoft Entra ID sign-in for the admin dashboard SPA at `/dashboard/` using MSAL Authorization Code + PKCE (`loginRedirect`) while preserving the existing opt-in authorization model.

Refs: [Azure/GPT-RAG#546](https://github.com/Azure/GPT-RAG/issues/546)

## What changed

### Backend authorization

- Added public `GET /api/dashboard/auth-config` runtime bootstrap configuration with `Cache-Control: no-store`.
- Authentication remains opt-in: when `OAUTH_AZURE_AD_TENANT_ID` is unset, the dashboard runs without MSAL and `require_admin` remains a no-op.
- Partial configuration now fails closed: when the tenant is set but `OAUTH_AZURE_AD_CLIENT_ID` is missing, both bootstrap and protected routes return a server misconfiguration instead of skipping audience validation.
- `validate_access_token` now always validates the orchestrator API audience and returns the verified `roles` claim.
- `require_admin` continues to require the exact `Admin` app role and rejects malformed/non-list role claims.
- Corrected token troubleshooting guidance to use the `access_as_user` scope and removed the user principal name from info-level logs.

### Dashboard SPA

- Added `@azure/msal-browser` and `@azure/msal-react` with tenant/client/scope configuration supplied by the orchestrator API.
- Requests acquire an API-scoped token through MSAL and attach it to every protected `/api/dashboard/*` call; the old `localStorage["dashboard.bearer"]` path is no longer the default.
- Active account selection is pinned after redirect and used consistently for token acquisition and sign-out.
- Concurrent token requests are coalesced so multiple initial dashboard calls cannot start competing interactive redirects.
- 401 renders an actionable session-expired reauthentication state; 403 renders an explicit missing-`Admin`-role state with a sign-out/account-switch action.
- Sign-in/sign-out actions include pending and failure states. Bootstrap failures no longer expose raw exceptions and include a retry action.
- Added accessible alert states and a complete keyboard/ARIA tab pattern.

### Documentation and validation preparation

- Updated `README.md` with the single App Registration model, App Configuration keys, scope/audience behavior, exact `Admin` app-role requirement, where to define vs assign app roles, why `Assignment required? = No` is useful for app-level 403 validation, and why users must sign out/in after role changes.
- Added `.azure/deployment-plan.md` with the Azure validation plan for `mcaps-paulolacerda`.
- The previous planned validation RG `rg-gptrag-546val` no longer exists in the target subscription, so live validation now requires either recreating a controlled validation environment or selecting another complete environment after read-only inventory.
- Updated `CHANGELOG.md` under `Unreleased` and linked the operator sign-in guide.
- Added focused tests for partial auth configuration, malformed role claims, verified role propagation, and non-cacheable auth bootstrap responses.

## Operator prerequisites

1. Use one Microsoft Entra app registration for both the dashboard SPA and orchestrator API.
2. Add a **Single-page application** redirect URI for the deployed dashboard, for example `https://<host>/dashboard/`.
3. Expose an `access_as_user` delegated scope, defaulting to `api://<client_id>/access_as_user`.
4. Define exactly one app role with value `Admin` under App registrations > app > App roles.
5. Assign the `Admin` role under Enterprise applications > app > Users and groups.
6. Configure App Configuration label `gpt-rag-orchestrator`:
   - `ENABLE_DASHBOARD=true`
   - `OAUTH_AZURE_AD_TENANT_ID`
   - `OAUTH_AZURE_AD_CLIENT_ID`
   - `OAUTH_AZURE_AD_API_SCOPE` (optional; defaults to `api://<client_id>/access_as_user`)

## Validation

- `python -m pytest tests/test_dashboard.py` — **32 passed**
- `python -m pytest -q` — **297 passed** before the validation-plan commit
- `cd frontend && npm run lint -- --max-warnings=0` — passed
- `cd frontend && npm run build` — passed
- Independent security/code review — no high-confidence defects remaining
- Final UX/accessibility review findings addressed

## Remaining environment validation

Live-tenant validation is prepared but not executed in this PR branch. The prepared plan is in `.azure/deployment-plan.md`.

Required scenarios before production rollout:

1. Auth off: dashboard loads without MSAL.
2. Auth on with an assigned `Admin`: redirect returns to `/dashboard/` and protected tabs load.
3. Auth on without `Admin`: the access-denied state appears. Keep Enterprise Application `Assignment required? = No` for this test.
4. Expired/invalid session: the 401 reauthentication action obtains a fresh API token.

The main `gpt-rag-ui` chat frontend is unchanged.
