### PR TITLE
Work IQ knowledge source support (Phase 0 plumbing + Work IQ kind)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Work IQ (Microsoft 365) knowledge source support (opt-in, default off).**
+  The Foundry IQ retrieve client can now include a Work IQ knowledge source
+  alongside existing `azureBlob` / `searchIndex` sources, giving grounded
+  answers over the caller's Outlook mail, Teams chats, SharePoint / OneDrive
+  files, and other M365 signals. Behavior is gated by
+  `WORK_IQ_ENABLED` and `WORK_IQ_KNOWLEDGE_SOURCE_NAME`; when both are set and
+  an on-behalf-of user token is available, a `kind="workIQ"` entry is
+  appended to `knowledgeSourceParams`. ACL is enforced natively by M365 via
+  the forwarded user token, so no `filterAddOn` is emitted. Managed-identity
+  fallback is never used for remote knowledge source kinds — when the OBO
+  token is missing the Work IQ source is skipped (with a warning) and local
+  sources still serve the request. See
+  [Azure/GPT-RAG#543](https://github.com/Azure/GPT-RAG/issues/543) for the
+  end-to-end enablement guide (gated preview, admin consent, service
+  principal, and Work IQ knowledge source provisioning).
+
+- **Foundry IQ `maxRuntimeInSeconds` plumbing.** Remote knowledge source kinds
+  fan out to Microsoft 365 (and, later, Fabric) and can take 40–60 seconds
+  end-to-end. The retrieve body now carries `maxRuntimeInSeconds` (default
+  `120`, override via `FOUNDRY_IQ_MAX_RUNTIME_SECONDS`) whenever a remote
+  kind is enabled. The header is not emitted for Pattern A / Pattern B — the
+  default retrieve body is byte-identical to prior releases.
+
+- **Reference-normalization seam for remote knowledge sources.** The
+  `_normalize_references` mapper now recognizes the Work IQ `sourceData`
+  shape (`attributions[].seeMoreWebUrl` + `extracts[].text`) and returns the
+  same `{title, link, content}` contract the rest of the orchestrator
+  expects. The seam is generic so future Fabric IQ shapes can be added
+  without touching call sites.
+
 ### Fixed
 
 - **Foundry IQ conversation upload filter compatibility:** Changed the

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ The **GPT-RAG Orchestrator** service is an agentic orchestration layer built on 
 > [!IMPORTANT]
 > When using the `nl2sql` strategy, configure every SQL Server, Azure SQL, or Fabric SQL datasource with a least-privilege read-only principal. Grant only the `SELECT` permissions needed for approved schemas, tables, or views, and do not use admin, owner, contributor, ingestion, or write-capable identities for NL2SQL query execution. The orchestrator validates generated SQL before execution, but database permissions remain the primary security boundary.
 
+### Retrieval backends
+
+The `rag` and `multimodal_rag` strategies use Foundry IQ's Knowledge Base retrieve API. Alongside the existing native `azureBlob` and `searchIndex` (Pattern B) knowledge sources, the orchestrator can optionally query a Microsoft 365 **Work IQ** knowledge source for grounded answers over the caller's Outlook mail, Teams chats, and SharePoint / OneDrive files.
+
+Work IQ is opt-in and off by default:
+
+- Set `WORK_IQ_ENABLED=true` and `WORK_IQ_KNOWLEDGE_SOURCE_NAME=<your Work IQ knowledge source>` to enable it.
+- Work IQ requires a per-user on-behalf-of token. When the OBO token is missing the Work IQ source is skipped with a warning; managed-identity fallback is never used for remote knowledge source kinds.
+- ACL is enforced natively by Microsoft 365 via the forwarded user token — no `filterAddOn` is emitted for Work IQ.
+- Remote kinds can take 40–60 seconds end-to-end; set `FOUNDRY_IQ_MAX_RUNTIME_SECONDS` (default `120`) to control the retrieve runtime ceiling. The value is only emitted when a remote kind is enabled, so Pattern A / Pattern B requests stay byte-identical.
+
+Work IQ is currently a gated preview and requires admin consent plus a Work IQ knowledge source provisioned on the same Azure AI Search service. See the enablement guide in the [Azure/GPT-RAG](https://github.com/Azure/GPT-RAG) repo for the end-to-end setup ([issue #543](https://github.com/Azure/GPT-RAG/issues/543)).
+
 ## Documentation
 
 For comprehensive information about GPT-RAG, including architecture details, configuration guides, best practices, troubleshooting resources, deployment guidance, customization options, and advanced usage scenarios, please refer to the [official project documentation](https://azure.github.io/GPT-RAG/).

--- a/src/api/config_settings.py
+++ b/src/api/config_settings.py
@@ -160,6 +160,13 @@ _FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND_OPTIONS: List[SettingOption] = [
         "Existing Azure AI Search index",
         "Legacy Pattern B: register the GPT-RAG generated search index and optionally apply filterAddOn.",
     ),
+    SettingOption(
+        "workIQ",
+        "Work IQ (Microsoft 365)",
+        "Remote Microsoft 365 knowledge source (mail, files, chats). Requires the "
+        "gated Work IQ preview and OBO (x-ms-query-source-authorization). ACL is "
+        "enforced natively by M365 — no filterAddOn is applied.",
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -393,6 +400,49 @@ SECTIONS: List[SettingSection] = [
                     "is on. Provisioned by the deployment; defaults to "
                     "'<SEARCH_RAG_INDEX_NAME>-conv-ks'. Leave blank to let the "
                     "deployment set it."
+                ),
+            ),
+            SettingSpec(
+                key="FOUNDRY_IQ_MAX_RUNTIME_SECONDS",
+                type="int",
+                default=120,
+                label="Foundry IQ retrieve max runtime",
+                description=(
+                    "Upper bound on the Foundry IQ retrieve action runtime, sent "
+                    "as maxRuntimeInSeconds on the request body. Remote knowledge "
+                    "sources such as Work IQ can take 40–60 seconds; the default "
+                    "leaves headroom. Only emitted when a remote knowledge source "
+                    "kind (workIQ, fabric*) is enabled, so default Pattern A / "
+                    "Pattern B request bodies remain unchanged."
+                ),
+                min=30,
+                max=600,
+                step=1,
+                unit="seconds",
+            ),
+            SettingSpec(
+                key="WORK_IQ_ENABLED",
+                type="bool",
+                default=False,
+                label="Enable Work IQ knowledge source",
+                description=(
+                    "When enabled and WORK_IQ_KNOWLEDGE_SOURCE_NAME is set, the "
+                    "Foundry IQ retrieve request appends a workIQ knowledge source "
+                    "for Microsoft 365 grounding (mail, files, chats). Requires "
+                    "the gated Work IQ preview and admin consent on the Foundry "
+                    "connector. OBO is mandatory — anonymous / managed-identity "
+                    "fallback is never used for Work IQ."
+                ),
+            ),
+            SettingSpec(
+                key="WORK_IQ_KNOWLEDGE_SOURCE_NAME",
+                type="string",
+                default="",
+                label="Work IQ knowledge source name",
+                description=(
+                    "Name of the Work IQ knowledge source registered on the "
+                    "knowledge base. Required when WORK_IQ_ENABLED is true. "
+                    "No effect when Work IQ is disabled."
                 ),
             ),
             SettingSpec(

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -57,6 +57,26 @@ FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED_KEY = "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENA
 FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME_KEY = (
     "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME"
 )
+# Upper bound on the retrieve action runtime (maxRuntimeInSeconds on the
+# request body). Remote knowledge source kinds such as workIQ / fabricOntology
+# can take 40-60s to fan out; the default leaves headroom without penalising
+# the fast local kinds. Only emitted when a remote kind is enabled so today's
+# Pattern A / Pattern B request bodies remain byte-identical.
+FOUNDRY_IQ_MAX_RUNTIME_SECONDS_KEY = "FOUNDRY_IQ_MAX_RUNTIME_SECONDS"
+DEFAULT_FOUNDRY_IQ_MAX_RUNTIME_SECONDS = 120
+
+# Work IQ (Microsoft 365 remote knowledge source). Opt-in; default off. When
+# enabled, the retrieve request appends a workIQ knowledge source in
+# knowledgeSourceParams. ACL is enforced natively by M365, so no filterAddOn
+# is applied. OBO is required — MI fallback is never used for remote kinds.
+WORK_IQ_ENABLED_KEY = "WORK_IQ_ENABLED"
+WORK_IQ_KNOWLEDGE_SOURCE_NAME_KEY = "WORK_IQ_KNOWLEDGE_SOURCE_NAME"
+
+# Knowledge source kinds that must never fall back to the service managed
+# identity for x-ms-query-source-authorization. These sources run against
+# external systems (M365, Fabric) where impersonation, not app identity, is
+# the security boundary.
+_REMOTE_KNOWLEDGE_SOURCE_KINDS = frozenset({"workIQ"})
 
 # Search-audience scope used for the service token.
 _SEARCH_SCOPE = "https://search.azure.com/.default"
@@ -220,6 +240,21 @@ class FoundryIQClient:
         self.conversation_knowledge_source_name = (
             self.cfg.get(FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
         ).strip()
+        # Retrieve-runtime ceiling for remote knowledge source kinds.
+        self.max_runtime_seconds = _as_optional_int(
+            self.cfg.get(
+                FOUNDRY_IQ_MAX_RUNTIME_SECONDS_KEY,
+                DEFAULT_FOUNDRY_IQ_MAX_RUNTIME_SECONDS,
+            )
+        ) or DEFAULT_FOUNDRY_IQ_MAX_RUNTIME_SECONDS
+        # Work IQ (Microsoft 365) remote knowledge source. Opt-in; requires
+        # a per-user OBO token — anonymous / MI fallback is never used.
+        self.work_iq_enabled = _as_bool(
+            self.cfg.get(WORK_IQ_ENABLED_KEY, False, type=bool)
+        )
+        self.work_iq_knowledge_source_name = (
+            self.cfg.get(WORK_IQ_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
+        ).strip()
         self.credential = self.cfg.aiocredential
 
         # Shared aiohttp session — reuses TCP connections across calls.
@@ -256,7 +291,66 @@ class FoundryIQClient:
         )
 
     @staticmethod
-    def _normalize_references(payload: Dict[str, Any]) -> List[Dict[str, str]]:
+    def _normalize_work_iq_reference(source: Dict[str, Any]) -> Optional[Dict[str, str]]:
+        """Map a Work IQ ``sourceData`` payload into ``{title, link, content}``.
+
+        Work IQ references do not use the flat ``snippet`` / ``blob_url`` shape.
+        Instead they carry:
+
+        - ``attributions[]`` — one or more entries per reference. Each carries
+          a ``seeMoreWebUrl`` (Outlook / SharePoint / Teams deep link) and,
+          when available, a subject / filename we can use as the citation
+          title.
+        - ``extracts[]`` — extracted chunks with a ``text`` field. Concatenating
+          the extracts gives the grounding content the LLM sees.
+
+        Returns ``None`` when the payload has neither extracts nor attributions
+        we can use, so the caller can skip empty Work IQ hits without falling
+        through to the generic azureBlob / searchIndex path (which would
+        otherwise emit a ``reference`` title and no link).
+        """
+        attributions = source.get("attributions") or []
+        extracts = source.get("extracts") or []
+        if not attributions and not extracts:
+            return None
+
+        extract_texts: List[str] = []
+        for extract in extracts:
+            if isinstance(extract, Mapping):
+                text = extract.get("text")
+                if text:
+                    extract_texts.append(str(text))
+        content = "\n\n".join(extract_texts).strip()
+        if not content:
+            return None
+
+        link = ""
+        title: Optional[str] = None
+        for attribution in attributions:
+            if not isinstance(attribution, Mapping):
+                continue
+            if not link:
+                link = str(attribution.get("seeMoreWebUrl") or "")
+            if not title:
+                # Prefer human-friendly labels, fall back to filename.
+                for key in ("subject", "name", "title", "filename", "fileName"):
+                    value = attribution.get(key)
+                    if value:
+                        title = str(value)
+                        break
+            if link and title:
+                break
+
+        if not title and link:
+            tail = link.rsplit("/", 1)[-1]
+            title = tail.split("?", 1)[0] or None
+        if not title:
+            title = "reference"
+
+        return {"title": title, "link": link, "content": content}
+
+    @classmethod
+    def _normalize_references(cls, payload: Dict[str, Any]) -> List[Dict[str, str]]:
         """Map a retrieve response into ``[{title, link, content}]`` records.
 
         The knowledge base retrieve response carries a ``references`` array;
@@ -269,6 +363,9 @@ class FoundryIQClient:
           ``sourceData.blob_url`` and do not include ``title``.
         - ``searchIndex`` Pattern B sources return whatever the index
           projects (typically ``content``, ``filepath``/``url``, ``title``).
+        - ``workIQ`` (Microsoft 365) sources return ``sourceData.attributions``
+          and ``sourceData.extracts`` instead of a flat snippet field. See
+          :meth:`_normalize_work_iq_reference`.
 
         We accept the union with explicit priority so the downstream
         ``{title, link, content}`` contract is identical across backends,
@@ -279,6 +376,14 @@ class FoundryIQClient:
         records: List[Dict[str, str]] = []
         for ref in payload.get("references", []) or []:
             source = ref.get("sourceData") or {}
+
+            # Work IQ / future Fabric shapes: prefer the specialised mapper
+            # when the payload carries the remote-kind fields.
+            if source.get("attributions") or source.get("extracts"):
+                record = cls._normalize_work_iq_reference(source)
+                if record is not None:
+                    records.append(record)
+                continue
 
             content = (
                 source.get("snippet")
@@ -371,6 +476,53 @@ class FoundryIQClient:
             self.conversation_knowledge_source_name,
         )
         return params
+
+    def _build_work_iq_source_params(
+        self, *, obo_token: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Build the Work IQ (Microsoft 365) knowledge source entry.
+
+        Returns ``None`` when Work IQ does not apply:
+
+        - the feature is disabled, or
+        - no knowledge source name was provisioned, or
+        - no per-user OBO token is available (remote kinds strictly require
+          impersonation — MI fallback is never used).
+
+        Work IQ enforces ACL natively via the M365 user token, so no
+        ``filterAddOn`` is emitted.
+        """
+        if not self.work_iq_enabled:
+            return None
+        if not self.work_iq_knowledge_source_name:
+            logging.warning(
+                "[FoundryIQClient] WORK_IQ_ENABLED=true but "
+                "WORK_IQ_KNOWLEDGE_SOURCE_NAME is empty; skipping Work IQ source."
+            )
+            return None
+        if not obo_token:
+            logging.warning(
+                "[FoundryIQClient] WORK_IQ_ENABLED=true but no OBO token "
+                "(x-ms-query-source-authorization) available; skipping Work IQ "
+                "source. Managed-identity fallback is never used for remote "
+                "knowledge source kinds."
+            )
+            return None
+
+        logging.info(
+            "[FoundryIQClient][WorkIQ] Adding workIQ source %s (ACL native, no filterAddOn)",
+            self.work_iq_knowledge_source_name,
+        )
+        return {
+            "knowledgeSourceName": self.work_iq_knowledge_source_name,
+            "kind": "workIQ",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+
+    def _remote_kinds_enabled(self) -> bool:
+        """Return True when any remote (M365 / Fabric) knowledge source is on."""
+        return self.work_iq_enabled
 
     async def retrieve(
         self,
@@ -489,8 +641,18 @@ class FoundryIQClient:
         if conversation_source_params:
             knowledge_source_params.append(conversation_source_params)
 
+        work_iq_source_params = self._build_work_iq_source_params(obo_token=obo_token)
+        if work_iq_source_params:
+            knowledge_source_params.append(work_iq_source_params)
+
         if knowledge_source_params:
             body["knowledgeSourceParams"] = knowledge_source_params
+
+        # Remote kinds (workIQ, future fabric*) can take 40-60s to fan out.
+        # Emit the runtime ceiling only when a remote kind is enabled so the
+        # default Pattern A / Pattern B request body stays byte-identical.
+        if self._remote_kinds_enabled():
+            body["maxRuntimeInSeconds"] = self.max_runtime_seconds
 
         session = await self._get_session()
         async with session.post(url, headers=headers, json=body) as resp:

--- a/tests/test_foundry_iq_work_iq.py
+++ b/tests/test_foundry_iq_work_iq.py
@@ -1,0 +1,330 @@
+"""Tests for the Work IQ (Microsoft 365) knowledge source path.
+
+Covers Azure/GPT-RAG#543 Phase 0 plumbing + Phase 1 Work IQ kind:
+
+- ``maxRuntimeInSeconds`` is emitted only when a remote knowledge source kind
+  is enabled, so today's Pattern A / Pattern B request bodies remain
+  byte-identical.
+- ``workIQ`` knowledge source params are appended only when
+  ``WORK_IQ_ENABLED`` is true and ``WORK_IQ_KNOWLEDGE_SOURCE_NAME`` is set.
+- ``workIQ`` params never carry a ``filterAddOn`` — ACL is enforced natively
+  by Microsoft 365 via the forwarded user token.
+- The MI fallback controlled by ``FOUNDRY_IQ_FORWARD_SOURCE_AUTH`` still
+  applies to local ``azureBlob`` / ``searchIndex`` sources and never
+  substitutes for OBO on remote kinds.
+- ``_normalize_references`` maps the Work IQ ``attributions[].seeMoreWebUrl`` +
+  ``extracts[].text`` shape to the shared ``{title, link, content}`` contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fakes (kept in-file so this module is self-contained; matches the style of
+# tests/test_foundry_iq.py).
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def text(self):
+        import json
+        return json.dumps(self._payload)
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self._status = status
+        self.captured = {}
+
+    def post(self, url, headers=None, json=None):  # noqa: A002
+        self.captured = {"url": url, "headers": headers, "json": json}
+        return _FakeResponse(self._payload, self._status)
+
+
+def _build_client(payload, status=200, config_overrides=None):
+    from connectors import foundry_iq
+
+    values = {
+        "KNOWLEDGE_BASE_ENDPOINT": "https://fake-search.search.windows.net",
+        "SEARCH_SERVICE_QUERY_ENDPOINT": "https://fake-search.search.windows.net",
+        "KNOWLEDGE_BASE_NAME": "kb-test",
+        "FOUNDRY_IQ_API_VERSION": "2026-05-01-preview",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND": "",
+        "FOUNDRY_IQ_PATTERN": "",
+        "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED": False,
+        "FOUNDRY_IQ_SECURITY_FIELD_NAME": "metadata_security_id",
+        "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": None,
+        "FOUNDRY_IQ_FORWARD_SOURCE_AUTH": True,
+        "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": False,
+        "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_MAX_RUNTIME_SECONDS": 120,
+        "WORK_IQ_ENABLED": False,
+        "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "",
+    }
+    values.update(config_overrides or {})
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda key, default=None, type=str: values.get(key, default)  # noqa: A002
+    cfg.aiocredential = MagicMock()
+    cfg.aiocredential.get_token = AsyncMock(return_value=SimpleNamespace(token="svc-token"))
+
+    with patch("connectors.foundry_iq.get_config", return_value=cfg):
+        client = foundry_iq.FoundryIQClient()
+    session = _FakeSession(payload, status)
+    client._get_session = AsyncMock(return_value=session)
+    return client, session
+
+
+_SAMPLE_PAYLOAD = {"references": []}
+
+
+# ---------------------------------------------------------------------------
+# Phase 0: maxRuntimeInSeconds
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_max_runtime_not_emitted_by_default():
+    """Default Pattern A / Pattern B request body must stay byte-identical:
+    no maxRuntimeInSeconds when no remote kind is enabled."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={"FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks"},
+    )
+    await client.retrieve("hello")
+    assert "maxRuntimeInSeconds" not in session.captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_max_runtime_emitted_when_work_iq_enabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    assert session.captured["json"]["maxRuntimeInSeconds"] == 120
+
+
+@pytest.mark.asyncio
+async def test_max_runtime_override_respected():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+            "FOUNDRY_IQ_MAX_RUNTIME_SECONDS": 240,
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    assert session.captured["json"]["maxRuntimeInSeconds"] == 240
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Work IQ knowledge source emission
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_work_iq_not_emitted_when_disabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "WORK_IQ_ENABLED": False,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "workIQ" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_work_iq_not_emitted_when_name_missing():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "workIQ" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_work_iq_emitted_when_enabled_with_obo():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    work_iq = [s for s in sources if s.get("kind") == "workIQ"]
+    assert work_iq == [
+        {
+            "knowledgeSourceName": "workiq-ks",
+            "kind": "workIQ",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_work_iq_never_carries_filter_add_on():
+    """M365 enforces ACL natively; a filterAddOn on workIQ would be wrong."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+        },
+    )
+    await client.retrieve(
+        "hello",
+        obo_token="user-obo",
+        conversation_id="conv-1",
+        user_context={"principal_id": "user-1", "groups": ["g-a"]},
+    )
+    work_iq = [
+        s for s in session.captured["json"]["knowledgeSourceParams"]
+        if s.get("kind") == "workIQ"
+    ]
+    assert len(work_iq) == 1
+    assert "filterAddOn" not in work_iq[0]
+
+
+@pytest.mark.asyncio
+async def test_work_iq_skipped_when_obo_missing():
+    """CONTRACT: remote kinds require OBO. MI fallback must not be used for
+    Work IQ. When no OBO token is available the Work IQ source is dropped
+    (with a warning) so local sources still serve the request."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+        },
+    )
+    await client.retrieve("hello")
+
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "workIQ" for s in sources)
+    # Local source still present.
+    assert any(s.get("kind") == "azureBlob" for s in sources)
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: MI fallback still works for local kinds.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mi_fallback_still_works_for_azure_blob():
+    """Baseline behavior for Pattern A must be preserved when Work IQ is off."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={"FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks"},
+    )
+    await client.retrieve("hello")
+    headers = session.captured["headers"]
+    assert headers["x-ms-query-source-authorization"] == "svc-token"
+
+
+@pytest.mark.asyncio
+async def test_mi_fallback_still_works_for_search_index():
+    """Pattern B still uses the MI-forwarded header when no OBO token is
+    supplied and forwarding is enabled."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "ragindex-ks",
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND": "searchIndex",
+        },
+    )
+    await client.retrieve("hello")
+    headers = session.captured["headers"]
+    assert headers["x-ms-query-source-authorization"] == "svc-token"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_references for Work IQ shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_normalize_work_iq_reference_shape():
+    """Work IQ sourceData carries attributions[].seeMoreWebUrl for links,
+    extracts[].text for content, and a subject/name attribution for titles."""
+    payload = {
+        "references": [
+            {
+                "type": "workIQ",
+                "sourceData": {
+                    "attributions": [
+                        {
+                            "subject": "Q4 roadmap discussion",
+                            "seeMoreWebUrl": "https://outlook.office.com/mail/id/abc",
+                        }
+                    ],
+                    "extracts": [
+                        {"text": "Ship Work IQ integration this quarter."},
+                        {"text": "Follow-up: enable admin consent."},
+                    ],
+                },
+            },
+            {
+                # Attribution with only a link — title falls back to URL tail.
+                "type": "workIQ",
+                "sourceData": {
+                    "attributions": [
+                        {"seeMoreWebUrl": "https://contoso.sharepoint.com/sites/x/plan.docx"}
+                    ],
+                    "extracts": [{"text": "Draft plan section."}],
+                },
+            },
+            {
+                # Empty extracts must be dropped, not surfaced as a bare title.
+                "type": "workIQ",
+                "sourceData": {
+                    "attributions": [{"seeMoreWebUrl": "https://x/empty"}],
+                    "extracts": [],
+                },
+            },
+        ]
+    }
+    client, _ = _build_client(payload)
+    records = await client.retrieve("hello", obo_token="user-obo")
+    assert records == [
+        {
+            "title": "Q4 roadmap discussion",
+            "link": "https://outlook.office.com/mail/id/abc",
+            "content": "Ship Work IQ integration this quarter.\n\nFollow-up: enable admin consent.",
+        },
+        {
+            "title": "plan.docx",
+            "link": "https://contoso.sharepoint.com/sites/x/plan.docx",
+            "content": "Draft plan section.",
+        },
+    ]


### PR DESCRIPTION
## Summary

Adds Microsoft 365 **Work IQ** as an opt-in remote knowledge source for the Foundry IQ retrieve client, plus the Phase 0 plumbing needed to keep future remote kinds (Fabric IQ) additive. Default-off; the default retrieve body is byte-identical to today's Pattern A / Pattern B.

Refs: [Azure/GPT-RAG#543](https://github.com/Azure/GPT-RAG/issues/543).

## What changed

**Phase 0 plumbing (src/connectors/foundry_iq.py)**

- Emit `maxRuntimeInSeconds` on the retrieve body **only** when a remote kind is enabled. Configurable via `FOUNDRY_IQ_MAX_RUNTIME_SECONDS` (default 120). Chosen the safer path: no `maxRuntimeInSeconds` when only local kinds are configured, so today's requests are byte-identical.
- Enforce that remote kinds require an on-behalf-of user token. Managed-identity fallback (`FOUNDRY_IQ_FORWARD_SOURCE_AUTH`) continues to apply to `azureBlob` / `searchIndex` and is **never** used for remote kinds. When the OBO token is missing the Work IQ source is skipped with a warning and local sources still serve the request (graceful degradation over a hard error).
- New `_normalize_work_iq_reference` seam mapping `sourceData.attributions[].seeMoreWebUrl` (link), `attributions[].{subject,name,title,filename,fileName}` (title, with URL-tail fallback), and `extracts[].text` (content) to the shared `{title, link, content}` contract. Existing `azureBlob` / `searchIndex` normalization is unchanged. Generic enough for future Fabric shapes.

**Phase 1 Work IQ kind**

- `src/api/config_settings.py`: added `workIQ` to `FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND` options; added `WORK_IQ_ENABLED` (bool, default `false`), `WORK_IQ_KNOWLEDGE_SOURCE_NAME` (string, default empty), and `FOUNDRY_IQ_MAX_RUNTIME_SECONDS` (int, default 120).
- `src/connectors/foundry_iq.py`: when both `WORK_IQ_ENABLED` and `WORK_IQ_KNOWLEDGE_SOURCE_NAME` are set and an OBO token is available, a `kind="workIQ"` entry is appended to `knowledgeSourceParams` next to the primary source. ACL is enforced natively by M365 via the forwarded user token — no `filterAddOn` on Work IQ.

## Default-off guarantee

- `WORK_IQ_ENABLED` defaults to `false`.
- `maxRuntimeInSeconds` is not emitted unless a remote kind is enabled.
- MI-fallback behavior for `azureBlob` / `searchIndex` is unchanged.
- Explicit regression tests cover the MI fallback path.

## Testing

- 11 new focused unit tests in `tests/test_foundry_iq_work_iq.py` covering:
  - `maxRuntimeInSeconds` not emitted by default; emitted (with override respected) when Work IQ is enabled.
  - `workIQ` emitted only when enabled and named; skipped when disabled, name missing, or OBO missing.
  - `workIQ` never carries `filterAddOn` even when Pattern B filter add-on inputs are provided.
  - MI fallback still forwards the service token for `azureBlob` and `searchIndex` (regression guard).
  - `_normalize_references` maps the Work IQ `sourceData` shape correctly, including URL-tail title fallback and dropping empty extracts.
- Run: `python -m pytest -q tests/test_foundry_iq.py tests/test_foundry_iq_work_iq.py` — **32 passed** (21 pre-existing + 11 new).

## Docs

- README: new "Retrieval backends" subsection describing Work IQ opt-in, settings, and prereqs pointer.
- CHANGELOG: `[Unreleased]` entry for Phase 0 plumbing and the Work IQ kind.
- Full enablement guide (gated preview, admin consent, service principal, Work IQ knowledge source provisioning) intentionally lives in `Azure/GPT-RAG` — this PR keeps in-repo docs short.

## Prereqs to enable

Follow the Proposal draft in [Azure/GPT-RAG#543](https://github.com/Azure/GPT-RAG/issues/543). At a high level: gated preview access, admin consent for the required Graph permissions, and a Work IQ knowledge source provisioned on the same Azure AI Search service.

## Follow-ups (not in this PR)

- `GPT-RAG/manifest.json` bump for the new settings (tracked separately).
- Fabric IQ kinds (`fabricDataAgent` / `fabricOntology`) — Phase 0 seam already accommodates them.
- Target release: v3.2.0 (minor bump). No `VERSION` change on `develop`.