### PR TITLE
feat: add Fabric IQ (Microsoft Fabric ontology) knowledge source support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Added
 
+- **Fabric IQ (Microsoft Fabric ontology) knowledge source support (opt-in, default off).**
+  The Foundry IQ retrieve client can now include a `fabricOntology` knowledge
+  source alongside existing `azureBlob` / `searchIndex` / `workIQ` sources,
+  giving grounded answers over a Microsoft Fabric ontology (semantic model,
+  lakehouse, warehouse, or KQL database exposed through the ontology).
+  Behavior is gated by `FABRIC_IQ_ENABLED` and
+  `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME`; when both are set and an on-behalf-of
+  user token is available, a `kind="fabricOntology"` entry is appended to
+  `knowledgeSourceParams`. ACL is enforced natively by Fabric via the
+  forwarded per-user token (same `x-ms-query-source-authorization` header
+  used by Work IQ), so no `filterAddOn` is emitted. Managed-identity
+  fallback is never used for remote knowledge source kinds: when the OBO
+  token is missing the Fabric IQ source is skipped (with a warning) and
+  local sources still serve the request. See
+  [Azure/GPT-RAG#543](https://github.com/Azure/GPT-RAG/issues/543).
+
 ### Fixed
 
 ### Changed

--- a/src/api/config_settings.py
+++ b/src/api/config_settings.py
@@ -167,6 +167,13 @@ _FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND_OPTIONS: List[SettingOption] = [
         "gated Work IQ preview and OBO (x-ms-query-source-authorization). ACL is "
         "enforced natively by M365 — no filterAddOn is applied.",
     ),
+    SettingOption(
+        "fabricOntology",
+        "Fabric IQ (Microsoft Fabric ontology)",
+        "Remote Microsoft Fabric knowledge source backed by a Fabric ontology. "
+        "Requires OBO (x-ms-query-source-authorization); ACL is enforced "
+        "natively by Fabric so no filterAddOn is applied.",
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -412,7 +419,7 @@ SECTIONS: List[SettingSection] = [
                     "as maxRuntimeInSeconds on the request body. Remote knowledge "
                     "sources such as Work IQ can take 40–60 seconds; the default "
                     "leaves headroom. Only emitted when a remote knowledge source "
-                    "kind (workIQ, fabric*) is enabled, so default Pattern A / "
+                    "kind (workIQ, fabricOntology) is enabled, so default Pattern A / "
                     "Pattern B request bodies remain unchanged."
                 ),
                 min=30,
@@ -443,6 +450,34 @@ SECTIONS: List[SettingSection] = [
                     "Name of the Work IQ knowledge source registered on the "
                     "knowledge base. Required when WORK_IQ_ENABLED is true. "
                     "No effect when Work IQ is disabled."
+                ),
+            ),
+            SettingSpec(
+                key="FABRIC_IQ_ENABLED",
+                type="bool",
+                default=False,
+                label="Enable Fabric IQ knowledge source",
+                description=(
+                    "When enabled and FABRIC_IQ_KNOWLEDGE_SOURCE_NAME is set, "
+                    "the Foundry IQ retrieve request appends a fabricOntology "
+                    "knowledge source for grounding over a Microsoft Fabric "
+                    "ontology (semantic model, lakehouse, warehouse, or KQL "
+                    "database exposed through the ontology). ACL is enforced "
+                    "natively by Fabric via the forwarded per-user OBO token; "
+                    "managed-identity fallback is never used for Fabric IQ."
+                ),
+            ),
+            SettingSpec(
+                key="FABRIC_IQ_KNOWLEDGE_SOURCE_NAME",
+                type="string",
+                default="",
+                label="Fabric IQ knowledge source name",
+                description=(
+                    "Name of the fabricOntology knowledge source registered "
+                    "on the knowledge base. Required when FABRIC_IQ_ENABLED "
+                    "is true. The knowledge source itself binds a Fabric "
+                    "workspace and ontology at registration time; no effect "
+                    "when Fabric IQ is disabled."
                 ),
             ),
             SettingSpec(

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -68,15 +68,24 @@ DEFAULT_FOUNDRY_IQ_MAX_RUNTIME_SECONDS = 120
 # Work IQ (Microsoft 365 remote knowledge source). Opt-in; default off. When
 # enabled, the retrieve request appends a workIQ knowledge source in
 # knowledgeSourceParams. ACL is enforced natively by M365, so no filterAddOn
-# is applied. OBO is required — MI fallback is never used for remote kinds.
+# is applied. OBO is required; MI fallback is never used for remote kinds.
 WORK_IQ_ENABLED_KEY = "WORK_IQ_ENABLED"
 WORK_IQ_KNOWLEDGE_SOURCE_NAME_KEY = "WORK_IQ_KNOWLEDGE_SOURCE_NAME"
+
+# Fabric IQ (Microsoft Fabric ontology remote knowledge source). Opt-in;
+# default off. When enabled, the retrieve request appends a fabricOntology
+# knowledge source in knowledgeSourceParams. ACL is enforced natively by
+# Fabric via the forwarded per-user OBO token (same
+# x-ms-query-source-authorization header used by Work IQ), so no filterAddOn
+# is applied. OBO is required; MI fallback is never used for remote kinds.
+FABRIC_IQ_ENABLED_KEY = "FABRIC_IQ_ENABLED"
+FABRIC_IQ_KNOWLEDGE_SOURCE_NAME_KEY = "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME"
 
 # Knowledge source kinds that must never fall back to the service managed
 # identity for x-ms-query-source-authorization. These sources run against
 # external systems (M365, Fabric) where impersonation, not app identity, is
 # the security boundary.
-_REMOTE_KNOWLEDGE_SOURCE_KINDS = frozenset({"workIQ"})
+_REMOTE_KNOWLEDGE_SOURCE_KINDS = frozenset({"workIQ", "fabricOntology"})
 
 # Search-audience scope used for the service token.
 _SEARCH_SCOPE = "https://search.azure.com/.default"
@@ -255,6 +264,16 @@ class FoundryIQClient:
         self.work_iq_knowledge_source_name = (
             self.cfg.get(WORK_IQ_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
         ).strip()
+        # Fabric IQ (Microsoft Fabric ontology) remote knowledge source.
+        # Opt-in; requires a per-user OBO token (same
+        # x-ms-query-source-authorization header used by Work IQ), so
+        # anonymous / MI fallback is never used.
+        self.fabric_iq_enabled = _as_bool(
+            self.cfg.get(FABRIC_IQ_ENABLED_KEY, False, type=bool)
+        )
+        self.fabric_iq_knowledge_source_name = (
+            self.cfg.get(FABRIC_IQ_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
+        ).strip()
         self.credential = self.cfg.aiocredential
 
         # Shared aiohttp session — reuses TCP connections across calls.
@@ -349,6 +368,51 @@ class FoundryIQClient:
 
         return {"title": title, "link": link, "content": content}
 
+    @staticmethod
+    def _normalize_fabric_iq_reference(source: Dict[str, Any]) -> Optional[Dict[str, str]]:
+        """Map a Fabric IQ ``sourceData`` payload into ``{title, link, content}``.
+
+        Fabric IQ references carry a different shape from Work IQ:
+
+        - ``fabricAnswer`` (optional) is a natural-language summary produced by
+          the Fabric ontology retriever.
+        - ``fabricRawData`` (optional) is the raw grounding evidence, typically
+          CSV rows the LLM should be able to quote from verbatim.
+        - ``workspaceId`` / ``ontologyId`` identify the Fabric artifact used.
+
+        Both ``fabricAnswer`` and ``fabricRawData`` may be present; when both
+        exist we concatenate them so the LLM sees the summary plus the raw
+        rows. Returns ``None`` when neither field is present so the caller can
+        skip empty hits rather than emit a bare ``reference`` title.
+
+        Fabric IQ does not currently return a per-reference deep link, so
+        ``link`` is left empty and the citation title falls back to the
+        workspace / ontology identifiers.
+        """
+        answer = source.get("fabricAnswer")
+        raw = source.get("fabricRawData")
+        parts: List[str] = []
+        if isinstance(answer, str) and answer.strip():
+            parts.append(answer.strip())
+        if isinstance(raw, str) and raw.strip():
+            parts.append(raw.strip())
+        if not parts:
+            return None
+        content = "\n\n".join(parts)
+
+        workspace_id = str(source.get("workspaceId") or "").strip()
+        ontology_id = str(source.get("ontologyId") or "").strip()
+        if workspace_id and ontology_id:
+            title = f"Fabric ontology {ontology_id} (workspace {workspace_id})"
+        elif ontology_id:
+            title = f"Fabric ontology {ontology_id}"
+        elif workspace_id:
+            title = f"Fabric workspace {workspace_id}"
+        else:
+            title = "Fabric ontology"
+
+        return {"title": title, "link": "", "content": content}
+
     @classmethod
     def _normalize_references(cls, payload: Dict[str, Any]) -> List[Dict[str, str]]:
         """Map a retrieve response into ``[{title, link, content}]`` records.
@@ -366,6 +430,10 @@ class FoundryIQClient:
         - ``workIQ`` (Microsoft 365) sources return ``sourceData.attributions``
           and ``sourceData.extracts`` instead of a flat snippet field. See
           :meth:`_normalize_work_iq_reference`.
+        - ``fabricOntology`` (Microsoft Fabric) sources return
+          ``sourceData.fabricAnswer`` and/or ``sourceData.fabricRawData``
+          alongside ``workspaceId`` / ``ontologyId``. See
+          :meth:`_normalize_fabric_iq_reference`.
 
         We accept the union with explicit priority so the downstream
         ``{title, link, content}`` contract is identical across backends,
@@ -377,8 +445,15 @@ class FoundryIQClient:
         for ref in payload.get("references", []) or []:
             source = ref.get("sourceData") or {}
 
-            # Work IQ / future Fabric shapes: prefer the specialised mapper
-            # when the payload carries the remote-kind fields.
+            # Fabric IQ shape (fabricOntology): distinct fields, no
+            # attributions/extracts overlap with Work IQ.
+            if source.get("fabricAnswer") or source.get("fabricRawData"):
+                fabric_record = cls._normalize_fabric_iq_reference(source)
+                if fabric_record is not None:
+                    records.append(fabric_record)
+                continue
+
+            # Work IQ shape (workIQ): attributions + extracts.
             if source.get("attributions") or source.get("extracts"):
                 record = cls._normalize_work_iq_reference(source)
                 if record is not None:
@@ -520,9 +595,55 @@ class FoundryIQClient:
             "includeReferenceSourceData": True,
         }
 
+    def _build_fabric_iq_source_params(
+        self, *, obo_token: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Build the Fabric IQ (Microsoft Fabric ontology) knowledge source entry.
+
+        Returns ``None`` when Fabric IQ does not apply:
+
+        - the feature is disabled, or
+        - no knowledge source name was provisioned, or
+        - no per-user OBO token is available (remote kinds strictly require
+          impersonation; MI fallback is never used).
+
+        Fabric IQ enforces ACL natively via the forwarded per-user token
+        (workspace / ontology / underlying-item permissions), so no
+        ``filterAddOn`` is emitted. The fabricOntology KS itself carries the
+        workspaceId and ontologyId at registration time; the retrieve-time
+        entry only needs the knowledge source name and reference flags.
+        """
+        if not self.fabric_iq_enabled:
+            return None
+        if not self.fabric_iq_knowledge_source_name:
+            logging.warning(
+                "[FoundryIQClient] FABRIC_IQ_ENABLED=true but "
+                "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME is empty; skipping Fabric IQ source."
+            )
+            return None
+        if not obo_token:
+            logging.warning(
+                "[FoundryIQClient] FABRIC_IQ_ENABLED=true but no OBO token "
+                "(x-ms-query-source-authorization) available; skipping Fabric IQ "
+                "source. Managed-identity fallback is never used for remote "
+                "knowledge source kinds."
+            )
+            return None
+
+        logging.info(
+            "[FoundryIQClient][FabricIQ] Adding fabricOntology source %s (ACL native, no filterAddOn)",
+            self.fabric_iq_knowledge_source_name,
+        )
+        return {
+            "knowledgeSourceName": self.fabric_iq_knowledge_source_name,
+            "kind": "fabricOntology",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+
     def _remote_kinds_enabled(self) -> bool:
         """Return True when any remote (M365 / Fabric) knowledge source is on."""
-        return self.work_iq_enabled
+        return self.work_iq_enabled or self.fabric_iq_enabled
 
     async def retrieve(
         self,
@@ -644,6 +765,10 @@ class FoundryIQClient:
         work_iq_source_params = self._build_work_iq_source_params(obo_token=obo_token)
         if work_iq_source_params:
             knowledge_source_params.append(work_iq_source_params)
+
+        fabric_iq_source_params = self._build_fabric_iq_source_params(obo_token=obo_token)
+        if fabric_iq_source_params:
+            knowledge_source_params.append(fabric_iq_source_params)
 
         if knowledge_source_params:
             body["knowledgeSourceParams"] = knowledge_source_params

--- a/tests/test_foundry_iq_fabric_iq.py
+++ b/tests/test_foundry_iq_fabric_iq.py
@@ -1,0 +1,280 @@
+"""Tests for the Fabric IQ (Microsoft Fabric ontology) knowledge source path.
+
+Covers Azure/GPT-RAG#543 Fabric IQ enablement:
+
+- ``maxRuntimeInSeconds`` is emitted when a remote knowledge source kind is
+  enabled (fabricOntology counts).
+- ``fabricOntology`` knowledge source params are appended only when
+  ``FABRIC_IQ_ENABLED`` is true and ``FABRIC_IQ_KNOWLEDGE_SOURCE_NAME`` is set.
+- ``fabricOntology`` params never carry a ``filterAddOn``; ACL is enforced
+  natively by Fabric via the forwarded per-user OBO token.
+- The MI fallback controlled by ``FOUNDRY_IQ_FORWARD_SOURCE_AUTH`` never
+  substitutes for OBO on Fabric IQ.
+- ``_normalize_references`` maps the Fabric IQ ``fabricAnswer`` /
+  ``fabricRawData`` shape to the shared ``{title, link, content}`` contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def text(self):
+        import json
+        return json.dumps(self._payload)
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self._status = status
+        self.captured = {}
+
+    def post(self, url, headers=None, json=None):  # noqa: A002
+        self.captured = {"url": url, "headers": headers, "json": json}
+        return _FakeResponse(self._payload, self._status)
+
+
+def _build_client(payload, status=200, config_overrides=None):
+    from connectors import foundry_iq
+
+    values = {
+        "KNOWLEDGE_BASE_ENDPOINT": "https://fake-search.search.windows.net",
+        "SEARCH_SERVICE_QUERY_ENDPOINT": "https://fake-search.search.windows.net",
+        "KNOWLEDGE_BASE_NAME": "kb-test",
+        "FOUNDRY_IQ_API_VERSION": "2026-05-01-preview",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND": "",
+        "FOUNDRY_IQ_PATTERN": "",
+        "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED": False,
+        "FOUNDRY_IQ_SECURITY_FIELD_NAME": "metadata_security_id",
+        "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": None,
+        "FOUNDRY_IQ_FORWARD_SOURCE_AUTH": True,
+        "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": False,
+        "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_MAX_RUNTIME_SECONDS": 120,
+        "WORK_IQ_ENABLED": False,
+        "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FABRIC_IQ_ENABLED": False,
+        "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "",
+    }
+    values.update(config_overrides or {})
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda key, default=None, type=str: values.get(key, default)  # noqa: A002
+    cfg.aiocredential = MagicMock()
+    cfg.aiocredential.get_token = AsyncMock(return_value=SimpleNamespace(token="svc-token"))
+
+    with patch("connectors.foundry_iq.get_config", return_value=cfg):
+        client = foundry_iq.FoundryIQClient()
+    session = _FakeSession(payload, status)
+    client._get_session = AsyncMock(return_value=session)
+    return client, session
+
+
+_SAMPLE_PAYLOAD = {"references": []}
+
+
+# ---------------------------------------------------------------------------
+# maxRuntimeInSeconds: fabricOntology counts as a remote kind.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_max_runtime_emitted_when_fabric_iq_enabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FABRIC_IQ_ENABLED": True,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "fabric-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    assert session.captured["json"]["maxRuntimeInSeconds"] == 120
+
+
+# ---------------------------------------------------------------------------
+# Fabric IQ knowledge source emission
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fabric_iq_not_emitted_when_disabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "FABRIC_IQ_ENABLED": False,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "fabric-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "fabricOntology" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_fabric_iq_not_emitted_when_name_missing():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FABRIC_IQ_ENABLED": True,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "fabricOntology" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_fabric_iq_emitted_when_enabled_with_obo():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FABRIC_IQ_ENABLED": True,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "fabric-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    fabric = [s for s in sources if s.get("kind") == "fabricOntology"]
+    assert fabric == [
+        {
+            "knowledgeSourceName": "fabric-ks",
+            "kind": "fabricOntology",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fabric_iq_never_carries_filter_add_on():
+    """Fabric enforces ACL natively via OBO; a filterAddOn would be wrong."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FABRIC_IQ_ENABLED": True,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "fabric-ks",
+        },
+    )
+    await client.retrieve(
+        "hello",
+        obo_token="user-obo",
+        conversation_id="conv-1",
+        user_context={"principal_id": "user-1", "groups": ["g-a"]},
+    )
+    fabric = [
+        s for s in session.captured["json"]["knowledgeSourceParams"]
+        if s.get("kind") == "fabricOntology"
+    ]
+    assert len(fabric) == 1
+    assert "filterAddOn" not in fabric[0]
+
+
+@pytest.mark.asyncio
+async def test_fabric_iq_skipped_when_obo_missing():
+    """CONTRACT: remote kinds require OBO. MI fallback must not be used for
+    Fabric IQ. When no OBO token is available the Fabric IQ source is dropped
+    (with a warning) so local sources still serve the request."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "FABRIC_IQ_ENABLED": True,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "fabric-ks",
+        },
+    )
+    await client.retrieve("hello")
+
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "fabricOntology" for s in sources)
+    # Local source still present.
+    assert any(s.get("kind") == "azureBlob" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_work_iq_and_fabric_iq_coexist():
+    """Both remote kinds can be enabled together; both must be emitted."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+            "FABRIC_IQ_ENABLED": True,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "fabric-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    kinds = [s.get("kind") for s in session.captured["json"]["knowledgeSourceParams"]]
+    assert "workIQ" in kinds
+    assert "fabricOntology" in kinds
+
+
+# ---------------------------------------------------------------------------
+# _normalize_references for Fabric IQ shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_normalize_fabric_iq_reference_shape():
+    """Fabric IQ sourceData carries fabricAnswer and/or fabricRawData plus
+    workspaceId / ontologyId. Both fields are concatenated when present, and
+    the title falls back to workspace / ontology ids when no deep link is
+    available."""
+    payload = {
+        "references": [
+            {
+                "type": "fabricOntology",
+                "sourceData": {
+                    "fabricAnswer": "Sales grew 12% quarter over quarter.",
+                    "fabricRawData": "Region,QoQ\nEMEA,0.14\nAMER,0.11",
+                    "workspaceId": "ws-abc",
+                    "ontologyId": "ont-123",
+                },
+            },
+            {
+                # Only fabricAnswer.
+                "type": "fabricOntology",
+                "sourceData": {
+                    "fabricAnswer": "Top product: SKU-42.",
+                    "ontologyId": "ont-123",
+                },
+            },
+            {
+                # Empty payload must be dropped.
+                "type": "fabricOntology",
+                "sourceData": {
+                    "fabricAnswer": "",
+                    "fabricRawData": "",
+                    "workspaceId": "ws-abc",
+                },
+            },
+        ]
+    }
+    client, _ = _build_client(payload)
+    records = await client.retrieve("hello", obo_token="user-obo")
+    assert records == [
+        {
+            "title": "Fabric ontology ont-123 (workspace ws-abc)",
+            "link": "",
+            "content": "Sales grew 12% quarter over quarter.\n\nRegion,QoQ\nEMEA,0.14\nAMER,0.11",
+        },
+        {
+            "title": "Fabric ontology ont-123",
+            "link": "",
+            "content": "Top product: SKU-42.",
+        },
+    ]


### PR DESCRIPTION
Adds Fabric IQ (Microsoft Fabric ontology) as a Foundry IQ knowledge source, mirroring the Work IQ shape shipped in v3.2.0. See Azure/GPT-RAG#543.

## What

- New `fabricOntology` knowledge source kind, gated by `FABRIC_IQ_ENABLED` and `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME`.
- When both are set and an OBO token is available, the retrieve request appends a `kind="fabricOntology"` entry to `knowledgeSourceParams`.
- Reuses the existing `x-ms-query-source-authorization` OBO header. ACL is enforced natively by Fabric so no `filterAddOn` is emitted.
- Managed-identity fallback is never used for Fabric IQ (same rule as Work IQ). When the OBO token is missing the Fabric IQ source is skipped with a warning and local sources still serve the request.
- `_REMOTE_KNOWLEDGE_SOURCE_KINDS` now includes `fabricOntology`, so `maxRuntimeInSeconds` emission and the MI-fallback exclusion apply automatically.
- `_normalize_fabric_iq_reference` maps `fabricAnswer` / `fabricRawData` / `workspaceId` / `ontologyId` into the shared `{title, link, content}` contract.
- Registers `FABRIC_IQ_ENABLED` and `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME` settings and adds a `fabricOntology` option to the KS-kind enum in `config_settings.py`.

## Tests

New `tests/test_foundry_iq_fabric_iq.py` mirrors the Work IQ suite (8 tests):

- `maxRuntimeInSeconds` emitted when Fabric IQ is enabled.
- Fabric IQ source not emitted when disabled or when the name is missing.
- Fabric IQ source emitted with correct shape when enabled + OBO present.
- Fabric IQ never carries a `filterAddOn`.
- Fabric IQ skipped when OBO is absent (local source still present).
- Work IQ + Fabric IQ coexist correctly.
- Reference normalization for `fabricAnswer` / `fabricRawData` shape.

Ran `pytest tests/ -k "foundry_iq or config_settings"`: 44 passed, no regressions.

## Config

Operator sets in App Configuration (label `gpt-rag`):

- `FABRIC_IQ_ENABLED=true`
- `FABRIC_IQ_KNOWLEDGE_SOURCE_NAME=<name of fabricOntology KS registered on the KB>`

The knowledge source itself is registered by the GPT-RAG main repo `config/search` step (separate PR against `Azure/gpt-rag`) and binds a Fabric workspace + ontology at registration time.

## Prerequisites (surface in release notes and docs)

- Microsoft Fabric workspace with an ontology item the caller has access to.
- Tenant-level Fabric ontology enablement.
- End users with Fabric licenses and ontology access.
- Same Entra tenant as the Foundry / Search resource.
- **Data-egress caveat:** Fabric IQ may route data outside the Azure compliance boundary. Operators must review.

## Refs

Azure/GPT-RAG#543
