### PR TITLE
feat: add SharePoint remote (Copilot Retrieval API) knowledge source

### DIFF
--- a/src/api/config_settings.py
+++ b/src/api/config_settings.py
@@ -519,6 +519,46 @@ SECTIONS: List[SettingSection] = [
                 ),
             ),
             SettingSpec(
+                key="SHAREPOINT_REMOTE_ENABLED",
+                type="bool",
+                default=False,
+                label="Enable SharePoint remote (Copilot Retrieval API)",
+                description=(
+                    "Opt-in. When enabled, the Foundry IQ retrieve call adds "
+                    "a remoteSharePoint knowledge source that queries "
+                    "SharePoint at retrieval time via the Microsoft 365 "
+                    "Copilot Retrieval API. Item-level SharePoint "
+                    "permissions are enforced natively by M365 via the "
+                    "forwarded per-user OBO token; managed-identity "
+                    "fallback is never used for SharePoint remote."
+                ),
+            ),
+            SettingSpec(
+                key="SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME",
+                type="string",
+                default="",
+                label="SharePoint remote knowledge source name",
+                description=(
+                    "Name of the remoteSharePoint knowledge source "
+                    "registered on the knowledge base. Required when "
+                    "SHAREPOINT_REMOTE_ENABLED is true. No effect when "
+                    "SharePoint remote is disabled."
+                ),
+            ),
+            SettingSpec(
+                key="SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON",
+                type="string",
+                default="",
+                label="SharePoint remote filter expression add-on",
+                description=(
+                    "Optional KQL filter appended at retrieval time to the "
+                    "remoteSharePoint knowledge source "
+                    "(filterExpressionAddOn). Use it to scope results to a "
+                    "specific site, path, or content type. Leave empty for "
+                    "no additional filter."
+                ),
+            ),
+            SettingSpec(
                 key="SEARCH_RETRIEVAL_ENABLED",
                 type="bool",
                 default=True,

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -92,12 +92,26 @@ FABRIC_IQ_KNOWLEDGE_SOURCE_NAME_KEY = "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME"
 FABRIC_DATA_AGENT_ENABLED_KEY = "FABRIC_DATA_AGENT_ENABLED"
 FABRIC_DATA_AGENT_KNOWLEDGE_SOURCE_NAME_KEY = "FABRIC_DATA_AGENT_KNOWLEDGE_SOURCE_NAME"
 
+# SharePoint remote (Microsoft 365 Copilot Retrieval API remote knowledge
+# source). Opt-in; default off. When enabled, the retrieve request appends a
+# remoteSharePoint knowledge source in knowledgeSourceParams. SharePoint
+# item-level permissions are enforced natively by M365 via the forwarded
+# per-user OBO token (same x-ms-query-source-authorization header used by
+# Work IQ / Fabric ontology), so no filterAddOn is applied. OBO is required;
+# MI fallback is never used for remote kinds. An optional retrieval-time KQL
+# scope can be forwarded via filterExpressionAddOn.
+SHAREPOINT_REMOTE_ENABLED_KEY = "SHAREPOINT_REMOTE_ENABLED"
+SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME_KEY = "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME"
+SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON_KEY = (
+    "SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON"
+)
+
 # Knowledge source kinds that must never fall back to the service managed
 # identity for x-ms-query-source-authorization. These sources run against
 # external systems (M365, Fabric) where impersonation, not app identity, is
 # the security boundary.
 _REMOTE_KNOWLEDGE_SOURCE_KINDS = frozenset(
-    {"workIQ", "fabricOntology", "fabricDataAgent"}
+    {"workIQ", "fabricOntology", "fabricDataAgent", "remoteSharePoint"}
 )
 
 # Search-audience scope used for the service token.
@@ -297,6 +311,19 @@ class FoundryIQClient:
         self.fabric_data_agent_knowledge_source_name = (
             self.cfg.get(FABRIC_DATA_AGENT_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
         ).strip()
+        # SharePoint remote knowledge source (Copilot Retrieval API). Opt-in;
+        # requires a per-user OBO token (same x-ms-query-source-authorization
+        # header used by Work IQ / Fabric ontology), so anonymous / MI
+        # fallback is never used.
+        self.sharepoint_remote_enabled = _as_bool(
+            self.cfg.get(SHAREPOINT_REMOTE_ENABLED_KEY, False, type=bool)
+        )
+        self.sharepoint_remote_knowledge_source_name = (
+            self.cfg.get(SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
+        ).strip()
+        self.sharepoint_remote_filter_expression_add_on = (
+            self.cfg.get(SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON_KEY, "") or ""
+        ).strip()
         self.credential = self.cfg.aiocredential
 
         # Shared aiohttp session - reuses TCP connections across calls.
@@ -484,6 +511,65 @@ class FoundryIQClient:
 
         return {"title": title, "link": "", "content": content}
 
+    @staticmethod
+    def _normalize_sharepoint_remote_reference(
+        source: Dict[str, Any],
+    ) -> Optional[Dict[str, str]]:
+        """Map a remoteSharePoint ``sourceData`` payload into ``{title, link, content}``.
+
+        SharePoint remote references come from the Copilot Retrieval API. A
+        reference typically carries:
+
+        - ``webUrl`` - deep link to the SharePoint item (file, page, list
+          item), the natural value for the citation ``link``.
+        - ``resourceMetadata`` - object with SharePoint properties such as
+          ``Title`` / ``Name`` / ``FileName`` / ``LastModifiedTime``.
+        - ``extracts`` - list of ``{text}`` snippets (same shape used by
+          Work IQ) and/or a flat ``text`` / ``content`` / ``snippet`` field
+          when the API returns pre-joined text.
+
+        Returns ``None`` when neither snippet content nor extracts can be
+        recovered so the caller can skip empty hits rather than emit a bare
+        ``reference`` title.
+        """
+        parts: List[str] = []
+        for extract in source.get("extracts") or []:
+            if not isinstance(extract, Mapping):
+                continue
+            text = extract.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        if not parts:
+            for key in ("text", "content", "snippet"):
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    parts.append(value.strip())
+                    break
+        if not parts:
+            return None
+        content = "\n\n".join(parts)
+
+        link = ""
+        web_url = source.get("webUrl")
+        if isinstance(web_url, str):
+            link = web_url.strip()
+
+        title = ""
+        metadata = source.get("resourceMetadata")
+        if isinstance(metadata, Mapping):
+            for key in ("Title", "title", "Name", "name", "FileName", "fileName"):
+                value = metadata.get(key)
+                if isinstance(value, str) and value.strip():
+                    title = value.strip()
+                    break
+        if not title and link:
+            tail = link.rsplit("/", 1)[-1]
+            title = tail.split("?", 1)[0]
+        if not title:
+            title = "SharePoint item"
+
+        return {"title": title, "link": link, "content": content}
+
     @classmethod
     def _normalize_references(cls, payload: Dict[str, Any]) -> List[Dict[str, str]]:
         """Map a retrieve response into ``[{title, link, content}]`` records.
@@ -509,6 +595,10 @@ class FoundryIQClient:
           ``sourceData.dataAgentAnswer`` and/or ``sourceData.dataAgentRawData``
           alongside ``workspaceId`` / ``dataAgentId``. See
           :meth:`_normalize_fabric_data_agent_reference`.
+        - ``remoteSharePoint`` (Microsoft 365 Copilot Retrieval API) sources
+          return ``sourceData.webUrl`` and ``sourceData.resourceMetadata``
+          with SharePoint properties (Title, LastModifiedTime, ...) plus
+          ``extracts`` snippets. See :meth:`_normalize_sharepoint_remote_reference`.
 
         We accept the union with explicit priority so the downstream
         ``{title, link, content}`` contract is identical across backends,
@@ -526,6 +616,16 @@ class FoundryIQClient:
                 data_agent_record = cls._normalize_fabric_data_agent_reference(source)
                 if data_agent_record is not None:
                     records.append(data_agent_record)
+                continue
+
+            # SharePoint remote shape (remoteSharePoint / Copilot Retrieval
+            # API): keyed on webUrl + resourceMetadata. Check before Work IQ
+            # because both may carry extracts, but only SharePoint remote
+            # carries a webUrl deep link.
+            if source.get("webUrl") or source.get("resourceMetadata"):
+                sp_record = cls._normalize_sharepoint_remote_reference(source)
+                if sp_record is not None:
+                    records.append(sp_record)
                 continue
 
             # Fabric IQ shape (fabricOntology): distinct fields, no
@@ -773,12 +873,65 @@ class FoundryIQClient:
             "includeReferenceSourceData": True,
         }
 
+    def _build_sharepoint_remote_source_params(
+        self, *, obo_token: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Build the SharePoint remote (Copilot Retrieval API) KS entry.
+
+        Returns ``None`` when SharePoint remote does not apply:
+
+        - the feature is disabled, or
+        - no knowledge source name was provisioned, or
+        - no per-user OBO token is available (remote kinds strictly require
+          impersonation; MI fallback is never used).
+
+        SharePoint remote enforces ACL natively via the forwarded per-user
+        token (item-level M365 permissions), so no ``filterAddOn`` is
+        emitted. An optional retrieval-time KQL scope can be forwarded via
+        ``filterExpressionAddOn`` when configured.
+        """
+        if not self.sharepoint_remote_enabled:
+            return None
+        if not self.sharepoint_remote_knowledge_source_name:
+            logging.warning(
+                "[FoundryIQClient] SHAREPOINT_REMOTE_ENABLED=true but "
+                "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME is empty; skipping "
+                "SharePoint remote source."
+            )
+            return None
+        if not obo_token:
+            logging.warning(
+                "[FoundryIQClient] SHAREPOINT_REMOTE_ENABLED=true but no OBO "
+                "token (x-ms-query-source-authorization) available; skipping "
+                "SharePoint remote source. Managed-identity fallback is "
+                "never used for remote knowledge source kinds."
+            )
+            return None
+
+        logging.info(
+            "[FoundryIQClient][SharePointRemote] Adding remoteSharePoint "
+            "source %s (ACL native, no filterAddOn)",
+            self.sharepoint_remote_knowledge_source_name,
+        )
+        params: Dict[str, Any] = {
+            "knowledgeSourceName": self.sharepoint_remote_knowledge_source_name,
+            "kind": "remoteSharePoint",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+        if self.sharepoint_remote_filter_expression_add_on:
+            params["filterExpressionAddOn"] = (
+                self.sharepoint_remote_filter_expression_add_on
+            )
+        return params
+
     def _remote_kinds_enabled(self) -> bool:
         """Return True when any remote (M365 / Fabric) knowledge source is on."""
         return (
             self.work_iq_enabled
             or self.fabric_iq_enabled
             or self.fabric_data_agent_enabled
+            or self.sharepoint_remote_enabled
         )
 
     async def retrieve(
@@ -911,6 +1064,12 @@ class FoundryIQClient:
         )
         if fabric_data_agent_source_params:
             knowledge_source_params.append(fabric_data_agent_source_params)
+
+        sharepoint_remote_source_params = self._build_sharepoint_remote_source_params(
+            obo_token=obo_token
+        )
+        if sharepoint_remote_source_params:
+            knowledge_source_params.append(sharepoint_remote_source_params)
 
         if knowledge_source_params:
             body["knowledgeSourceParams"] = knowledge_source_params

--- a/tests/test_foundry_iq_sharepoint_remote.py
+++ b/tests/test_foundry_iq_sharepoint_remote.py
@@ -1,0 +1,302 @@
+"""Tests for the SharePoint remote (Copilot Retrieval API) knowledge source.
+
+Covers the 5th Foundry IQ knowledge source kind, ``remoteSharePoint``:
+
+- ``maxRuntimeInSeconds`` is emitted when the SharePoint remote source is
+  enabled (same contract as the other remote kinds).
+- ``remoteSharePoint`` knowledge source params are appended only when
+  ``SHAREPOINT_REMOTE_ENABLED`` is true and
+  ``SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME`` is set.
+- Optional ``filterExpressionAddOn`` (KQL) is forwarded verbatim when set,
+  and omitted when empty.
+- ``remoteSharePoint`` params never carry a ``filterAddOn``. ACL is
+  enforced natively by SharePoint via the forwarded per-user token.
+- The MI fallback controlled by ``FOUNDRY_IQ_FORWARD_SOURCE_AUTH`` still
+  applies to local ``azureBlob`` / ``searchIndex`` sources and never
+  substitutes for OBO on SharePoint remote.
+- ``_normalize_references`` maps the ``webUrl`` + ``resourceMetadata``
+  shape (and tolerant content fallbacks) into the shared
+  ``{title, link, content}`` contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def text(self):
+        import json
+        return json.dumps(self._payload)
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self._status = status
+        self.captured = {}
+
+    def post(self, url, headers=None, json=None):  # noqa: A002
+        self.captured = {"url": url, "headers": headers, "json": json}
+        return _FakeResponse(self._payload, self._status)
+
+
+def _build_client(payload, status=200, config_overrides=None):
+    from connectors import foundry_iq
+
+    values = {
+        "KNOWLEDGE_BASE_ENDPOINT": "https://fake-search.search.windows.net",
+        "SEARCH_SERVICE_QUERY_ENDPOINT": "https://fake-search.search.windows.net",
+        "KNOWLEDGE_BASE_NAME": "kb-test",
+        "FOUNDRY_IQ_API_VERSION": "2026-05-01-preview",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND": "",
+        "FOUNDRY_IQ_PATTERN": "",
+        "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED": False,
+        "FOUNDRY_IQ_SECURITY_FIELD_NAME": "metadata_security_id",
+        "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": None,
+        "FOUNDRY_IQ_FORWARD_SOURCE_AUTH": True,
+        "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": False,
+        "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_MAX_RUNTIME_SECONDS": 120,
+        "WORK_IQ_ENABLED": False,
+        "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FABRIC_IQ_ENABLED": False,
+        "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FABRIC_DATA_AGENT_ENABLED": False,
+        "FABRIC_DATA_AGENT_KNOWLEDGE_SOURCE_NAME": "",
+        "SHAREPOINT_REMOTE_ENABLED": False,
+        "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "",
+        "SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON": "",
+    }
+    values.update(config_overrides or {})
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda key, default=None, type=str: values.get(key, default)  # noqa: A002
+    cfg.aiocredential = MagicMock()
+    cfg.aiocredential.get_token = AsyncMock(return_value=SimpleNamespace(token="svc-token"))
+
+    with patch("connectors.foundry_iq.get_config", return_value=cfg):
+        client = foundry_iq.FoundryIQClient()
+    session = _FakeSession(payload, status)
+    client._get_session = AsyncMock(return_value=session)
+    return client, session
+
+
+_SAMPLE_PAYLOAD = {"references": []}
+
+
+@pytest.mark.asyncio
+async def test_max_runtime_emitted_when_sharepoint_remote_enabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "SHAREPOINT_REMOTE_ENABLED": True,
+            "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "sharepoint-remote-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    assert session.captured["json"]["maxRuntimeInSeconds"] == 120
+
+
+@pytest.mark.asyncio
+async def test_sharepoint_remote_not_emitted_when_disabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "SHAREPOINT_REMOTE_ENABLED": False,
+            "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "sharepoint-remote-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "remoteSharePoint" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_sharepoint_remote_not_emitted_when_name_missing():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "SHAREPOINT_REMOTE_ENABLED": True,
+            "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "remoteSharePoint" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_sharepoint_remote_emitted_when_enabled_with_obo():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "SHAREPOINT_REMOTE_ENABLED": True,
+            "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "sharepoint-remote-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    sp_sources = [s for s in sources if s.get("kind") == "remoteSharePoint"]
+    assert sp_sources == [
+        {
+            "knowledgeSourceName": "sharepoint-remote-ks",
+            "kind": "remoteSharePoint",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sharepoint_remote_forwards_filter_expression_add_on():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "SHAREPOINT_REMOTE_ENABLED": True,
+            "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "sharepoint-remote-ks",
+            "SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON": "filetype:docx",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    sp_sources = [s for s in sources if s.get("kind") == "remoteSharePoint"]
+    assert sp_sources == [
+        {
+            "knowledgeSourceName": "sharepoint-remote-ks",
+            "kind": "remoteSharePoint",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+            "filterExpressionAddOn": "filetype:docx",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sharepoint_remote_never_carries_filter_add_on():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "SHAREPOINT_REMOTE_ENABLED": True,
+            "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "sharepoint-remote-ks",
+        },
+    )
+    await client.retrieve(
+        "hello",
+        obo_token="user-obo",
+        conversation_id="conv-1",
+        user_context={"principal_id": "user-1", "groups": ["g-a"]},
+    )
+    sp_sources = [
+        s for s in session.captured["json"]["knowledgeSourceParams"]
+        if s.get("kind") == "remoteSharePoint"
+    ]
+    assert len(sp_sources) == 1
+    assert "filterAddOn" not in sp_sources[0]
+
+
+@pytest.mark.asyncio
+async def test_sharepoint_remote_skipped_when_obo_missing():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "SHAREPOINT_REMOTE_ENABLED": True,
+            "SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME": "sharepoint-remote-ks",
+        },
+    )
+    await client.retrieve("hello")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "remoteSharePoint" for s in sources)
+    assert any(s.get("kind") == "azureBlob" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_normalize_sharepoint_remote_reference_shape():
+    payload = {
+        "references": [
+            {
+                "type": "remoteSharePoint",
+                "sourceData": {
+                    "webUrl": "https://contoso.sharepoint.com/sites/x/plan.docx",
+                    "resourceMetadata": {
+                        "Title": "Q4 rollout plan",
+                        "Author": "Sarah",
+                    },
+                    "extracts": [
+                        {"text": "Milestone A ships in October."},
+                        {"text": "Milestone B ships in November."},
+                    ],
+                },
+            },
+            {
+                "type": "remoteSharePoint",
+                "sourceData": {
+                    "webUrl": "https://contoso.sharepoint.com/sites/x/notes.docx",
+                    "resourceMetadata": {"Title": "Notes"},
+                    "text": "Weekly notes, no headings.",
+                },
+            },
+            {
+                "type": "remoteSharePoint",
+                "sourceData": {
+                    "webUrl": "https://contoso.sharepoint.com/sites/x/deck.pptx",
+                    "resourceMetadata": {"Author": "Sarah"},
+                    "extracts": [{"text": "Deck section 1."}],
+                },
+            },
+            {
+                "type": "remoteSharePoint",
+                "sourceData": {
+                    "webUrl": "https://contoso.sharepoint.com/sites/x/empty.docx",
+                    "resourceMetadata": {"Title": "Empty"},
+                    "extracts": [],
+                },
+            },
+        ]
+    }
+    client, _ = _build_client(payload)
+    records = await client.retrieve("hello", obo_token="user-obo")
+    assert records == [
+        {
+            "title": "Q4 rollout plan",
+            "link": "https://contoso.sharepoint.com/sites/x/plan.docx",
+            "content": "Milestone A ships in October.\n\nMilestone B ships in November.",
+        },
+        {
+            "title": "Notes",
+            "link": "https://contoso.sharepoint.com/sites/x/notes.docx",
+            "content": "Weekly notes, no headings.",
+        },
+        {
+            "title": "deck.pptx",
+            "link": "https://contoso.sharepoint.com/sites/x/deck.pptx",
+            "content": "Deck section 1.",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mi_fallback_still_works_when_sharepoint_remote_off():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={"FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks"},
+    )
+    await client.retrieve("hello")
+    headers = session.captured["headers"]
+    assert headers["x-ms-query-source-authorization"] == "svc-token"


### PR DESCRIPTION
## User impact

Adds **SharePoint remote** as the 5th Foundry IQ knowledge source kind. When
opted in and configured, the orchestrator will surface citations from
SharePoint items (docs, pages, list items) that the calling user is allowed to
see. Item-level permissions are enforced natively by Microsoft 365 via the
forwarded per-user OBO token; SharePoint results appear inline alongside
existing `azureBlob` / `searchIndex` / `workIQ` / `fabricOntology` /
`fabricDataAgent` citations, using the SharePoint deep link and the item
title.

Default is off. No behavior change unless `SHAREPOINT_REMOTE_ENABLED=true` in
App Configuration and a `remoteSharePoint` KS is registered on the knowledge
base with a matching name.

## Technical details

- Add `kind: "remoteSharePoint"` to the retrieve-time
  `knowledgeSourceParams` list when `SHAREPOINT_REMOTE_ENABLED=true` and
  `SHAREPOINT_REMOTE_KNOWLEDGE_SOURCE_NAME` is set. Requires an OBO token;
  managed-identity fallback is never used for remote kinds.
- No `filterAddOn` is emitted. ACL is enforced natively by SharePoint.
  Optional `SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON` forwards a KQL scope
  via `filterExpressionAddOn` when configured.
- `_normalize_sharepoint_remote_reference` maps `sourceData.webUrl` +
  `resourceMetadata` (Title / Name / FileName ...) plus `extracts[].text`
  (with `text` / `content` / `snippet` fallbacks) into the shared
  `{title, link, content}` contract. Empty hits are dropped rather than
  surfaced as bare references.
- Dispatcher checks the SharePoint shape before Work IQ because both may carry
  `extracts`, but only SharePoint remote carries `webUrl` +
  `resourceMetadata`.
- Extends `_REMOTE_KNOWLEDGE_SOURCE_KINDS` and `_remote_kinds_enabled` so
  the runtime ceiling (`maxRuntimeInSeconds`) is emitted whenever
  SharePoint remote is on.
- `config_settings.py`: 3 new `SettingSpec` entries with defaults
  (enabled=false, names/filters empty).

API contract: `2026-05-01-preview`. Kind string: `remoteSharePoint`
(camelCase, capital P) per the Foundry IQ knowledge-base retrieve reference.

## Validation

- New unit tests: 9 cases in `tests/test_foundry_iq_sharepoint_remote.py`
  covering disabled skip, missing name skip, OBO-required skip, params shape
  (with/without filterExpressionAddOn), no `filterAddOn` invariant,
  `maxRuntimeInSeconds` emission, MI fallback for local sources when
  SharePoint remote is off, and `_normalize_references` mapping across
  extracts / flat text / URL-tail title / empty-hit skip.
- Full suite: `pytest -q` -> 326 passed.
- Prohibited-char regex `[\uFFFD\u0000-\u0008\u000B\u000C\u000E-\u001F\u2014]`:
  0 matches across changed files.

## Draft on purpose

Part of the 5-KS fleet. Manifest / changelog / whatisnew / mkdocs.yml nav are
intentionally not touched here; Samantha will consolidate those when merging
the fleet into v3.5.0.