### PR TITLE
feat: add indexedOneLake (OneLake) knowledge source support

### DIFF
--- a/src/api/config_settings.py
+++ b/src/api/config_settings.py
@@ -559,6 +559,59 @@ SECTIONS: List[SettingSection] = [
                 ),
             ),
             SettingSpec(
+                key="ONELAKE_KS_ENABLED",
+                type="bool",
+                default=False,
+                label="Enable OneLake indexed knowledge source",
+                description=(
+                    "When enabled and ONELAKE_KNOWLEDGE_SOURCE_NAME is set, "
+                    "the Foundry IQ retrieve request appends an "
+                    "indexedOneLake knowledge source for grounding over a "
+                    "Microsoft Fabric OneLake lakehouse. Foundry IQ manages "
+                    "the underlying Azure AI Search index internally, so "
+                    "OneLake is a native (not remote) kind: it does not "
+                    "require a per-user OBO token."
+                ),
+            ),
+            SettingSpec(
+                key="ONELAKE_KNOWLEDGE_SOURCE_NAME",
+                type="string",
+                default="",
+                label="OneLake knowledge source name",
+                description=(
+                    "Name of the indexedOneLake knowledge source registered "
+                    "on the knowledge base. Required when ONELAKE_KS_ENABLED "
+                    "is true. The knowledge source itself binds a Fabric "
+                    "workspace and lakehouse at registration time; no effect "
+                    "when OneLake is disabled."
+                ),
+            ),
+            SettingSpec(
+                key="ONELAKE_WORKSPACE_ID",
+                type="string",
+                default="",
+                label="OneLake Fabric workspace ID",
+                description=(
+                    "Identifier of the Microsoft Fabric workspace that hosts "
+                    "the OneLake lakehouse bound to the indexedOneLake "
+                    "knowledge source. Captured for observability and used "
+                    "by platform provisioning to assign Fabric RBAC to the "
+                    "Foundry IQ managed identity; not sent on retrieve."
+                ),
+            ),
+            SettingSpec(
+                key="ONELAKE_LAKEHOUSE_ID",
+                type="string",
+                default="",
+                label="OneLake Fabric lakehouse ID",
+                description=(
+                    "Identifier of the Microsoft Fabric lakehouse (within "
+                    "ONELAKE_WORKSPACE_ID) bound to the indexedOneLake "
+                    "knowledge source. Captured for observability and "
+                    "documentation; not sent on retrieve."
+                ),
+            ),
+            SettingSpec(
                 key="SEARCH_RETRIEVAL_ENABLED",
                 type="bool",
                 default=True,

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -106,6 +106,28 @@ SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON_KEY = (
     "SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON"
 )
 
+# OneLake indexed knowledge source (Microsoft Fabric OneLake, indexed variant).
+# Opt-in; default off. When enabled, the retrieve request appends an
+# ``indexedOneLake`` knowledge source in ``knowledgeSourceParams``. Unlike
+# the remote kinds (workIQ / fabricOntology / fabricDataAgent), Foundry IQ
+# manages the underlying Azure AI Search index internally: at KS registration
+# time it is bound to a Fabric workspace + lakehouse and provisions the
+# datasource, skillset, index, and indexer transparently. GPT-RAG therefore
+# does not maintain a Bicep AI Search sidecar for OneLake; the KS itself
+# owns the pipeline. The retrieve-time entry only needs the knowledge source
+# name and reference flags; workspace / lakehouse identifiers are used only
+# by platform provisioning (postProvision RBAC assignment for the Foundry
+# IQ managed identity on the target Fabric workspace) and by the operator
+# docs. Because content is stored in AI Search, ``indexedOneLake`` is a
+# native (not remote) kind: no OBO requirement and no maxRuntimeInSeconds
+# bump. If the service MI token is forwarded
+# (``FOUNDRY_IQ_FORWARD_SOURCE_AUTH=true``), Foundry IQ evaluates any
+# permission filters against the bound source using that identity.
+ONELAKE_KS_ENABLED_KEY = "ONELAKE_KS_ENABLED"
+ONELAKE_KNOWLEDGE_SOURCE_NAME_KEY = "ONELAKE_KNOWLEDGE_SOURCE_NAME"
+ONELAKE_WORKSPACE_ID_KEY = "ONELAKE_WORKSPACE_ID"
+ONELAKE_LAKEHOUSE_ID_KEY = "ONELAKE_LAKEHOUSE_ID"
+
 # Knowledge source kinds that must never fall back to the service managed
 # identity for x-ms-query-source-authorization. These sources run against
 # external systems (M365, Fabric) where impersonation, not app identity, is
@@ -323,6 +345,22 @@ class FoundryIQClient:
         ).strip()
         self.sharepoint_remote_filter_expression_add_on = (
             self.cfg.get(SHAREPOINT_REMOTE_FILTER_EXPRESSION_ADD_ON_KEY, "") or ""
+        ).strip()
+        # OneLake indexed knowledge source. Native kind (Foundry IQ owns the
+        # underlying AI Search index), so no OBO is required. Workspace and
+        # lakehouse identifiers are read here for observability / logging
+        # only; the retrieve-time entry carries just the KS name.
+        self.onelake_ks_enabled = _as_bool(
+            self.cfg.get(ONELAKE_KS_ENABLED_KEY, False, type=bool)
+        )
+        self.onelake_knowledge_source_name = (
+            self.cfg.get(ONELAKE_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
+        ).strip()
+        self.onelake_workspace_id = (
+            self.cfg.get(ONELAKE_WORKSPACE_ID_KEY, "") or ""
+        ).strip()
+        self.onelake_lakehouse_id = (
+            self.cfg.get(ONELAKE_LAKEHOUSE_ID_KEY, "") or ""
         ).strip()
         self.credential = self.cfg.aiocredential
 
@@ -570,6 +608,59 @@ class FoundryIQClient:
 
         return {"title": title, "link": link, "content": content}
 
+    @staticmethod
+    def _normalize_onelake_reference(source: Dict[str, Any]) -> Optional[Dict[str, str]]:
+        """Map an ``indexedOneLake`` ``sourceData`` payload into ``{title, link, content}``.
+
+        Because Foundry IQ manages the underlying Azure AI Search index for
+        OneLake internally, the reference shape is projection-driven: it
+        looks like a native ``azureBlob`` chunk (a snippet plus a file
+        pointer) rather than the ``attributions`` / ``extracts`` shape of
+        remote M365 / Fabric kinds. The exact field names are not fully
+        pinned down in the preview API surface, so the normalizer accepts
+        the plausible variants (``snippet`` / ``content`` / ``text`` for
+        the chunk; ``oneLakeFilePath`` / ``filePath`` / ``path`` /
+        ``abfssPath`` / ``webUrl`` for the pointer) and annotates the
+        citation title with the workspace / lakehouse identifiers when
+        they are present. Returns ``None`` when no textual content can be
+        found so the caller can skip empty hits.
+        """
+        content = (
+            source.get("snippet")
+            or source.get("content")
+            or source.get("text")
+            or ""
+        )
+        if not content:
+            return None
+
+        link = (
+            source.get("webUrl")
+            or source.get("oneLakeFilePath")
+            or source.get("filePath")
+            or source.get("path")
+            or source.get("abfssPath")
+            or ""
+        )
+
+        title = source.get("title") or source.get("fileName") or source.get("name")
+        if not title and link:
+            tail = link.rsplit("/", 1)[-1]
+            title = tail.split("?", 1)[0] or None
+        if not title:
+            title = "OneLake reference"
+
+        workspace_id = str(source.get("workspaceId") or "").strip()
+        lakehouse_id = str(source.get("lakehouseId") or "").strip()
+        if workspace_id and lakehouse_id:
+            title = f"{title} (workspace {workspace_id}, lakehouse {lakehouse_id})"
+        elif workspace_id:
+            title = f"{title} (workspace {workspace_id})"
+        elif lakehouse_id:
+            title = f"{title} (lakehouse {lakehouse_id})"
+
+        return {"title": title, "link": link, "content": content}
+
     @classmethod
     def _normalize_references(cls, payload: Dict[str, Any]) -> List[Dict[str, str]]:
         """Map a retrieve response into ``[{title, link, content}]`` records.
@@ -599,6 +690,11 @@ class FoundryIQClient:
           return ``sourceData.webUrl`` and ``sourceData.resourceMetadata``
           with SharePoint properties (Title, LastModifiedTime, ...) plus
           ``extracts`` snippets. See :meth:`_normalize_sharepoint_remote_reference`.
+        - ``indexedOneLake`` (Microsoft Fabric OneLake, indexed) sources
+          return an azureBlob-shaped projection: a chunk snippet plus a
+          OneLake file pointer, optionally annotated with
+          ``workspaceId`` / ``lakehouseId``. See
+          :meth:`_normalize_onelake_reference`.
 
         We accept the union with explicit priority so the downstream
         ``{title, link, content}`` contract is identical across backends,
@@ -641,6 +737,20 @@ class FoundryIQClient:
                 record = cls._normalize_work_iq_reference(source)
                 if record is not None:
                     records.append(record)
+                continue
+
+            # indexedOneLake shape: azureBlob-like projection with a
+            # OneLake-flavored file pointer or lakehouse identifier.
+            # Checked before the generic azureBlob fallback so the
+            # citation carries workspace / lakehouse context.
+            if (
+                source.get("oneLakeFilePath")
+                or source.get("abfssPath")
+                or source.get("lakehouseId")
+            ):
+                onelake_record = cls._normalize_onelake_reference(source)
+                if onelake_record is not None:
+                    records.append(onelake_record)
                 continue
 
             content = (
@@ -925,6 +1035,45 @@ class FoundryIQClient:
             )
         return params
 
+    def _build_onelake_source_params(self) -> Optional[Dict[str, Any]]:
+        """Build the ``indexedOneLake`` knowledge source entry.
+
+        Returns ``None`` when OneLake does not apply:
+
+        - the feature is disabled, or
+        - no knowledge source name was provisioned.
+
+        Because Foundry IQ owns the underlying AI Search index for the
+        OneLake KS, this is a native (not remote) kind: it does not
+        require an OBO token and does not trigger the
+        ``maxRuntimeInSeconds`` bump. Workspace / lakehouse identifiers
+        are bound at KS registration time; the retrieve-time entry only
+        needs the knowledge source name and reference flags.
+        """
+        if not self.onelake_ks_enabled:
+            return None
+        if not self.onelake_knowledge_source_name:
+            logging.warning(
+                "[FoundryIQClient] ONELAKE_KS_ENABLED=true but "
+                "ONELAKE_KNOWLEDGE_SOURCE_NAME is empty; skipping "
+                "OneLake source."
+            )
+            return None
+
+        logging.info(
+            "[FoundryIQClient][OneLake] Adding indexedOneLake source "
+            "%s (workspace=%s, lakehouse=%s)",
+            self.onelake_knowledge_source_name,
+            self.onelake_workspace_id or "<unset>",
+            self.onelake_lakehouse_id or "<unset>",
+        )
+        return {
+            "knowledgeSourceName": self.onelake_knowledge_source_name,
+            "kind": "indexedOneLake",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+
     def _remote_kinds_enabled(self) -> bool:
         """Return True when any remote (M365 / Fabric) knowledge source is on."""
         return (
@@ -1070,6 +1219,10 @@ class FoundryIQClient:
         )
         if sharepoint_remote_source_params:
             knowledge_source_params.append(sharepoint_remote_source_params)
+
+        onelake_source_params = self._build_onelake_source_params()
+        if onelake_source_params:
+            knowledge_source_params.append(onelake_source_params)
 
         if knowledge_source_params:
             body["knowledgeSourceParams"] = knowledge_source_params

--- a/tests/test_foundry_iq_onelake.py
+++ b/tests/test_foundry_iq_onelake.py
@@ -1,0 +1,290 @@
+"""Tests for the indexedOneLake (Microsoft Fabric OneLake) knowledge source path.
+
+Covers the OneLake indexed knowledge source, a native kind: Foundry IQ owns
+the underlying Azure AI Search index for the KS, so OneLake does not require
+a per-user OBO token and does not trigger the ``maxRuntimeInSeconds`` bump.
+
+- ``indexedOneLake`` knowledge source params are appended only when
+  ``ONELAKE_KS_ENABLED`` is true and ``ONELAKE_KNOWLEDGE_SOURCE_NAME`` is set.
+- ``indexedOneLake`` params never carry a ``filterAddOn``; ACL is enforced by
+  Foundry IQ against the underlying AI Search index.
+- OneLake does not count as a remote kind: it must not, on its own, cause
+  ``maxRuntimeInSeconds`` to be emitted.
+- OneLake does not require an OBO token: it must be emitted even when no
+  ``x-ms-query-source-authorization`` header is available.
+- ``_normalize_references`` maps the OneLake ``sourceData`` projection
+  (snippet + OneLake file pointer, optionally annotated with workspace /
+  lakehouse) to the shared ``{title, link, content}`` contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def text(self):
+        import json
+        return json.dumps(self._payload)
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self._status = status
+        self.captured = {}
+
+    def post(self, url, headers=None, json=None):  # noqa: A002
+        self.captured = {"url": url, "headers": headers, "json": json}
+        return _FakeResponse(self._payload, self._status)
+
+
+def _build_client(payload, status=200, config_overrides=None):
+    from connectors import foundry_iq
+
+    values = {
+        "KNOWLEDGE_BASE_ENDPOINT": "https://fake-search.search.windows.net",
+        "SEARCH_SERVICE_QUERY_ENDPOINT": "https://fake-search.search.windows.net",
+        "KNOWLEDGE_BASE_NAME": "kb-test",
+        "FOUNDRY_IQ_API_VERSION": "2026-05-01-preview",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND": "",
+        "FOUNDRY_IQ_PATTERN": "",
+        "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED": False,
+        "FOUNDRY_IQ_SECURITY_FIELD_NAME": "metadata_security_id",
+        "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": None,
+        "FOUNDRY_IQ_FORWARD_SOURCE_AUTH": True,
+        "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": False,
+        "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_MAX_RUNTIME_SECONDS": 120,
+        "WORK_IQ_ENABLED": False,
+        "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FABRIC_IQ_ENABLED": False,
+        "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FABRIC_DATA_AGENT_ENABLED": False,
+        "FABRIC_DATA_AGENT_KNOWLEDGE_SOURCE_NAME": "",
+        "ONELAKE_KS_ENABLED": False,
+        "ONELAKE_KNOWLEDGE_SOURCE_NAME": "",
+        "ONELAKE_WORKSPACE_ID": "",
+        "ONELAKE_LAKEHOUSE_ID": "",
+    }
+    values.update(config_overrides or {})
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda key, default=None, type=str: values.get(key, default)  # noqa: A002
+    cfg.aiocredential = MagicMock()
+    cfg.aiocredential.get_token = AsyncMock(return_value=SimpleNamespace(token="svc-token"))
+
+    with patch("connectors.foundry_iq.get_config", return_value=cfg):
+        client = foundry_iq.FoundryIQClient()
+    session = _FakeSession(payload, status)
+    client._get_session = AsyncMock(return_value=session)
+    return client, session
+
+
+_SAMPLE_PAYLOAD = {"references": []}
+
+
+# ---------------------------------------------------------------------------
+# OneLake knowledge source emission
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_onelake_not_emitted_when_disabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "ONELAKE_KS_ENABLED": False,
+            "ONELAKE_KNOWLEDGE_SOURCE_NAME": "onelake-ks",
+        },
+    )
+    await client.retrieve("hello")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "indexedOneLake" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_onelake_not_emitted_when_name_missing():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "ONELAKE_KS_ENABLED": True,
+            "ONELAKE_KNOWLEDGE_SOURCE_NAME": "",
+        },
+    )
+    await client.retrieve("hello")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "indexedOneLake" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_onelake_emitted_when_enabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "ONELAKE_KS_ENABLED": True,
+            "ONELAKE_KNOWLEDGE_SOURCE_NAME": "onelake-ks",
+            "ONELAKE_WORKSPACE_ID": "ws-abc",
+            "ONELAKE_LAKEHOUSE_ID": "lh-xyz",
+        },
+    )
+    await client.retrieve("hello")
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    onelake = [s for s in sources if s.get("kind") == "indexedOneLake"]
+    assert onelake == [
+        {
+            "knowledgeSourceName": "onelake-ks",
+            "kind": "indexedOneLake",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_onelake_never_carries_filter_add_on():
+    """OneLake ACL is enforced against the underlying AI Search index; the
+    Pattern B filterAddOn is only valid for the primary searchIndex source."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "ONELAKE_KS_ENABLED": True,
+            "ONELAKE_KNOWLEDGE_SOURCE_NAME": "onelake-ks",
+        },
+    )
+    await client.retrieve(
+        "hello",
+        conversation_id="conv-1",
+        user_context={"principal_id": "user-1", "groups": ["g-a"]},
+    )
+    onelake = [
+        s for s in session.captured["json"]["knowledgeSourceParams"]
+        if s.get("kind") == "indexedOneLake"
+    ]
+    assert len(onelake) == 1
+    assert "filterAddOn" not in onelake[0]
+
+
+@pytest.mark.asyncio
+async def test_onelake_emitted_without_obo_token():
+    """OneLake is a native kind (Foundry IQ owns the AI Search index) and
+    must not require an OBO token, unlike workIQ / fabricOntology /
+    fabricDataAgent."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "ONELAKE_KS_ENABLED": True,
+            "ONELAKE_KNOWLEDGE_SOURCE_NAME": "onelake-ks",
+        },
+    )
+    await client.retrieve("hello")  # no obo_token
+    kinds = [
+        s.get("kind")
+        for s in session.captured["json"].get("knowledgeSourceParams", [])
+    ]
+    assert "indexedOneLake" in kinds
+
+
+# ---------------------------------------------------------------------------
+# maxRuntimeInSeconds: OneLake is native, must not trigger the bump alone.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_max_runtime_not_emitted_when_only_onelake_enabled():
+    """indexedOneLake is a native kind (index is local to Foundry IQ), so on
+    its own it must not cause the maxRuntimeInSeconds bump used for M365 /
+    Fabric remote kinds."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "ONELAKE_KS_ENABLED": True,
+            "ONELAKE_KNOWLEDGE_SOURCE_NAME": "onelake-ks",
+        },
+    )
+    await client.retrieve("hello")
+    assert "maxRuntimeInSeconds" not in session.captured["json"]
+
+
+# ---------------------------------------------------------------------------
+# _normalize_references for indexedOneLake shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_normalize_onelake_reference_shape():
+    """OneLake sourceData looks like an azureBlob projection: a snippet plus
+    a OneLake file pointer, optionally annotated with workspace / lakehouse
+    identifiers. The normalizer must map it to the shared
+    ``{title, link, content}`` contract and drop empty entries."""
+    payload = {
+        "references": [
+            {
+                "type": "indexedOneLake",
+                "sourceData": {
+                    "title": "sales-fy25.parquet",
+                    "snippet": "Q1 revenue was 42.1M.",
+                    "oneLakeFilePath": (
+                        "https://onelake.dfs.fabric.microsoft.com/ws-abc/"
+                        "lh-xyz.Lakehouse/Files/sales/sales-fy25.parquet"
+                    ),
+                    "workspaceId": "ws-abc",
+                    "lakehouseId": "lh-xyz",
+                },
+            },
+            {
+                # No explicit title: derive from file name; workspace only.
+                "type": "indexedOneLake",
+                "sourceData": {
+                    "snippet": "Top product: SKU-42.",
+                    "webUrl": (
+                        "https://onelake.dfs.fabric.microsoft.com/ws-abc/"
+                        "lh-xyz.Lakehouse/Files/products/top.parquet?token=xyz"
+                    ),
+                    "workspaceId": "ws-abc",
+                    "lakehouseId": "lh-xyz",
+                },
+            },
+            {
+                # No content: must be dropped.
+                "type": "indexedOneLake",
+                "sourceData": {
+                    "snippet": "",
+                    "oneLakeFilePath": "abfss://foo/bar",
+                    "lakehouseId": "lh-xyz",
+                },
+            },
+        ]
+    }
+    client, _ = _build_client(payload)
+    records = await client.retrieve("hello")
+    assert records == [
+        {
+            "title": "sales-fy25.parquet (workspace ws-abc, lakehouse lh-xyz)",
+            "link": (
+                "https://onelake.dfs.fabric.microsoft.com/ws-abc/"
+                "lh-xyz.Lakehouse/Files/sales/sales-fy25.parquet"
+            ),
+            "content": "Q1 revenue was 42.1M.",
+        },
+        {
+            "title": "top.parquet (workspace ws-abc, lakehouse lh-xyz)",
+            "link": (
+                "https://onelake.dfs.fabric.microsoft.com/ws-abc/"
+                "lh-xyz.Lakehouse/Files/products/top.parquet?token=xyz"
+            ),
+            "content": "Top product: SKU-42.",
+        },
+    ]


### PR DESCRIPTION
Adds an opt-in `indexedOneLake` knowledge source path to the Foundry IQ retrieve client so operators can ground answers on a Microsoft Fabric OneLake lakehouse.

## Design

Treated as a **native** kind (not remote): Foundry IQ manages the underlying Azure AI Search index for the knowledge source internally. Consequences:

- No per-user OBO token required.
- Not added to `_REMOTE_KNOWLEDGE_SOURCE_KINDS`, so no `maxRuntimeInSeconds` bump when only OneLake is enabled.
- No `filterAddOn` (Foundry IQ enforces ACL against the AI Search index).

Aligned with the sibling SharePoint indexed KS approach in v3.5.0.

## New App Config keys (label `gpt-rag`, default off)

- `ONELAKE_KS_ENABLED`
- `ONELAKE_KNOWLEDGE_SOURCE_NAME`
- `ONELAKE_WORKSPACE_ID`
- `ONELAKE_LAKEHOUSE_ID`

Workspace / lakehouse ids are captured for observability and platform-side Fabric RBAC only; they are not sent on retrieve. The knowledge source binds them at registration time.

## Changes

- `src/connectors/foundry_iq.py`: constants, init reads, `_build_onelake_source_params`, `_normalize_onelake_reference`, wiring.
- `src/api/config_settings.py`: 4 new `SettingSpec` entries.
- `tests/test_foundry_iq_onelake.py`: 7 new tests.

## Validation

- `pytest tests/test_foundry_iq_onelake.py` -> 7 passed
- Full `pytest` -> 324 passed
- UTF-8 clean, no em-dashes.

## Caveats

- API version `2026-05-01-preview`. Kind string `indexedOneLake` per plan; re-verify against live Microsoft docs before GA. Reference normalizer is intentionally tolerant on the `sourceData` shape.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 37105e3a-7d9e-4431-906c-586e1938220b
