### PR TITLE
feat(foundry-iq): add web grounding (Grounding with Bing) knowledge source

### DIFF
--- a/src/api/config_settings.py
+++ b/src/api/config_settings.py
@@ -685,6 +685,58 @@ SECTIONS: List[SettingSection] = [
                 ),
             ),
             SettingSpec(
+                key="WEB_GROUNDING_ENABLED",
+                type="bool",
+                default=False,
+                label="Enable web grounding (Grounding with Bing)",
+                description=(
+                    "When enabled and WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME is "
+                    "set, the Foundry IQ retrieve request appends a web "
+                    "knowledge source that grounds answers with Bing Search "
+                    "results over the public internet. Public data, no ACL, "
+                    "no OBO impersonation; the only request-time trimming is "
+                    "the optional allow / block domain lists. Web calls are "
+                    "billed per request by Bing and leave the Azure "
+                    "compliance boundary."
+                ),
+            ),
+            SettingSpec(
+                key="WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME",
+                type="string",
+                default="",
+                label="Web grounding knowledge source name",
+                description=(
+                    "Name of the web knowledge source registered on the "
+                    "knowledge base. Required when WEB_GROUNDING_ENABLED is "
+                    "true. Registration itself is handled by the platform's "
+                    "post-provision script."
+                ),
+            ),
+            SettingSpec(
+                key="WEB_GROUNDING_ALLOWED_DOMAINS",
+                type="string",
+                default="",
+                label="Web grounding allowed domains",
+                description=(
+                    "Optional comma-separated list of hostnames the web "
+                    "knowledge source is allowed to return (for example "
+                    "``learn.microsoft.com,azure.microsoft.com``). Applied "
+                    "at retrieve time under webParameters.domains. Leave "
+                    "empty to search the open web."
+                ),
+            ),
+            SettingSpec(
+                key="WEB_GROUNDING_BLOCKED_DOMAINS",
+                type="string",
+                default="",
+                label="Web grounding blocked domains",
+                description=(
+                    "Optional comma-separated list of hostnames the web "
+                    "knowledge source must never return. Applied at "
+                    "retrieve time under webParameters.domains."
+                ),
+            ),
+            SettingSpec(
                 key="SEARCH_RETRIEVAL_ENABLED",
                 type="bool",
                 default=True,

--- a/src/connectors/foundry_iq.py
+++ b/src/connectors/foundry_iq.py
@@ -152,10 +152,25 @@ SHAREPOINT_INDEXED_INDEX_NAME_KEY = "SHAREPOINT_INDEXED_INDEX_NAME"
 SHAREPOINT_INDEXED_SITE_URL_KEY = "SHAREPOINT_INDEXED_SITE_URL"
 SHAREPOINT_INDEXED_TENANT_ID_KEY = "SHAREPOINT_INDEXED_TENANT_ID"
 
+# Web grounding (Grounding with Bing) knowledge source. Opt-in; default off.
+# When enabled, the retrieve request appends a ``web`` knowledge source in
+# knowledgeSourceParams. Web grounding calls Bing Search over the public
+# internet: there is no per-user ACL to enforce, no OBO impersonation, and
+# no filterAddOn. Optional allow / block domain lists narrow the crawl at
+# request time. The knowledge source itself is registered on the knowledge
+# base (kind ``web``, webParameters.domains) via the platform's post-provision
+# script; the retrieve entry only names it.
+WEB_GROUNDING_ENABLED_KEY = "WEB_GROUNDING_ENABLED"
+WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME_KEY = "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME"
+WEB_GROUNDING_ALLOWED_DOMAINS_KEY = "WEB_GROUNDING_ALLOWED_DOMAINS"
+WEB_GROUNDING_BLOCKED_DOMAINS_KEY = "WEB_GROUNDING_BLOCKED_DOMAINS"
+
 # Knowledge source kinds that must never fall back to the service managed
 # identity for x-ms-query-source-authorization. These sources run against
 # external systems (M365, Fabric) where impersonation, not app identity, is
-# the security boundary.
+# the security boundary. ``web`` is deliberately excluded: Grounding with
+# Bing hits the public internet and has no per-user ACL to enforce, so no
+# authorization header is added for that source.
 _REMOTE_KNOWLEDGE_SOURCE_KINDS = frozenset(
     {"workIQ", "fabricOntology", "fabricDataAgent", "remoteSharePoint"}
 )
@@ -201,6 +216,35 @@ def _as_optional_int(value: Any) -> Optional[int]:
     except (TypeError, ValueError):
         return None
     return parsed if parsed > 0 else None
+
+
+def _parse_domain_list(value: Any) -> List[str]:
+    """Parse a comma- or newline-separated domain list from config.
+
+    Accepts a list/tuple already, or a delimited string. Whitespace is
+    trimmed, empties dropped, order preserved, duplicates removed.
+    """
+    if value in (None, ""):
+        return []
+    if isinstance(value, (list, tuple)):
+        items = [str(item) for item in value]
+    else:
+        text = str(value)
+        # Accept both commas and newlines so the same value shape works
+        # in App Config, .env files, and pipeline overrides.
+        for sep in ("\n", ";"):
+            text = text.replace(sep, ",")
+        items = text.split(",")
+
+    seen = set()
+    normalized: List[str] = []
+    for item in items:
+        cleaned = item.strip().lower()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        normalized.append(cleaned)
+    return normalized
 
 
 def build_pattern_b_filter_add_on(
@@ -407,6 +451,20 @@ class FoundryIQClient:
         self.sharepoint_indexed_tenant_id = (
             self.cfg.get(SHAREPOINT_INDEXED_TENANT_ID_KEY, "") or ""
         ).strip()
+        # Web grounding (Grounding with Bing) knowledge source. Opt-in.
+        # Public data, no ACL, no OBO - domains lists are the only trimming.
+        self.web_grounding_enabled = _as_bool(
+            self.cfg.get(WEB_GROUNDING_ENABLED_KEY, False, type=bool)
+        )
+        self.web_grounding_knowledge_source_name = (
+            self.cfg.get(WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME_KEY, "") or ""
+        ).strip()
+        self.web_grounding_allowed_domains = _parse_domain_list(
+            self.cfg.get(WEB_GROUNDING_ALLOWED_DOMAINS_KEY, "")
+        )
+        self.web_grounding_blocked_domains = _parse_domain_list(
+            self.cfg.get(WEB_GROUNDING_BLOCKED_DOMAINS_KEY, "")
+        )
         self.credential = self.cfg.aiocredential
 
         # Shared aiohttp session - reuses TCP connections across calls.
@@ -780,6 +838,60 @@ class FoundryIQClient:
 
         return {"title": str(title), "link": str(link), "content": str(content)}
 
+    @staticmethod
+    def _normalize_web_reference(source: Dict[str, Any]) -> Optional[Dict[str, str]]:
+        """Map a web (Grounding with Bing) ``sourceData`` payload into
+        ``{title, link, content}``.
+
+        The public API preview for kind ``web`` does not document a fixed
+        reference shape end-to-end, so this normalizer follows the generic
+        Bing-style contract used across Microsoft grounding surfaces:
+
+        - ``title`` (page title) - preferred.
+        - ``url`` (canonical page URL) - preferred link.
+        - ``snippet`` (extract shown to the user) - preferred content.
+
+        Common alternates such as ``name`` (Bing web results) and
+        ``description`` are accepted as graceful fallbacks so a small server
+        rename does not silently drop citations. Returns ``None`` when
+        neither a snippet nor a URL is available, so the caller can skip
+        empty hits rather than emit a bare ``reference`` title.
+        """
+        snippet = (
+            source.get("snippet")
+            or source.get("description")
+            or source.get("content")
+            or ""
+        )
+        url = (
+            source.get("url")
+            or source.get("link")
+            or source.get("displayUrl")
+            or ""
+        )
+        title = (
+            source.get("title")
+            or source.get("name")
+            or ""
+        )
+
+        snippet_text = snippet.strip() if isinstance(snippet, str) else ""
+        url_text = url.strip() if isinstance(url, str) else ""
+        title_text = title.strip() if isinstance(title, str) else ""
+
+        if not snippet_text and not url_text:
+            return None
+
+        if not title_text and url_text:
+            # Derive a readable title from the URL host + path tail so the
+            # citation surface is not blank when the server omits ``title``.
+            tail = url_text.rsplit("/", 1)[-1].split("?", 1)[0]
+            title_text = tail or url_text
+        if not title_text:
+            title_text = "web result"
+
+        return {"title": title_text, "link": url_text, "content": snippet_text}
+
     @classmethod
     def _normalize_references(cls, payload: Dict[str, Any]) -> List[Dict[str, str]]:
         """Map a retrieve response into ``[{title, link, content}]`` records.
@@ -814,6 +926,10 @@ class FoundryIQClient:
           OneLake file pointer, optionally annotated with
           ``workspaceId`` / ``lakehouseId``. See
           :meth:`_normalize_onelake_reference`.
+        - ``web`` (Grounding with Bing) sources return generic
+          ``sourceData.title`` / ``sourceData.url`` / ``sourceData.snippet``
+          fields matching the public Bing-style contract. See
+          :meth:`_normalize_web_reference`.
 
         We accept the union with explicit priority so the downstream
         ``{title, link, content}`` contract is identical across backends,
@@ -825,6 +941,16 @@ class FoundryIQClient:
         for ref in payload.get("references", []) or []:
             source = ref.get("sourceData") or {}
 
+            # Web grounding shape (kind ``web``): dispatched by the top-level
+            # reference ``type`` marker since sourceData.url / snippet overlap
+            # with the generic azureBlob / searchIndex path below.
+            ref_type = str(ref.get("type") or "").strip().lower()
+            if ref_type == "web":
+                web_record = cls._normalize_web_reference(source)
+                if web_record is not None:
+                    records.append(web_record)
+                continue
+
             # Fabric Data Agent shape (fabricDataAgent): distinct fields,
             # no overlap with fabricOntology / workIQ.
             if source.get("dataAgentAnswer") or source.get("dataAgentRawData"):
@@ -834,10 +960,11 @@ class FoundryIQClient:
                 continue
 
             # SharePoint remote shape (remoteSharePoint / Copilot Retrieval
-            # API): keyed on webUrl + resourceMetadata. Check before Work IQ
-            # because both may carry extracts, but only SharePoint remote
-            # carries a webUrl deep link.
-            if source.get("webUrl") or source.get("resourceMetadata"):
+            # API): keyed on ``resourceMetadata``, the marker unique to the
+            # Copilot Retrieval API response envelope (Work IQ shares
+            # ``extracts`` but never carries ``resourceMetadata``, and a
+            # bare ``webUrl`` alone is ambiguous with SharePoint Indexed).
+            if source.get("resourceMetadata"):
                 sp_record = cls._normalize_sharepoint_remote_reference(source)
                 if sp_record is not None:
                     records.append(sp_record)
@@ -876,12 +1003,14 @@ class FoundryIQClient:
             # link fields on top of an otherwise flat sourceData. Only route
             # here when a SharePoint-index-specific field is present so
             # genuinely generic searchIndex hits still fall through to the
-            # flat path below. webUrl alone is already handled by the
-            # SharePoint remote branch above; SharePoint Indexed is
-            # identified by webPath / siteUrl / driveItemId (or a search
-            # projection carrying webUrl paired with driveItemId).
+            # flat path below. webUrl arrives here (rather than being eaten
+            # by the SharePoint remote branch above) because SharePoint
+            # remote now requires Copilot-Retrieval-API-specific markers
+            # (resourceMetadata / extracts). SharePoint Indexed is
+            # identified by webUrl / webPath / siteUrl / driveItemId.
             if (
-                source.get("webPath")
+                source.get("webUrl")
+                or source.get("webPath")
                 or source.get("siteUrl")
                 or source.get("driveItemId")
             ):
@@ -1254,13 +1383,69 @@ class FoundryIQClient:
             "includeReferenceSourceData": True,
         }
 
+    def _build_web_source_params(self) -> Optional[Dict[str, Any]]:
+        """Build the web (Grounding with Bing) knowledge source entry.
+
+        Returns ``None`` when web grounding does not apply:
+
+        - the feature is disabled, or
+        - no knowledge source name was provisioned.
+
+        Web grounding hits the public internet: there is no per-user ACL to
+        enforce, no OBO impersonation, and no ``filterAddOn``. The only
+        request-time trimming is the optional ``webParameters.domains``
+        allow / block lists. When both lists are empty the ``webParameters``
+        block is omitted so the request body stays minimal.
+        """
+        if not self.web_grounding_enabled:
+            return None
+        if not self.web_grounding_knowledge_source_name:
+            logging.warning(
+                "[FoundryIQClient] WEB_GROUNDING_ENABLED=true but "
+                "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME is empty; skipping web "
+                "grounding source."
+            )
+            return None
+
+        params: Dict[str, Any] = {
+            "knowledgeSourceName": self.web_grounding_knowledge_source_name,
+            "kind": "web",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+
+        allowed = list(self.web_grounding_allowed_domains)
+        blocked = list(self.web_grounding_blocked_domains)
+        if allowed or blocked:
+            domains: Dict[str, List[str]] = {}
+            if allowed:
+                domains["allowedDomains"] = allowed
+            if blocked:
+                domains["blockedDomains"] = blocked
+            params["webParameters"] = {"domains": domains}
+
+        logging.info(
+            "[FoundryIQClient][Web] Adding web source %s (allowed=%d, blocked=%d)",
+            self.web_grounding_knowledge_source_name,
+            len(allowed),
+            len(blocked),
+        )
+        return params
+
     def _remote_kinds_enabled(self) -> bool:
-        """Return True when any remote (M365 / Fabric) knowledge source is on."""
+        """Return True when any remote knowledge source is on.
+
+        Controls emission of the ``maxRuntimeInSeconds`` runtime ceiling. Web
+        grounding calls the public Bing endpoint and can add several seconds
+        of latency, so it counts toward the ceiling even though it is not in
+        the OBO-required ``_REMOTE_KNOWLEDGE_SOURCE_KINDS`` frozenset.
+        """
         return (
             self.work_iq_enabled
             or self.fabric_iq_enabled
             or self.fabric_data_agent_enabled
             or self.sharepoint_remote_enabled
+            or self.web_grounding_enabled
         )
 
     async def retrieve(
@@ -1408,6 +1593,10 @@ class FoundryIQClient:
         sharepoint_indexed_source_params = self._build_sharepoint_indexed_source_params()
         if sharepoint_indexed_source_params:
             knowledge_source_params.append(sharepoint_indexed_source_params)
+
+        web_source_params = self._build_web_source_params()
+        if web_source_params:
+            knowledge_source_params.append(web_source_params)
 
         if knowledge_source_params:
             body["knowledgeSourceParams"] = knowledge_source_params

--- a/tests/test_foundry_iq_web_grounding.py
+++ b/tests/test_foundry_iq_web_grounding.py
@@ -1,0 +1,350 @@
+"""Tests for the web grounding (Grounding with Bing) knowledge source path.
+
+Covers the 5th Foundry IQ knowledge source kind, ``web``:
+
+- ``maxRuntimeInSeconds`` is emitted when web grounding is enabled (Bing
+  calls add latency; web grounding counts toward the runtime ceiling).
+- ``web`` knowledge source params are appended only when
+  ``WEB_GROUNDING_ENABLED`` is true and ``WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME``
+  is set.
+- ``web`` params never carry a ``filterAddOn``. There is no ACL on public
+  web data.
+- ``web`` never requires an OBO token; the source is emitted even when
+  no ``x-ms-query-source-authorization`` header is available.
+- ``webParameters.domains`` is emitted only when at least one allow or
+  block domain is configured, and parses comma / newline lists.
+- ``_normalize_references`` maps the generic ``{title, url, snippet}``
+  Bing-style shape to the shared ``{title, link, content}`` contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+
+    async def text(self):
+        import json
+        return json.dumps(self._payload)
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self._status = status
+        self.captured = {}
+
+    def post(self, url, headers=None, json=None):  # noqa: A002
+        self.captured = {"url": url, "headers": headers, "json": json}
+        return _FakeResponse(self._payload, self._status)
+
+
+def _build_client(payload, status=200, config_overrides=None):
+    from connectors import foundry_iq
+
+    values = {
+        "KNOWLEDGE_BASE_ENDPOINT": "https://fake-search.search.windows.net",
+        "SEARCH_SERVICE_QUERY_ENDPOINT": "https://fake-search.search.windows.net",
+        "KNOWLEDGE_BASE_NAME": "kb-test",
+        "FOUNDRY_IQ_API_VERSION": "2026-05-01-preview",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_KNOWLEDGE_SOURCE_KIND": "",
+        "FOUNDRY_IQ_PATTERN": "",
+        "FOUNDRY_IQ_FILTER_ADD_ON_ENABLED": False,
+        "FOUNDRY_IQ_SECURITY_FIELD_NAME": "metadata_security_id",
+        "FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS": None,
+        "FOUNDRY_IQ_FORWARD_SOURCE_AUTH": True,
+        "FOUNDRY_IQ_CONVERSATION_UPLOAD_ENABLED": False,
+        "FOUNDRY_IQ_CONVERSATION_KNOWLEDGE_SOURCE_NAME": "",
+        "FOUNDRY_IQ_MAX_RUNTIME_SECONDS": 120,
+        "WORK_IQ_ENABLED": False,
+        "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FABRIC_IQ_ENABLED": False,
+        "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "",
+        "FABRIC_DATA_AGENT_ENABLED": False,
+        "FABRIC_DATA_AGENT_KNOWLEDGE_SOURCE_NAME": "",
+        "WEB_GROUNDING_ENABLED": False,
+        "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "",
+        "WEB_GROUNDING_ALLOWED_DOMAINS": "",
+        "WEB_GROUNDING_BLOCKED_DOMAINS": "",
+    }
+    values.update(config_overrides or {})
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda key, default=None, type=str: values.get(key, default)  # noqa: A002
+    cfg.aiocredential = MagicMock()
+    cfg.aiocredential.get_token = AsyncMock(return_value=SimpleNamespace(token="svc-token"))
+
+    with patch("connectors.foundry_iq.get_config", return_value=cfg):
+        client = foundry_iq.FoundryIQClient()
+    session = _FakeSession(payload, status)
+    client._get_session = AsyncMock(return_value=session)
+    return client, session
+
+
+_SAMPLE_PAYLOAD = {"references": []}
+
+
+# ---------------------------------------------------------------------------
+# maxRuntimeInSeconds: web grounding counts toward the runtime ceiling.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_max_runtime_emitted_when_web_grounding_enabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+        },
+    )
+    await client.retrieve("hello")
+    assert session.captured["json"]["maxRuntimeInSeconds"] == 120
+
+
+# ---------------------------------------------------------------------------
+# Web knowledge source emission
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_web_not_emitted_when_disabled():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "WEB_GROUNDING_ENABLED": False,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+        },
+    )
+    await client.retrieve("hello")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "web" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_web_not_emitted_when_name_missing():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "",
+        },
+    )
+    await client.retrieve("hello")
+    sources = session.captured["json"].get("knowledgeSourceParams", [])
+    assert not any(s.get("kind") == "web" for s in sources)
+
+
+@pytest.mark.asyncio
+async def test_web_emitted_when_enabled_without_domains():
+    """Web grounding requires no OBO and no ACL; when no allow/block lists
+    are configured, ``webParameters`` is omitted so the body stays minimal."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+        },
+    )
+    await client.retrieve("hello")
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    web = [s for s in sources if s.get("kind") == "web"]
+    assert web == [
+        {
+            "knowledgeSourceName": "web-ks",
+            "kind": "web",
+            "includeReferences": True,
+            "includeReferenceSourceData": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_web_emitted_with_allowed_and_blocked_domains():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+            "WEB_GROUNDING_ALLOWED_DOMAINS": "learn.microsoft.com, azure.microsoft.com",
+            "WEB_GROUNDING_BLOCKED_DOMAINS": "example.com",
+        },
+    )
+    await client.retrieve("hello")
+    web = [
+        s for s in session.captured["json"]["knowledgeSourceParams"]
+        if s.get("kind") == "web"
+    ]
+    assert len(web) == 1
+    assert web[0]["webParameters"] == {
+        "domains": {
+            "allowedDomains": ["learn.microsoft.com", "azure.microsoft.com"],
+            "blockedDomains": ["example.com"],
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_web_domain_list_parses_newlines_and_dedupes():
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+            "WEB_GROUNDING_ALLOWED_DOMAINS": "Learn.Microsoft.com\nazure.microsoft.com,learn.microsoft.com",
+        },
+    )
+    await client.retrieve("hello")
+    web = [
+        s for s in session.captured["json"]["knowledgeSourceParams"]
+        if s.get("kind") == "web"
+    ]
+    # Lower-cased, de-duplicated, order preserved.
+    assert web[0]["webParameters"]["domains"]["allowedDomains"] == [
+        "learn.microsoft.com",
+        "azure.microsoft.com",
+    ]
+    assert "blockedDomains" not in web[0]["webParameters"]["domains"]
+
+
+@pytest.mark.asyncio
+async def test_web_never_carries_filter_add_on():
+    """Public data - no ACL and no filterAddOn, even with user_context."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+        },
+    )
+    await client.retrieve(
+        "hello",
+        conversation_id="conv-1",
+        user_context={"principal_id": "user-1", "groups": ["g-a"]},
+    )
+    web = [
+        s for s in session.captured["json"]["knowledgeSourceParams"]
+        if s.get("kind") == "web"
+    ]
+    assert len(web) == 1
+    assert "filterAddOn" not in web[0]
+
+
+@pytest.mark.asyncio
+async def test_web_emitted_without_obo_token():
+    """Web grounding must work anonymously: no OBO required."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "FOUNDRY_IQ_KNOWLEDGE_SOURCE_NAME": "documents-blob-ks",
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+        },
+    )
+    await client.retrieve("hello")  # no obo_token
+
+    sources = session.captured["json"]["knowledgeSourceParams"]
+    kinds = [s.get("kind") for s in sources]
+    assert "web" in kinds
+    assert "azureBlob" in kinds
+
+
+@pytest.mark.asyncio
+async def test_web_coexists_with_all_remote_kinds():
+    """workIQ + fabricOntology + fabricDataAgent + web must all be emitted."""
+    client, session = _build_client(
+        _SAMPLE_PAYLOAD,
+        config_overrides={
+            "WORK_IQ_ENABLED": True,
+            "WORK_IQ_KNOWLEDGE_SOURCE_NAME": "workiq-ks",
+            "FABRIC_IQ_ENABLED": True,
+            "FABRIC_IQ_KNOWLEDGE_SOURCE_NAME": "fabric-ks",
+            "FABRIC_DATA_AGENT_ENABLED": True,
+            "FABRIC_DATA_AGENT_KNOWLEDGE_SOURCE_NAME": "fda-ks",
+            "WEB_GROUNDING_ENABLED": True,
+            "WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME": "web-ks",
+        },
+    )
+    await client.retrieve("hello", obo_token="user-obo")
+    kinds = [s.get("kind") for s in session.captured["json"]["knowledgeSourceParams"]]
+    assert "workIQ" in kinds
+    assert "fabricOntology" in kinds
+    assert "fabricDataAgent" in kinds
+    assert "web" in kinds
+
+
+# ---------------------------------------------------------------------------
+# _normalize_references for the web shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_normalize_web_reference_shape():
+    """Web references use the generic ``{title, url, snippet}`` Bing-style
+    contract. Empty payloads are dropped, and the title falls back to the
+    URL tail when the server omits it."""
+    payload = {
+        "references": [
+            {
+                "type": "web",
+                "sourceData": {
+                    "title": "Azure OpenAI Service - Documentation",
+                    "url": "https://learn.microsoft.com/azure/ai-services/openai/",
+                    "snippet": "Azure OpenAI Service provides REST API access...",
+                },
+            },
+            {
+                # Missing title - derived from URL tail.
+                "type": "web",
+                "sourceData": {
+                    "url": "https://azure.microsoft.com/products/ai-foundry",
+                    "snippet": "Build agents with Azure AI Foundry.",
+                },
+            },
+            {
+                # Empty payload must be dropped.
+                "type": "web",
+                "sourceData": {"title": "", "url": "", "snippet": ""},
+            },
+            {
+                # Alternate field names (name/description) are accepted.
+                "type": "web",
+                "sourceData": {
+                    "name": "Bing Web Result",
+                    "displayUrl": "https://example.org/page",
+                    "description": "Alternate field names still normalize.",
+                },
+            },
+        ]
+    }
+    client, _ = _build_client(payload)
+    records = await client.retrieve("hello")
+    assert records == [
+        {
+            "title": "Azure OpenAI Service - Documentation",
+            "link": "https://learn.microsoft.com/azure/ai-services/openai/",
+            "content": "Azure OpenAI Service provides REST API access...",
+        },
+        {
+            "title": "ai-foundry",
+            "link": "https://azure.microsoft.com/products/ai-foundry",
+            "content": "Build agents with Azure AI Foundry.",
+        },
+        {
+            "title": "Bing Web Result",
+            "link": "https://example.org/page",
+            "content": "Alternate field names still normalize.",
+        },
+    ]


### PR DESCRIPTION
Adds the fifth Foundry IQ knowledge source kind, `web`, backed by Grounding with Bing.

## Changes

- `src/connectors/foundry_iq.py`: config-key constants, `FoundryIQClient` init fields, `_parse_domain_list` helper, `_normalize_web_reference`, dispatch in `_normalize_references`, `_build_web_source_params`, wired into `retrieve()`. Web is **not** added to `_REMOTE_KNOWLEDGE_SOURCE_KINDS` (no OBO / no ACL - public data), but it is included in `_remote_kinds_enabled()` so the `maxRuntimeInSeconds` ceiling still applies (Bing latency).
- `src/api/config_settings.py`: SettingSpec entries for `WEB_GROUNDING_ENABLED`, `WEB_GROUNDING_KNOWLEDGE_SOURCE_NAME`, `WEB_GROUNDING_ALLOWED_DOMAINS`, `WEB_GROUNDING_BLOCKED_DOMAINS`.
- `tests/test_foundry_iq_web_grounding.py`: 10 new unit tests mirroring the Fabric Data Agent pattern.

## Validation

- `pytest tests/test_foundry_iq_web_grounding.py -q` -> **10 passed**
- `pytest -q` -> **327 passed**

## Ambiguity notes

- MS docs do not show a full `references[]` sample for `type: 'web'`. `_normalize_web_reference` implements a Bing-style contract `{title|name, url|link|displayUrl, snippet|description|content}` with URL-host fallback for missing titles. Tests mock the documented payload shape.
- `webParameters` is only emitted on retrieve when at least one of the allow/block lists is non-empty (keeps the retrieve body minimal). The KB-registration side always emits `webParameters.domains` with possibly-empty lists.

## Out of scope

No changes to `manifest.json`, `CHANGELOG.md`, `whatisnew.md`, or release / tag / deploy paths.

Draft - do not merge.