### PR TITLE
feat: migrate MCP strategy to Microsoft Agent Framework

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -69,6 +69,8 @@ ORCHESTRATOR_APP_NAME=ca-<uniqueSuffix>-orchestrator
 MCP_APP_ENDPOINT=https://ca-<uniqueSuffix>-mcp.<environmentHash>.<region>.azurecontainerapps.io
 MCP_APP_NAME=ca-<uniqueSuffix>-mcp
 MCP_CONTAINER=mcp
+MCP_SERVER_TRANSPORT=sse
+MCP_CLIENT_TIMEOUT=600
 
 # Deployment toggles / metadata
 DEPLOYMENT_NAME=<envName>-<epochSecondsOrBuildId>

--- a/.env.sample
+++ b/.env.sample
@@ -69,7 +69,9 @@ ORCHESTRATOR_APP_NAME=ca-<uniqueSuffix>-orchestrator
 MCP_APP_ENDPOINT=https://ca-<uniqueSuffix>-mcp.<environmentHash>.<region>.azurecontainerapps.io
 MCP_APP_NAME=ca-<uniqueSuffix>-mcp
 MCP_CONTAINER=mcp
+# Allowed: sse (default, resolves to /sse) or streamable_http (resolves to /mcp)
 MCP_SERVER_TRANSPORT=sse
+# Seconds; must be greater than zero
 MCP_CLIENT_TIMEOUT=600
 
 # Deployment toggles / metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   error. Per-request identity headers replace the process-wide `h11` patch,
   preventing caller context from leaking between concurrent requests.
 
+- **MCP chat-client lifecycle cleanup.** Request-scoped Azure OpenAI clients
+  now close deterministically after successful, failed, or cancelled streams
+  without masking the original request failure.
+
 ### Removed
 
 - **Semantic Kernel runtime dependency.** The remaining plugin decorators now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP strategy now uses the pinned Microsoft Agent Framework runtime.**
+  The local MCP strategy now uses request-scoped MAF agents and MCP clients for
+  both legacy SSE and streamable HTTP transports. Existing configuration and
+  response framing remain unchanged, while identity headers can no longer leak
+  between concurrent requests through a process-wide `h11` patch. Unsupported
+  transports and conflicting `/sse` or `/mcp` endpoints now fail with clear
+  configuration errors.
+
+### Removed
+
+- **Semantic Kernel runtime dependency.** The remaining plugin decorators now
+  use MAF `ai_function`, so the orchestrator no longer installs or imports
+  Semantic Kernel.
+
 ## [v3.5.1] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Changed
 
-- **MCP strategy now uses the pinned Microsoft Agent Framework runtime.**
-  The local MCP strategy now uses request-scoped MAF agents and MCP clients for
-  both legacy SSE and streamable HTTP transports. Existing configuration and
-  response framing remain unchanged, while identity headers can no longer leak
-  between concurrent requests through a process-wide `h11` patch. Unsupported
-  transports and conflicting `/sse` or `/mcp` endpoints now fail with clear
-  configuration errors.
+- **Existing MCP deployments keep their configuration and SSE behavior.**
+  The `mcp` strategy now runs on request-scoped Microsoft Agent Framework agents
+  and MCP clients instead of Semantic Kernel. The `sse` transport remains the
+  default, streamed responses are unchanged, and `streamable_http` is also
+  supported. The orchestrator appends `/sse` or `/mcp` once based on the
+  selected transport, and rejects unsupported transports, non-positive
+  timeouts, or a conflicting explicit suffix with an actionable configuration
+  error. Per-request identity headers replace the process-wide `h11` patch,
+  preventing caller context from leaking between concurrent requests.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The **GPT-RAG Orchestrator** service is an agentic orchestration layer built on 
 | `single_agent_rag` | Single Agent RAG | RAG strategy using Azure AI Foundry Agent Service v2 with dynamic routing and direct LLM bypass. |
 | `maf_agent_service` | MAF + Agent Service | Microsoft Agent Framework with Azure AI Foundry Agent Service v2 for server-side threads and tool orchestration, with request-scoped client lifecycle for stable async cleanup. |
 | `maf_lite` | MAF Lite | Microsoft Agent Framework with direct Azure OpenAI model access (no Agent Service dependency). |
-| `mcp` | MCP | Model Context Protocol strategy using Semantic Kernel. |
+| `mcp` | MCP | Request-scoped Microsoft Agent Framework strategy supporting legacy SSE and streamable HTTP MCP servers. |
 | `nl2sql` | NL2SQL | Natural language to SQL translation strategy for structured data queries. |
 
 ### NL2SQL datasource security

--- a/README.md
+++ b/README.md
@@ -29,6 +29,54 @@ The **GPT-RAG Orchestrator** service is an agentic orchestration layer built on 
 | `mcp` | MCP | Request-scoped Microsoft Agent Framework strategy supporting legacy SSE and streamable HTTP MCP servers. |
 | `nl2sql` | NL2SQL | Natural language to SQL translation strategy for structured data queries. |
 
+### MCP strategy configuration
+
+The `mcp` strategy now runs on Microsoft Agent Framework instead of Semantic
+Kernel. Existing SSE deployments remain compatible: keep `AGENT_STRATEGY=mcp`
+and the existing MCP configuration keys. The default transport is still `sse`,
+and the streamed response contract is unchanged.
+
+Configure these values in Azure App Configuration. Use the
+`gpt-rag-orchestrator` label for an orchestrator-specific override, or the
+shared `gpt-rag` label when every component should use the same value:
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `MCP_APP_ENDPOINT` | `http://localhost:80` in Azure; local runs use `http://localhost:5000` | Base URL of the trusted MCP server. HTTPS should be used outside local development. |
+| `MCP_SERVER_TRANSPORT` | `sse` | MCP transport. Supported values are `sse` and `streamable_http`. |
+| `MCP_CLIENT_TIMEOUT` | `600` | Connection and read timeout in seconds. It must be an integer greater than zero. |
+| `MCP_APP_APIKEY` | Unset | Optional API key sent to the MCP server as `X-API-KEY`. Store it as a Key Vault reference, not as plain text. |
+| `AGENT_ID` | Unset | Optional agent identifier passed to the request-scoped Microsoft Agent Framework agent. |
+
+The orchestrator resolves the transport endpoint from `MCP_APP_ENDPOINT`:
+
+| Transport | Endpoint suffix | Example resolved endpoint |
+| --- | --- | --- |
+| `sse` | `/sse` | `https://mcp.contoso.com/sse` |
+| `streamable_http` | `/mcp` | `https://mcp.contoso.com/mcp` |
+
+You can configure the base URL or include the matching suffix. The orchestrator
+adds the suffix once, so both `https://mcp.contoso.com` and
+`https://mcp.contoso.com/sse` resolve to the same SSE endpoint. A conflicting
+suffix fails during strategy initialization. For example,
+`MCP_SERVER_TRANSPORT=streamable_http` with an endpoint ending in `/sse` is
+rejected and the error tells the operator to use `/mcp`.
+
+> [!IMPORTANT]
+> The orchestrator forwards the caller's `user-context` header and, when
+> configured, `X-API-KEY` to this endpoint for every request. Use only a trusted
+> MCP server, require HTTPS outside local development, restrict network access,
+> and keep `MCP_APP_APIKEY` in Key Vault.
+
+For a controlled rollout, leave existing deployments on `sse`, deploy the new
+orchestrator revision, and verify that a representative request discovers and
+calls the expected tools. To adopt streamable HTTP, confirm that the server
+exposes `/mcp`, then change the transport and endpoint together. Monitor startup
+and request logs for invalid transport, conflicting endpoint suffix, timeout,
+or connection errors. Because the configuration names and SSE default are
+unchanged, you can roll back to the previous orchestrator image without
+rewriting the existing SSE configuration.
+
 ### NL2SQL datasource security
 
 > [!IMPORTANT]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     
     # AI/ML
     "openai>=2.9.0",
-    "semantic-kernel>=1.34.0",
     "tiktoken>=0.7.0",
     
     # Data validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,7 @@ tiktoken==0.13.0
 regex>=2022.1.18
 openai==2.41.1
 
-# Semantic Kernel dependencies
-semantic-kernel[mcp]==1.34.0
+# Async and data dependencies
 aiohttp==3.13.4
 pydantic==2.11.4
 
@@ -31,6 +30,7 @@ agent-framework-core==1.0.0b260116
 agent-framework-azure-ai==1.0.0b260116
 agent-framework-azure-ai-search==1.0.0b260116
 opentelemetry-semantic-conventions-ai>=0.4.13,<0.5.0
+mcp>=1.25.0
 
 # Utility dependencies
 tenacity

--- a/src/connectors/mcp_client.py
+++ b/src/connectors/mcp_client.py
@@ -1,0 +1,162 @@
+"""Request-scoped MCP clients for the local Microsoft Agent Framework strategy."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import asynccontextmanager
+from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from agent_framework import MCPStreamableHTTPTool
+from agent_framework._mcp import MCPTool
+from mcp.client.sse import sse_client
+
+MCPTransport = Literal["sse", "streamable_http"]
+_SUPPORTED_TRANSPORTS = frozenset({"sse", "streamable_http"})
+_TRANSPORT_PATHS: dict[MCPTransport, str] = {
+    "sse": "sse",
+    "streamable_http": "mcp",
+}
+
+
+def normalize_mcp_transport(value: str | None) -> MCPTransport:
+    """Validate and normalize the configured MCP transport."""
+
+    transport = (value or "sse").strip().lower()
+    if transport not in _SUPPORTED_TRANSPORTS:
+        raise ValueError(
+            f"Invalid MCP_SERVER_TRANSPORT '{value}'. "
+            "Supported values: sse, streamable_http."
+        )
+    return transport  # type: ignore[return-value]
+
+
+def resolve_mcp_endpoint(endpoint: str | None, transport: str | None) -> str:
+    """Append the transport path once and reject a conflicting explicit path."""
+
+    normalized_transport = normalize_mcp_transport(transport)
+    endpoint_value = (endpoint or "").strip()
+    if not endpoint_value:
+        raise ValueError("MCP_APP_ENDPOINT is required when the MCP strategy is enabled.")
+
+    parsed = urlsplit(endpoint_value)
+    path = parsed.path.rstrip("/")
+    final_segment = path.rsplit("/", 1)[-1].lower() if path else ""
+    expected_segment = _TRANSPORT_PATHS[normalized_transport]
+    conflicting_segment = "mcp" if expected_segment == "sse" else "sse"
+
+    if final_segment == conflicting_segment:
+        raise ValueError(
+            f"MCP_APP_ENDPOINT '{endpoint_value}' conflicts with transport "
+            f"'{normalized_transport}'. Use '/{expected_segment}' for "
+            f"{normalized_transport}."
+        )
+
+    if final_segment == expected_segment:
+        parent_path = path.rsplit("/", 1)[0]
+        path = (
+            f"{parent_path}/{expected_segment}"
+            if parent_path
+            else f"/{expected_segment}"
+        )
+    else:
+        path = f"{path}/{expected_segment}" if path else f"/{expected_segment}"
+
+    return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
+
+
+def build_mcp_headers(
+    user_context: Mapping[str, Any] | None,
+    api_key: str | None,
+) -> dict[str, str]:
+    """Create a fresh header mapping for one caller."""
+
+    headers = {"user-context": json.dumps(dict(user_context or {}))}
+    if api_key:
+        headers["X-API-KEY"] = api_key
+    return headers
+
+
+class LegacySSEMCPTool(MCPTool):
+    """MAF MCP tool adapter for the MCP SDK's legacy SSE transport.
+
+    The pinned MAF release has no public SSE tool, so this adapter subclasses its
+    MCP base and supplies the SDK transport context manager.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        request_timeout: int,
+        httpx_client_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            load_prompts=False,
+            request_timeout=request_timeout,
+        )
+        self.url = url
+        self.headers = dict(headers)
+        self._httpx_client_factory = httpx_client_factory
+
+    def get_mcp_client(self):
+        kwargs: dict[str, Any] = {
+            "url": self.url,
+            "headers": self.headers,
+            "timeout": float(self.request_timeout or 5),
+            "sse_read_timeout": float(self.request_timeout or 300),
+        }
+        if self._httpx_client_factory is not None:
+            kwargs["httpx_client_factory"] = self._httpx_client_factory
+        return sse_client(**kwargs)
+
+
+@asynccontextmanager
+async def open_mcp_tool(
+    *,
+    endpoint: str,
+    transport: str | None,
+    timeout: int,
+    user_context: Mapping[str, Any] | None,
+    api_key: str | None,
+    http_client_factory: Callable[..., httpx.AsyncClient] = httpx.AsyncClient,
+) -> AsyncIterator[MCPTool]:
+    """Open one MCP tool and all of its request-scoped transport resources."""
+
+    if timeout <= 0:
+        raise ValueError("MCP_CLIENT_TIMEOUT must be greater than zero.")
+
+    normalized_transport = normalize_mcp_transport(transport)
+    url = resolve_mcp_endpoint(endpoint, normalized_transport)
+    headers = build_mcp_headers(user_context, api_key)
+
+    if normalized_transport == "sse":
+        tool = LegacySSEMCPTool(
+            name="McpServerPlugin",
+            url=url,
+            headers=headers,
+            request_timeout=timeout,
+        )
+        async with tool:
+            yield tool
+        return
+
+    http_client = http_client_factory(
+        headers=headers,
+        timeout=httpx.Timeout(float(timeout)),
+    )
+    async with http_client:
+        tool = MCPStreamableHTTPTool(
+            name="McpServerPlugin",
+            url=url,
+            request_timeout=timeout,
+            load_prompts=False,
+            http_client=http_client,
+        )
+        async with tool:
+            yield tool

--- a/src/plugins/common/plugin.py
+++ b/src/plugins/common/plugin.py
@@ -1,16 +1,22 @@
-from semantic_kernel.functions import kernel_function
 from datetime import datetime
+
+from agent_framework import ai_function
+
 
 class CommonPlugin:
 
-    @kernel_function(name="GetTodayDate",
-                 description="The output is today's date in string format")
+    @ai_function(
+        name="GetTodayDate",
+        description="The output is today's date in string format",
+    )
     def get_today_date(self) -> str:
         today = datetime.now().strftime("%Y-%m-%d")
         return f"Today's date is {today}"
 
-    @kernel_function(name="GetTime",
-                 description="The output is the current time (hour and minutes) in HH:MM format")
+    @ai_function(
+        name="GetTime",
+        description="The output is the current time (hour and minutes) in HH:MM format",
+    )
     def get_time(self) -> str:
         current_time = datetime.now().strftime("%H:%M")
         return f"The current time is {current_time}"

--- a/src/plugins/retrieval/plugin.py
+++ b/src/plugins/retrieval/plugin.py
@@ -1,4 +1,3 @@
-import os
 import re
 import time
 import json
@@ -8,7 +7,7 @@ from typing import Annotated, Optional, List, Dict, Any
 from urllib.parse import urlparse
 
 import aiohttp
-from semantic_kernel.functions import kernel_function
+from agent_framework import ai_function
 from connectors.identity_manager import get_identity_manager
 from dependencies import get_config
 from connectors import AzureOpenAIClient
@@ -53,7 +52,7 @@ class RetrievalPlugin:
                 logging.error("Error during asynchronous HTTP request.", exc_info=True)
                 raise Exception("Failed to execute search query.") from e
 
-    @kernel_function(
+    @ai_function(
         name="VectorIndexRetrieve",
         description="Performs a vector search against Azure Cognitive Search and returns the results as a string."
     )
@@ -139,7 +138,7 @@ class RetrievalPlugin:
             content = content.replace(image_path, image_url)
         return content
 
-    @kernel_function(
+    @ai_function(
         name="MultimodalVectorIndexRetrieve",
         description="Performs a multimodal vector search and returns texts, images, and captions."
     )
@@ -241,7 +240,7 @@ class RetrievalPlugin:
             error=error_message
         )
 
-    @kernel_function(
+    @ai_function(
         name="GetDataPointsFromChatLog",
         description="Extracts data points (e.g., filenames) from a chat log."
     )

--- a/src/strategies/base_agent_strategy.py
+++ b/src/strategies/base_agent_strategy.py
@@ -1,10 +1,9 @@
-import h11
 import logging
 import os
 import re
 import json
 
-from typing import Any, Dict, AsyncIterator, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
 from abc import ABC, abstractmethod
 from azure.ai.projects.aio import AIProjectClient
 from connectors.appconfig import AppConfigClient

--- a/src/strategies/mcp_strategy.py
+++ b/src/strategies/mcp_strategy.py
@@ -1,306 +1,209 @@
-import json
-import h11
+import asyncio
 import logging
+import time
+from typing import Any
+from urllib.parse import urlsplit
 
-from typing import Any, Optional
-
-from util.tools import is_azure_environment
+from agent_framework import ChatAgent, Role, TextContent, UsageContent
+from agent_framework.azure import AzureOpenAIChatClient
 from azure.identity import get_bearer_token_provider
+from opentelemetry.trace import SpanKind
 
-from azure.ai.agents.models import (
-    AsyncAgentEventHandler,
-    MessageDeltaChunk,
-    MessageDeltaTextUrlCitationAnnotation,
-    RunStep,
-    ThreadMessage,
-    ThreadRun,
+from connectors.mcp_client import (
+    normalize_mcp_transport,
+    open_mcp_tool,
+    resolve_mcp_endpoint,
 )
-
-from opentelemetry.trace import (
-    SpanKind,
-    format_span_id,
-    format_trace_id,
-    get_current_span
-)
-
-from semantic_kernel import Kernel
-from semantic_kernel.agents import ChatCompletionAgent
-from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
-from semantic_kernel.connectors.ai import FunctionChoiceBehavior
-from semantic_kernel.connectors.mcp import MCPSsePlugin
-
-from .base_agent_strategy import BaseAgentStrategy
-from .agent_strategies import AgentStrategies
-
-from connectors.appconfig import AppConfigClient
-from dependencies import get_config
 from telemetry import Telemetry
+from util.tools import is_azure_environment
+
+from .agent_strategies import AgentStrategies
+from .base_agent_strategy import BaseAgentStrategy
 
 tracer = Telemetry.get_tracer(__name__)
 
+
 class McpStrategy(BaseAgentStrategy):
-    """
-    Implements a MCP Server strategy. This class handles creating an agent, sending
-    a user message, streaming the response, and cleaning up resources.
-    """
+    """Run a request-scoped local MAF agent with tools from an MCP server."""
 
-    #override this method in subclasses to provide custom headers for user identity
-    def write_headers(self, headers, write) -> None:
-        # "Since the Host field-value is critical information for handling a
-        # request, a user agent SHOULD generate Host as the first header field
-        # following the request-line." - RFC 7230
-        raw_items = headers._full_items
-        for raw_name, name, value in raw_items:
-            if name == b"host":
-                write(b"%s: %s\r\n" % (raw_name, value))
-        for raw_name, name, value in raw_items:
-            if name != b"host":
-                write(b"%s: %s\r\n" % (raw_name, value))
-
-        #write the user context header if it exists
-        if self.user_context:
-            write(b"user-context: %s\r\n" % json.dumps(self.user_context).encode('utf-8'))
-        write(b"\r\n")
-
-    def __init__(self):
-        """
-        Initialize base credentials and tools.
-        """
+    def __init__(self) -> None:
         super().__init__()
-
-        # Force all logs at DEBUG or above to appear
-        logging.debug("Initializing McpStrategy...")
-
-        # Event handler for streaming responses
         self.strategy_type = AgentStrategies.MCP
-        self.event_handler = EventHandler()
-
-        cfg = get_config()
-
-        # Agent Tools Initialization Section
-        # =========================================================
-
-        # Allow the user to specify an existing agent ID (optional)
-        self.existing_agent_id = cfg.get("AGENT_ID", "") or None
-
-        # need to inject the user_context header into the h11 writer
-        # this is a workaround for the fact that h11 does not support custom headers
-        h11._writers.write_headers = self.write_headers
-    
-    async def create():
-        cfg = get_config()
-        instance = McpStrategy()
-        instance.config = cfg
-        instance.kernel = Kernel()
-
-        # Agent Tools Initialization Section
-        # =========================================================
-        instance.tools_list = []
-        instance.tool_resources = {}
-        
-        logging.debug(f"Final tools_list: {instance.tools_list}")
-        logging.debug(f"Final tool_resources: {instance.tool_resources}")
-
-        token_provider = get_bearer_token_provider(
-            cfg.credential,
-            "https://ai.azure.com/.default"
+        self.existing_agent_id = self.cfg.get("AGENT_ID", "") or None
+        self.mcp_server_timeout = self.cfg.get(
+            "MCP_CLIENT_TIMEOUT",
+            default=600,
+            type=int,
+        )
+        self.mcp_server_api_key = self.cfg.get("MCP_APP_APIKEY", default=None)
+        self.mcp_server_transport = normalize_mcp_transport(
+            self.cfg.get("MCP_SERVER_TRANSPORT", default="sse")
         )
 
-        instance.model = instance._get_model()
-
-        instance.kernel.add_service(AzureChatCompletion(
-            service_id=instance.model.get("name"),
-            deployment_name=instance.model.get("name"),
-            endpoint=instance.model.get("endpoint"),
-            api_version=instance.model.get("version"),
-            ad_token_provider= token_provider
-        ))
-
-        instance.agent = ChatCompletionAgent(
-            kernel=instance.kernel,
-            #function_choice_behavior=FunctionChoiceBehavior.AUTO,
-            name="MultiPluginAgent",
-            #plugins=instance.tools_list
+        endpoint = self.cfg.get(
+            "MCP_APP_ENDPOINT",
+            default="http://localhost:80",
         )
-
-        return instance
-    
-    async def _create_mcp_plugin(self, extra_headers: Optional[dict] = {}) -> MCPSsePlugin:
-        # Add an MCP Server tool if configured
-        mcp_server_url = self.cfg.get("MCP_APP_ENDPOINT", default="http://localhost:80") + "/sse"
-
         if not is_azure_environment():
-            mcp_server_url = 'http://localhost:5000/sse'
+            endpoint = "http://localhost:5000"
+        self.mcp_server_url = resolve_mcp_endpoint(
+            endpoint,
+            self.mcp_server_transport,
+        )
 
-        mcp_server_timeout = self.cfg.get("MCP_CLIENT_TIMEOUT", default=600, type=int)
-        mcp_server_api_key = self.cfg.get("MCP_APP_APIKEY", default=None)
-        mcp_server_transport = self.cfg.get("MCP_SERVER_TRANSPORT", default="sse")
+        self.model: dict[str, Any] | None = None
+        self._token_provider = None
 
-        if mcp_server_url:
-            logging.debug(f"Adding MCP Server tool with URL: {mcp_server_url}")
+    @classmethod
+    async def create(cls) -> "McpStrategy":
+        instance = cls()
+        instance.model = instance._get_model()
+        if not instance.model:
+            raise ValueError(
+                "MODEL_DEPLOYMENTS must contain the configured chat deployment."
+            )
+        instance._token_provider = get_bearer_token_provider(
+            instance.cfg.credential,
+            "https://ai.azure.com/.default",
+        )
+        return instance
 
-            headers = {
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-                'user-context': json.dumps(self.user_context) if self.user_context else '{}'
-            }
+    def _create_chat_client(self) -> AzureOpenAIChatClient:
+        if self.model is None or self._token_provider is None:
+            raise RuntimeError("MCP strategy has not been initialized.")
+        return AzureOpenAIChatClient(
+            deployment_name=self.model["name"],
+            endpoint=self.model["endpoint"],
+            api_version=self.model["version"],
+            ad_token_provider=self._token_provider,
+        )
 
-            # Add any extra headers provided
-            if extra_headers:
-                logging.debug(f"Adding extra headers: {extra_headers}")
-                headers.update(extra_headers)
+    @staticmethod
+    def _assistant_text(update: Any) -> str:
+        role = getattr(update.role, "value", update.role)
+        if role != Role.ASSISTANT.value:
+            return ""
+        return "".join(
+            content.text
+            for content in update.contents
+            if isinstance(content, TextContent)
+        )
 
-            if mcp_server_api_key:
-                logging.debug("MCP Server API key provided; adding to headers.")
-                headers["X-API-KEY"] = f"{mcp_server_api_key}"
-
-            if mcp_server_transport == "sse":
-                # Use the MCPSsePlugin for SSE transport
-                logging.debug("Using MCPSsePlugin for MCP Server with SSE transport.")
-                plugin = MCPSsePlugin(
-                    name="McpServerPlugin",
-                    url=mcp_server_url,
-                    headers=headers,
-                    timeout=mcp_server_timeout,
-                    kernel=self.kernel
-                )
-
-                await plugin.connect()
-
-                return plugin
-
-        else:
-            logging.debug("No MCP Server URL provided; skipping MCP Server tool initialization.")
-
+    @staticmethod
+    def _usage(update: Any) -> tuple[int, int]:
+        prompt_tokens = 0
+        completion_tokens = 0
+        for content in update.contents:
+            if not isinstance(content, UsageContent):
+                continue
+            prompt_tokens += content.details.input_token_count or 0
+            completion_tokens += content.details.output_token_count or 0
+        return prompt_tokens, completion_tokens
 
     async def initiate_agent_flow(self, user_message: str):
-        """
-        Sends a user message and yields streamed chunks.
-        Manages thread creation/reuse entirely here, storing both
-        agent_id, thread_id and full messages list in self.conversation.
-        """
-        logging.debug(f"invoke_stream called with user_message: {user_message!r}")
+        """Stream assistant text and persist exactly the emitted response."""
+
         conv = self.conversation
-        thread_id = conv.get("thread_id")
-        logging.debug(f"Current conversation state: thread_id={thread_id}")
+        full_response_parts: list[str] = []
+        prompt_tokens = 0
+        completion_tokens = 0
+        request_status = "error"
+        connection_started = time.monotonic()
+        stream_started: float | None = None
+        connection_latency_ms = 0.0
+        stream_latency_ms = 0.0
+        tool_count = 0
+        mcp_host = urlsplit(self.mcp_server_url).hostname or ""
 
-        conv["agent_id"] = self.agent.id
+        with tracer.start_as_current_span(
+            "initiate_agent_flow",
+            kind=SpanKind.CLIENT,
+        ) as span:
+            span.set_attribute("agent.strategy", self.strategy_type.value)
+            span.set_attribute("agent.id", self.existing_agent_id or "generated")
+            span.set_attribute("mcp.transport", self.mcp_server_transport)
+            span.set_attribute("mcp.host", mcp_host)
 
-        plugin = await self._create_mcp_plugin(extra_headers={})
+            try:
+                async with open_mcp_tool(
+                    endpoint=self.mcp_server_url,
+                    transport=self.mcp_server_transport,
+                    timeout=self.mcp_server_timeout,
+                    user_context=self.user_context,
+                    api_key=self.mcp_server_api_key,
+                ) as mcp_tool:
+                    connection_latency_ms = (
+                        time.monotonic() - connection_started
+                    ) * 1000
+                    tool_count = len(mcp_tool.functions)
+                    span.set_attribute("mcp.tool_count", tool_count)
 
-        self.kernel.add_plugin(plugin)
+                    chat_client = self._create_chat_client()
+                    async with ChatAgent(
+                        chat_client=chat_client,
+                        id=self.existing_agent_id,
+                        name="MultiPluginAgent",
+                        tools=mcp_tool.functions,
+                    ) as agent:
+                        conv["agent_id"] = agent.id
+                        thread = agent.get_new_thread()
+                        stream_started = time.monotonic()
 
-        with tracer.start_as_current_span('initiate_agent_flow', kind=SpanKind.CLIENT) as span:
-        
-            response = await self.agent.get_response(messages=user_message)
+                        async for update in agent.run_stream(
+                            user_message,
+                            thread=thread,
+                        ):
+                            update_prompt_tokens, update_completion_tokens = (
+                                self._usage(update)
+                            )
+                            prompt_tokens += update_prompt_tokens
+                            completion_tokens += update_completion_tokens
 
-            yield response
-        
-            conv["messages"] = []
-            conv["messages"].append({
-                "role": "system",
-                "text": response.message.content
-            })
-            conv['completion_tokens'] = response.metadata.get('usage').completion_tokens
-            conv['prompt_tokens'] = response.metadata.get('usage').prompt_tokens
+                            text = self._assistant_text(update)
+                            if not text:
+                                continue
+                            full_response_parts.append(text)
+                            yield text
 
-            if self.user_context:
-                conv['user_context'] = self.user_context
+                        stream_latency_ms = (
+                            time.monotonic() - stream_started
+                        ) * 1000
 
-            logging.debug(f"Final conversation messages: {conv['messages']}")
-
-class EventHandler(AsyncAgentEventHandler[str]):
-    """
-    Handles events emitted during the agent run lifecycle,
-    converting each into a human-readable string.
-    """
-
-    async def on_message_delta(self, delta: MessageDeltaChunk) -> Optional[str]:
-        """
-        Called when a partial message is received.
-        :param delta: Chunk of the message text.
-        :return: The text chunk.
-        """
-        logging.debug(f"EventHandler.on_message_delta called with delta={delta!r}")
-        text = delta.text
-
-        # Collect annotation objects, if any
-        raw = getattr(delta, "delta", None)
-        annotations = []
-        if raw:
-            for piece in getattr(raw, "content", []):
-                txt = getattr(piece, "text", None)
-                if not txt:
-                    continue
-                anns = getattr(txt, "annotations", None)
-                if not anns:
-                    continue
-                annotations.extend(anns)
-
-        for ann in annotations:
-            if isinstance(ann, MessageDeltaTextUrlCitationAnnotation) and "url_citation" in ann:
-                info = ann["url_citation"]
-                placeholder = ann["text"]
-            else:
-                continue
-            url = info.get("url")
-            title = info.get("title", url)
-            if url and placeholder:
-                text = text.replace(placeholder, f"[{title}]({url})")
-
-        # logging.trace(f"on_message_delta returning text={text!r}")
-        return text
-
-    async def on_thread_message(self, message: ThreadMessage) -> Optional[str]:
-        """
-        Called when a new thread message object is created.
-        :param message: The ThreadMessage instance.
-        :return: Summary including message ID and status.
-        """
-        logging.debug(f"EventHandler.on_thread_message called: ID={message.id}, status={message.status}")
-        return f"Thread message created: ID={message.id}, status={message.status}"
-
-    async def on_thread_run(self, run: ThreadRun) -> Optional[str]:
-        """
-        Called when a new thread run event occurs.
-        :param run: The ThreadRun instance.
-        :return: Summary of the run status.
-        """
-        logging.debug(f"EventHandler.on_thread_run called: status={run.status}")
-        return f"Thread run status: {run.status}"
-
-    async def on_run_step(self, step: RunStep) -> Optional[str]:
-        """
-        Called at each step of the run pipeline.
-        :param step: The RunStep instance.
-        :return: Type and status of the step.
-        """
-        logging.debug(f"EventHandler.on_run_step called: type={step.type}, status={step.status}")
-        return f"Run step: type={step.type}, status={step.status}"
-
-    async def on_error(self, data: str) -> Optional[str]:
-        """
-        Called when an error occurs during the stream.
-        :param data: Error information.
-        :return: Formatted error message.
-        """
-        logging.debug(f"EventHandler.on_error called with data={data!r}")
-        return f"Error in stream: {data}"
-
-    async def on_done(self) -> Optional[str]:
-        """
-        Called when the streaming completes successfully.
-        :return: Completion message.
-        """
-        logging.debug("EventHandler.on_done called")
-        return "Streaming completed"
-
-    async def on_unhandled_event(self, event_type: str, event_data: Any) -> Optional[str]:
-        """
-        Catches any events not handled by other methods.
-        :param event_type: The type identifier of the event.
-        :param event_data: The raw event payload.
-        :return: Description of the unhandled event.
-        """
-        logging.debug(f"EventHandler.on_unhandled_event called: type={event_type}, data={event_data!r}")
-        return f"Unhandled event: type={event_type}, data={event_data}"
+                full_response = "".join(full_response_parts)
+                conv["messages"] = [
+                    {
+                        "role": "system",
+                        "text": full_response,
+                    }
+                ]
+                conv["completion_tokens"] = completion_tokens
+                conv["prompt_tokens"] = prompt_tokens
+                if self.user_context:
+                    conv["user_context"] = self.user_context
+                request_status = "success"
+            except asyncio.CancelledError:
+                request_status = "cancelled"
+                raise
+            finally:
+                if stream_started is not None and stream_latency_ms == 0.0:
+                    stream_latency_ms = (
+                        time.monotonic() - stream_started
+                    ) * 1000
+                span.set_attribute(
+                    "mcp.connection_latency_ms",
+                    connection_latency_ms,
+                )
+                span.set_attribute("agent.stream_latency_ms", stream_latency_ms)
+                span.set_attribute("agent.request_status", request_status)
+                logging.info(
+                    "[McpStrategy] Request finished transport=%s host=%s "
+                    "agent_id=%s status=%s tools=%s connection_ms=%.2f "
+                    "stream_ms=%.2f",
+                    self.mcp_server_transport,
+                    mcp_host,
+                    conv.get("agent_id", self.existing_agent_id or "generated"),
+                    request_status,
+                    tool_count,
+                    connection_latency_ms,
+                    stream_latency_ms,
+                )

--- a/src/strategies/mcp_strategy.py
+++ b/src/strategies/mcp_strategy.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 import time
 from typing import Any
 from urllib.parse import urlsplit
@@ -114,6 +115,7 @@ class McpStrategy(BaseAgentStrategy):
         stream_latency_ms = 0.0
         tool_count = 0
         mcp_host = urlsplit(self.mcp_server_url).hostname or ""
+        chat_client: AzureOpenAIChatClient | None = None
 
         with tracer.start_as_current_span(
             "initiate_agent_flow",
@@ -185,6 +187,21 @@ class McpStrategy(BaseAgentStrategy):
                 request_status = "cancelled"
                 raise
             finally:
+                primary_exception = sys.exception()
+                cleanup_error: BaseException | None = None
+                if chat_client is not None:
+                    try:
+                        await chat_client.client.close()
+                    except BaseException:
+                        if primary_exception is not None:
+                            logging.exception(
+                                "[McpStrategy] Failed to close chat client while "
+                                "preserving the primary exception."
+                            )
+                        else:
+                            request_status = "error"
+                            cleanup_error = sys.exception()
+
                 if stream_started is not None and stream_latency_ms == 0.0:
                     stream_latency_ms = (
                         time.monotonic() - stream_started
@@ -207,3 +224,5 @@ class McpStrategy(BaseAgentStrategy):
                     connection_latency_ms,
                     stream_latency_ms,
                 )
+                if cleanup_error is not None:
+                    raise cleanup_error

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,301 @@
+import asyncio
+import json
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+from agent_framework import TextContent
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+
+from connectors import mcp_client
+from connectors.mcp_client import (
+    LegacySSEMCPTool,
+    build_mcp_headers,
+    normalize_mcp_transport,
+    open_mcp_tool,
+    resolve_mcp_endpoint,
+)
+
+
+@pytest.mark.parametrize(
+    ("transport", "expected"),
+    [
+        (None, "sse"),
+        ("sse", "sse"),
+        (" SSE ", "sse"),
+        ("streamable_http", "streamable_http"),
+    ],
+)
+def test_normalize_mcp_transport(transport, expected):
+    assert normalize_mcp_transport(transport) == expected
+
+
+def test_normalize_mcp_transport_rejects_unsupported_value():
+    with pytest.raises(
+        ValueError,
+        match="Supported values: sse, streamable_http",
+    ):
+        normalize_mcp_transport("websocket")
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "transport", "expected"),
+    [
+        ("https://example.test", "sse", "https://example.test/sse"),
+        ("https://example.test/", "sse", "https://example.test/sse"),
+        ("https://example.test/sse", "sse", "https://example.test/sse"),
+        ("https://example.test/sse/", "sse", "https://example.test/sse"),
+        (
+            "https://example.test/api?tenant=one",
+            "streamable_http",
+            "https://example.test/api/mcp?tenant=one",
+        ),
+        (
+            "https://example.test/api/mcp",
+            "streamable_http",
+            "https://example.test/api/mcp",
+        ),
+        (
+            "https://example.test/api/MCP/",
+            "streamable_http",
+            "https://example.test/api/mcp",
+        ),
+    ],
+)
+def test_resolve_mcp_endpoint_is_idempotent(
+    endpoint,
+    transport,
+    expected,
+):
+    assert resolve_mcp_endpoint(endpoint, transport) == expected
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "transport", "expected_path"),
+    [
+        ("https://example.test/mcp", "sse", "/sse"),
+        ("https://example.test/sse", "streamable_http", "/mcp"),
+    ],
+)
+def test_resolve_mcp_endpoint_rejects_conflicting_path(
+    endpoint,
+    transport,
+    expected_path,
+):
+    with pytest.raises(ValueError, match=expected_path):
+        resolve_mcp_endpoint(endpoint, transport)
+
+
+def test_build_mcp_headers_only_sets_request_identity_and_optional_key():
+    headers = build_mcp_headers({"principal_id": "user-1"}, "secret")
+
+    assert json.loads(headers["user-context"]) == {"principal_id": "user-1"}
+    assert headers["X-API-KEY"] == "secret"
+    assert "Content-Type" not in headers
+    assert "Accept" not in headers
+    assert build_mcp_headers(None, None) == {"user-context": "{}"}
+
+
+def test_legacy_sse_adapter_uses_request_scoped_headers(monkeypatch):
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_sse_client(**kwargs):
+        captured.update(kwargs)
+        yield object(), object()
+
+    monkeypatch.setattr(mcp_client, "sse_client", fake_sse_client)
+    tool = LegacySSEMCPTool(
+        name="test",
+        url="https://example.test/sse",
+        headers={"user-context": '{"principal_id": "one"}'},
+        request_timeout=42,
+    )
+
+    tool.get_mcp_client()
+
+    assert captured == {}
+    context_manager = tool.get_mcp_client()
+
+    async def enter_context():
+        async with context_manager:
+            pass
+
+    asyncio.run(enter_context())
+    assert captured["headers"] == {
+        "user-context": '{"principal_id": "one"}',
+    }
+    assert captured["timeout"] == 42.0
+    assert captured["sse_read_timeout"] == 42.0
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_clients_isolate_concurrent_users(monkeypatch):
+    clients = []
+    tools = []
+
+    class FakeHTTPClient:
+        def __init__(self, **kwargs):
+            self.headers = kwargs["headers"]
+            self.timeout = kwargs["timeout"]
+            self.closed = False
+            clients.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            self.closed = True
+
+    class FakeMCPTool:
+        def __init__(self, **kwargs):
+            self.http_client = kwargs["http_client"]
+            self.functions = []
+            self.closed = False
+            tools.append(self)
+
+        async def __aenter__(self):
+            await asyncio.sleep(0)
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            self.closed = True
+
+    monkeypatch.setattr(
+        mcp_client,
+        "MCPStreamableHTTPTool",
+        FakeMCPTool,
+    )
+
+    async def connect(principal_id):
+        async with open_mcp_tool(
+            endpoint="https://example.test",
+            transport="streamable_http",
+            timeout=30,
+            user_context={"principal_id": principal_id},
+            api_key=f"key-{principal_id}",
+            http_client_factory=FakeHTTPClient,
+        ):
+            await asyncio.sleep(0)
+
+    await asyncio.gather(connect("one"), connect("two"))
+
+    assert len(clients) == 2
+    assert clients[0].headers is not clients[1].headers
+    observed_contexts = {
+        json.loads(client.headers["user-context"])["principal_id"]
+        for client in clients
+    }
+    assert observed_contexts == {"one", "two"}
+    assert {client.headers["X-API-KEY"] for client in clients} == {
+        "key-one",
+        "key-two",
+    }
+    assert all(client.closed for client in clients)
+    assert all(tool.closed for tool in tools)
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_cleanup_runs_when_caller_fails(monkeypatch):
+    state = {"client_closed": False, "tool_closed": False}
+
+    class FakeHTTPClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            state["client_closed"] = True
+
+    class FakeMCPTool:
+        def __init__(self, **kwargs):
+            self.functions = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            state["tool_closed"] = True
+
+    monkeypatch.setattr(
+        mcp_client,
+        "MCPStreamableHTTPTool",
+        FakeMCPTool,
+    )
+
+    with pytest.raises(RuntimeError, match="caller failed"):
+        async with open_mcp_tool(
+            endpoint="https://example.test",
+            transport="streamable_http",
+            timeout=30,
+            user_context={},
+            api_key=None,
+            http_client_factory=FakeHTTPClient,
+        ):
+            raise RuntimeError("caller failed")
+
+    assert state == {"client_closed": True, "tool_closed": True}
+
+
+class _CaptureHeaders:
+    def __init__(self, app):
+        self.app = app
+        self.requests = []
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            self.requests.append(
+                {
+                    key.decode().lower(): value.decode()
+                    for key, value in scope["headers"]
+                }
+            )
+        await self.app(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_in_process_transport_contract():
+    server = FastMCP(
+        "contract-test",
+        stateless_http=True,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
+    )
+
+    @server.tool()
+    def echo(text: str) -> str:
+        return text
+
+    app = server.streamable_http_app()
+    captured_app = _CaptureHeaders(app)
+
+    def client_factory(**kwargs):
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=captured_app),
+            base_url="http://test",
+            **kwargs,
+        )
+
+    async with app.router.lifespan_context(app):
+        async with open_mcp_tool(
+            endpoint="http://test",
+            transport="streamable_http",
+            timeout=30,
+            user_context={"principal_id": "contract-user"},
+            api_key="contract-key",
+            http_client_factory=client_factory,
+        ) as tool:
+            assert [function.name for function in tool.functions] == ["echo"]
+            result = await tool.call_tool("echo", text="hello")
+
+    assert any(
+        request["user-context"] == '{"principal_id": "contract-user"}'
+        and request["x-api-key"] == "contract-key"
+        for request in captured_app.requests
+    )
+    assert isinstance(result[0], TextContent)
+    assert result[0].text == "hello"

--- a/tests/test_mcp_strategy.py
+++ b/tests/test_mcp_strategy.py
@@ -3,7 +3,7 @@ import ast
 import inspect
 from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import h11
 import pytest
@@ -84,6 +84,12 @@ class _FakeAgent:
             await asyncio.Event().wait()
 
 
+class _FakeChatClient:
+    def __init__(self, *, close_error: BaseException | None = None):
+        self.client = MagicMock()
+        self.client.close = AsyncMock(side_effect=close_error)
+
+
 def _fake_mcp_context(state):
     @asynccontextmanager
     async def open_tool(**kwargs):
@@ -106,6 +112,7 @@ async def test_mcp_strategy_streams_assistant_text_and_sums_usage(
     strategy.conversation = {"id": "conversation"}
     strategy.user_context = {"principal_id": "user-one"}
     state = {}
+    chat_client = _FakeChatClient()
     fake_agent = _FakeAgent(
         [
             AgentResponseUpdate(role="assistant", text="Hello "),
@@ -149,7 +156,7 @@ async def test_mcp_strategy_streams_assistant_text_and_sums_usage(
         patch.object(
             strategy,
             "_create_chat_client",
-            return_value=MagicMock(),
+            return_value=chat_client,
         ),
     ):
         chunks = [
@@ -168,6 +175,7 @@ async def test_mcp_strategy_streams_assistant_text_and_sums_usage(
     }
     assert state["closed"] is True
     assert fake_agent.closed is True
+    chat_client.client.close.assert_awaited_once_with()
     assert state["open_kwargs"]["user_context"] == {
         "principal_id": "user-one"
     }
@@ -184,6 +192,7 @@ async def test_mcp_strategy_cleans_up_after_stream_error(
     strategy = await _create_strategy(mock_config)
     strategy.conversation = {}
     state = {}
+    chat_client = _FakeChatClient()
     fake_agent = _FakeAgent(error=RuntimeError("model failed"))
 
     with (
@@ -198,7 +207,7 @@ async def test_mcp_strategy_cleans_up_after_stream_error(
         patch.object(
             strategy,
             "_create_chat_client",
-            return_value=MagicMock(),
+            return_value=chat_client,
         ),
     ):
         with pytest.raises(RuntimeError, match="model failed"):
@@ -209,6 +218,7 @@ async def test_mcp_strategy_cleans_up_after_stream_error(
 
     assert state["closed"] is True
     assert fake_agent.closed is True
+    chat_client.client.close.assert_awaited_once_with()
     assert "messages" not in strategy.conversation
 
 
@@ -220,6 +230,7 @@ async def test_mcp_strategy_cleans_up_after_cancellation(
     strategy = await _create_strategy(mock_config)
     strategy.conversation = {}
     state = {}
+    chat_client = _FakeChatClient()
     fake_agent = _FakeAgent(
         [AgentResponseUpdate(role="assistant", text="started")],
         block=True,
@@ -241,7 +252,7 @@ async def test_mcp_strategy_cleans_up_after_cancellation(
         patch.object(
             strategy,
             "_create_chat_client",
-            return_value=MagicMock(),
+            return_value=chat_client,
         ),
     ):
         task = asyncio.create_task(consume())
@@ -252,7 +263,131 @@ async def test_mcp_strategy_cleans_up_after_cancellation(
 
     assert state["closed"] is True
     assert fake_agent.closed is True
+    chat_client.client.close.assert_awaited_once_with()
     assert "messages" not in strategy.conversation
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_preserves_agent_error_when_chat_cleanup_fails(
+    patch_dependencies,
+    mock_config,
+    caplog,
+):
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {}
+    state = {}
+    close_error = RuntimeError("chat close failed")
+    chat_client = _FakeChatClient(close_error=close_error)
+    fake_agent = _FakeAgent(error=RuntimeError("model failed"))
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ),
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=chat_client,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="model failed"):
+            _ = [
+                chunk
+                async for chunk in strategy.initiate_agent_flow("prompt")
+            ]
+
+    assert state["closed"] is True
+    assert fake_agent.closed is True
+    chat_client.client.close.assert_awaited_once_with()
+    assert "Failed to close chat client" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_preserves_cancellation_when_chat_cleanup_fails(
+    patch_dependencies,
+    mock_config,
+    caplog,
+):
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {}
+    state = {}
+    chat_client = _FakeChatClient(close_error=RuntimeError("chat close failed"))
+    fake_agent = _FakeAgent(
+        [AgentResponseUpdate(role="assistant", text="started")],
+        block=True,
+    )
+
+    async def consume():
+        async for _ in strategy.initiate_agent_flow("prompt"):
+            pass
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ),
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=chat_client,
+        ),
+    ):
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(fake_agent.blocking.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert state["closed"] is True
+    assert fake_agent.closed is True
+    chat_client.client.close.assert_awaited_once_with()
+    assert "Failed to close chat client" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_surfaces_chat_cleanup_error_without_primary_error(
+    patch_dependencies,
+    mock_config,
+):
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {}
+    state = {}
+    chat_client = _FakeChatClient(close_error=RuntimeError("chat close failed"))
+    fake_agent = _FakeAgent([AgentResponseUpdate(role="assistant", text="done")])
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ),
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=chat_client,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="chat close failed"):
+            _ = [
+                chunk
+                async for chunk in strategy.initiate_agent_flow("prompt")
+            ]
+
+    assert state["closed"] is True
+    assert fake_agent.closed is True
+    chat_client.client.close.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_strategy.py
+++ b/tests/test_mcp_strategy.py
@@ -1,0 +1,374 @@
+import asyncio
+import ast
+import inspect
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import h11
+import pytest
+from agent_framework import AgentResponseUpdate, TextContent, UsageContent, UsageDetails
+
+
+async def _create_strategy(mock_config, *, overrides=None):
+    values = {
+        "AGENT_ID": "configured-agent",
+        "MCP_APP_ENDPOINT": "https://mcp.example.test",
+        "MCP_CLIENT_TIMEOUT": 90,
+        "MCP_APP_APIKEY": "api-key",
+        "MCP_SERVER_TRANSPORT": "sse",
+    }
+    values.update(overrides or {})
+    original_get = mock_config.get.side_effect
+
+    def get_value(key, default=None, type=str):  # noqa: A002
+        if key in values:
+            return values[key]
+        return original_get(key, default, type)
+
+    mock_config.get.side_effect = get_value
+
+    from strategies.mcp_strategy import McpStrategy
+
+    with (
+        patch(
+            "strategies.mcp_strategy.is_azure_environment",
+            return_value=True,
+        ),
+        patch.object(
+            McpStrategy,
+            "_get_model",
+            return_value={
+                "name": "gpt-4o",
+                "endpoint": "https://models.example.test",
+                "version": "2025-04-01-preview",
+            },
+        ),
+        patch(
+            "strategies.mcp_strategy.get_bearer_token_provider",
+            return_value=MagicMock(name="token_provider"),
+        ),
+    ):
+        return await McpStrategy.create()
+
+
+class _FakeAgent:
+    def __init__(self, updates=None, *, error=None, block=False):
+        self.id = "configured-agent"
+        self.updates = updates or []
+        self.error = error
+        self.block = block
+        self.entered = False
+        self.closed = False
+        self.thread = object()
+        self.blocking = asyncio.Event()
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self.closed = True
+
+    def get_new_thread(self):
+        return self.thread
+
+    async def run_stream(self, messages, *, thread):
+        assert thread is self.thread
+        if self.error:
+            raise self.error
+        for update in self.updates:
+            yield update
+        if self.block:
+            self.blocking.set()
+            await asyncio.Event().wait()
+
+
+def _fake_mcp_context(state):
+    @asynccontextmanager
+    async def open_tool(**kwargs):
+        state["open_kwargs"] = kwargs
+        state["entered"] = True
+        try:
+            yield MagicMock(functions=[object(), object()])
+        finally:
+            state["closed"] = True
+
+    return open_tool
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_streams_assistant_text_and_sums_usage(
+    patch_dependencies,
+    mock_config,
+):
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {"id": "conversation"}
+    strategy.user_context = {"principal_id": "user-one"}
+    state = {}
+    fake_agent = _FakeAgent(
+        [
+            AgentResponseUpdate(role="assistant", text="Hello "),
+            AgentResponseUpdate(role="tool", text="private tool result"),
+            AgentResponseUpdate(
+                role="assistant",
+                contents=[
+                    UsageContent(
+                        UsageDetails(
+                            input_token_count=10,
+                            output_token_count=4,
+                        )
+                    )
+                ],
+            ),
+            AgentResponseUpdate(role=None, text="not assistant"),
+            AgentResponseUpdate(role="assistant", text="world"),
+            AgentResponseUpdate(
+                role="assistant",
+                contents=[
+                    UsageContent(
+                        UsageDetails(
+                            input_token_count=7,
+                            output_token_count=3,
+                        )
+                    )
+                ],
+            ),
+        ]
+    )
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ) as chat_agent,
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        chunks = [
+            chunk
+            async for chunk in strategy.initiate_agent_flow("private prompt")
+        ]
+
+    assert chunks == ["Hello ", "world"]
+    assert strategy.conversation == {
+        "id": "conversation",
+        "agent_id": "configured-agent",
+        "messages": [{"role": "system", "text": "Hello world"}],
+        "completion_tokens": 7,
+        "prompt_tokens": 17,
+        "user_context": {"principal_id": "user-one"},
+    }
+    assert state["closed"] is True
+    assert fake_agent.closed is True
+    assert state["open_kwargs"]["user_context"] == {
+        "principal_id": "user-one"
+    }
+    chat_agent.assert_called_once()
+    assert chat_agent.call_args.kwargs["id"] == "configured-agent"
+    assert chat_agent.call_args.kwargs["name"] == "MultiPluginAgent"
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_cleans_up_after_stream_error(
+    patch_dependencies,
+    mock_config,
+):
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {}
+    state = {}
+    fake_agent = _FakeAgent(error=RuntimeError("model failed"))
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ),
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="model failed"):
+            _ = [
+                chunk
+                async for chunk in strategy.initiate_agent_flow("prompt")
+            ]
+
+    assert state["closed"] is True
+    assert fake_agent.closed is True
+    assert "messages" not in strategy.conversation
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_cleans_up_after_cancellation(
+    patch_dependencies,
+    mock_config,
+):
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {}
+    state = {}
+    fake_agent = _FakeAgent(
+        [AgentResponseUpdate(role="assistant", text="started")],
+        block=True,
+    )
+
+    async def consume():
+        async for _ in strategy.initiate_agent_flow("prompt"):
+            pass
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ),
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(fake_agent.blocking.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert state["closed"] is True
+    assert fake_agent.closed is True
+    assert "messages" not in strategy.conversation
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_preserves_azure_openai_configuration(
+    patch_dependencies,
+    mock_config,
+):
+    strategy = await _create_strategy(mock_config)
+
+    with patch(
+        "strategies.mcp_strategy.AzureOpenAIChatClient",
+    ) as chat_client:
+        strategy._create_chat_client()
+
+    chat_client.assert_called_once_with(
+        deployment_name="gpt-4o",
+        endpoint="https://models.example.test",
+        api_version="2025-04-01-preview",
+        ad_token_provider=strategy._token_provider,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_rejects_unsupported_transport(
+    patch_dependencies,
+    mock_config,
+):
+    with pytest.raises(ValueError, match="Supported values"):
+        await _create_strategy(
+            mock_config,
+            overrides={"MCP_SERVER_TRANSPORT": "websocket"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_does_not_mutate_h11(
+    patch_dependencies,
+    mock_config,
+):
+    original_write_headers = h11._writers.write_headers
+
+    await _create_strategy(mock_config)
+
+    assert h11._writers.write_headers is original_write_headers
+
+
+def test_migrated_surfaces_do_not_import_semantic_kernel():
+    root = Path(__file__).parents[1]
+    migrated_files = [
+        root / "src" / "strategies" / "mcp_strategy.py",
+        root / "src" / "strategies" / "base_agent_strategy.py",
+        root / "src" / "plugins" / "common" / "plugin.py",
+        root / "src" / "plugins" / "retrieval" / "plugin.py",
+        root / "requirements.txt",
+        root / "pyproject.toml",
+    ]
+
+    for path in migrated_files:
+        assert "semantic_kernel" not in path.read_text(encoding="utf-8")
+
+
+def test_plugin_decorators_preserve_public_contracts():
+    from plugins.common.plugin import CommonPlugin
+
+    assert CommonPlugin.get_today_date.name == "GetTodayDate"
+    assert CommonPlugin.get_time.name == "GetTime"
+
+    retrieval_path = (
+        Path(__file__).parents[1]
+        / "src"
+        / "plugins"
+        / "retrieval"
+        / "plugin.py"
+    )
+    tree = ast.parse(retrieval_path.read_text(encoding="utf-8"))
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    expected_names = {
+        "vector_index_retrieve": "VectorIndexRetrieve",
+        "multimodal_vector_index_retrieve": "MultimodalVectorIndexRetrieve",
+        "get_data_points_from_chat_log": "GetDataPointsFromChatLog",
+    }
+
+    for function_name, public_name in expected_names.items():
+        decorator = functions[function_name].decorator_list[0]
+        assert isinstance(decorator, ast.Call)
+        assert isinstance(decorator.func, ast.Name)
+        assert decorator.func.id == "ai_function"
+        name_argument = next(
+            keyword.value
+            for keyword in decorator.keywords
+            if keyword.arg == "name"
+        )
+        assert isinstance(name_argument, ast.Constant)
+        assert name_argument.value == public_name
+
+    security_default = functions["vector_index_retrieve"].args.defaults[0]
+    assert isinstance(security_default, ast.Constant)
+    assert security_default.value == "anonymous"
+
+
+def test_stream_filter_only_returns_assistant_text():
+    from strategies.mcp_strategy import McpStrategy
+
+    assistant = AgentResponseUpdate(
+        role="assistant",
+        contents=[TextContent("visible")],
+    )
+    tool = AgentResponseUpdate(
+        role="tool",
+        contents=[TextContent("hidden")],
+    )
+
+    assert McpStrategy._assistant_text(assistant) == "visible"
+    assert McpStrategy._assistant_text(tool) == ""
+    assert "semantic_kernel" not in inspect.getsource(McpStrategy)


### PR DESCRIPTION
## Purpose

Migrate the local `mcp` strategy from Semantic Kernel to the repository-pinned Microsoft Agent Framework release without changing the operator-facing contract.

Target branch: `develop`

## What changed

- Replaced the Semantic Kernel agent with `AzureOpenAIChatClient`, request-scoped `ChatAgent` instances, local MAF threads, and `ChatAgent.run_stream()`.
- Added request-scoped MCP clients for `sse` and `streamable_http`, including native `MCPStreamableHTTPTool` use with a dedicated `httpx.AsyncClient` and a small pinned-MAF SSE adapter backed by `mcp.client.sse.sse_client`.
- Removed the process-wide `h11` header patch. `user-context` and optional `X-API-KEY` headers are now isolated per request.
- Explicitly close each request-scoped Azure OpenAI client through the pinned public `await chat_client.client.close()` API. This runs exactly once after success, agent failures, and stream cancellation; cleanup failures are logged without masking an active primary failure and surface otherwise.
- Preserved the existing Azure OpenAI endpoint, deployment, API version, bearer-token scope, response framing, conversation persistence shape, and configuration names.
- Filtered streaming to assistant-role text only, summed usage over all rounds, and guaranteed agent, MCP session, and HTTP client cleanup on success, error, and cancellation.
- Migrated the remaining Semantic Kernel decorators to MAF `ai_function` and removed the Semantic Kernel runtime dependency.
- Documented the transport default in `.env.sample`, README, and the Unreleased changelog.

## Compatibility and design notes

- `MCP_SERVER_TRANSPORT` accepts `sse` (default) or `streamable_http` only.
- Endpoint suffixes are resolved idempotently to `/sse` or `/mcp`; conflicting explicit suffixes fail with an actionable error.
- The pinned MAF version does not publicly export its MCP base class or provide an SSE tool, so the isolated legacy SSE adapter imports the pinned internal `MCPTool` base. No MAF dependency upgrade or hosted Foundry Agent Service migration is included.
- Factory, orchestrator, API entrypoint, and custom OpenAI adapter behavior are unchanged.

## Validation

- Focused MCP suite: `tests/test_mcp_strategy.py` — 12 passed, 1 warning.
- Full suite: 392 passed, 13 warnings in 104.66s.
- Ruff on changed Python files: passed.
- `python -m compileall -q src tests`: passed.
- Full-repository Ruff reports 105 pre-existing findings outside this change.
- `python -m pip install -e ".[test]"` remains blocked by the repository's pre-existing Hatch wheel package-selection configuration; tests ran successfully against the installed pinned dependencies with `src` on the module path and the `connectors` package preloaded to work around a pre-existing `dependencies`/`connectors` import cycle.

## Follow-up

Update the GPT-RAG docs branch `docs/services_orchestrator.md` to replace the Semantic Kernel description and document transport values, timeout, endpoint suffix selection, and conflict errors.

Closes Azure/gpt-rag#527