### PR TITLE
docs: finalize deployment plan for Azure/GPT-RAG#571

### DIFF
--- a/.azure/deployment-plan.md
+++ b/.azure/deployment-plan.md
@@ -4,190 +4,222 @@
 
 Ready for Validation
 
+Status history for this pass: `Approved` (plan drafted and scope confirmed)
+-> `Ready for Validation` (preparation checks completed, handoff proof
+recorded below).
+
 ## Scope
 
-Prepare real Microsoft Entra tenant validation for PR #260, which adds MSAL sign-in and `Admin` app-role authorization to the orchestrator admin dashboard.
+Prepare and record validation evidence for the `gpt-rag-orchestrator`
+component of [Azure/GPT-RAG#571](https://github.com/Azure/GPT-RAG/issues/571)
+("Establish a practical governance baseline and auditable AI activity
+trail"). This supersedes the stale plan previously recorded in this file for
+`Azure/gpt-rag-orchestrator#260` (dashboard MSAL sign-in), which was handled
+separately and no longer applies.
 
-This plan does not authorize deployment, merge, release, deletion, or Azure/Entra mutation. The next step is explicit validation approval, then `azure-validate`, then `azure-deploy`.
+This plan does not authorize deployment, merge, release, deletion, or
+Azure/Entra mutation. It records a MODIFY-mode preparation and validation pass
+over application configuration that ships inside the existing orchestrator
+container image; it does not add, remove, or resize any Azure resource.
 
-## Azure context
+## Preparation finding
 
-- Subscription: `9788a92c-2f71-4629-8173-7ad449cb50e1` (`mcaps-paulolacerda`)
-- Tenant: `16b3c013-d300-468d-ac64-7eda0820b6d3`
-- Preferred validation location: `australiaeast`, matching the existing Entra redirect URI and prior validation endpoint.
+The orchestrator-side implementation for issue #571 (the shared v1 audit
+event contract, disabled-by-default instrumentation, and admin-safe
+configuration defaults) was already implemented, reviewed, merged, and
+released before this preparation pass started:
 
-## Safety constraints
+- Pull request: [Azure/gpt-rag-orchestrator#277](https://github.com/Azure/gpt-rag-orchestrator/pull/277)
+  (`feature/audit-events-v1` -> `develop`, merged).
+- Release: [`v3.8.0`](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.8.0)
+  (published; `VERSION` file synchronized to `3.8.0` on `develop` and `main`).
+- This preparation pass therefore does not introduce new orchestrator
+  application code. It validates the already-released state and finalizes
+  this deployment-plan artifact, which had not been updated since the
+  unrelated `#260` preparation.
 
-- No resource-group deletion is authorized by this plan.
-- Before any future deletion consideration, run:
-  - `az group show --subscription 9788a92c-2f71-4629-8173-7ad449cb50e1 --name <rg> --query tags`
-- Never delete a resource group tagged `keep=true`.
-- Never delete resource groups by substring matching such as `gpt-rag` or `gptrag`.
-- Only delete a validation environment by exact resource group name after explicit approval.
+## MODIFY mode and recipe
 
-## Workspace analysis
+- Mode: MODIFY. No new Azure resource type is introduced. Audit configuration
+  is delivered through existing Azure App Configuration key-values (label
+  `gpt-rag-orchestrator` or shared `gpt-rag`) and the existing Key Vault
+  secret-reference pattern already used for other orchestrator secrets
+  (for example `MCP_APP_APIKEY`, `OAUTH_AZURE_AD_CLIENT_SECRET`).
+- Recipe: this repository's `infra/` is a documented pointer, not a
+  standalone Bicep environment (`infra/README.md`: "The infrastructure for
+  this project is defined in: https://github.com/Azure/GPT-RAG"; `infra/main.bicep`
+  is a one-line `targetScope = 'resourceGroup'` stub). The existing AZD
+  workflow (`azure.yaml` -> `scripts/preProvision.*` / `scripts/deploy.*`)
+  builds and deploys the orchestrator container image into the Container App
+  provisioned by the main `Azure/GPT-RAG` environment. No changes to that
+  recipe are required for this feature; it is pure application configuration
+  that ships inside the existing image.
 
-- Repository: `Azure/gpt-rag-orchestrator`
-- Branch: `feature/dashboard-msal-signin`
-- PR: `Azure/gpt-rag-orchestrator#260`
-- Base branch: `develop`
-- Application: Python 3.12 FastAPI orchestrator with a Vite/React admin dashboard served from `/dashboard/`.
-- Deployment artifacts already present:
-  - `Dockerfile` builds the dashboard bundle in a Node 20 stage and copies it into the Python runtime image.
-  - `azure.yaml` exists and points to azd hooks/scripts, but this repository does not carry standalone `infra/` files. Full GPT-RAG environment creation is owned by the main GPT-RAG infrastructure repository.
-- Preparation mode: MODIFY existing application and validate a PR image against a real tenant.
-- Recipe: use existing GPT-RAG deployment flow for environment provisioning, then deploy the orchestrator container image/revision from this branch. If no reusable environment exists, recreate a controlled validation environment from the main GPT-RAG infrastructure instead of modifying unrelated resource groups.
+## Architecture
 
-## Current environment inventory
+- Audit events reuse the existing OpenTelemetry + Application Insights export
+  path (`src/telemetry/telemetry.py`, `src/telemetry/audit.py`) under the
+  `gptrag.audit` logger namespace; no new telemetry backend is introduced.
+- Configuration is read through the existing App Configuration provider
+  (`src/api/config_settings.py`), the same mechanism used for every other
+  runtime setting.
+- The shared v1 contract (`contracts/audit-event-v1.schema.json` and
+  `contracts/audit-event-v1.application-insights.schema.json`) is versioned
+  and additive; the ingestion component reserves its own event names in the
+  same schema but the orchestrator does not emit them.
+- Cross-repo alignment: `gpt-rag-orchestrator` v3.8.0 is the paired release
+  that carries this shared contract; `gpt-rag-ingestion` v2.5.0 is the
+  expected companion release on the ingestion side for the remaining
+  `Azure/GPT-RAG#571` scope (ingestion audit events, ingestion governance
+  defaults, and additive Azure AI Search index fields). Ingestion-side and
+  Azure/GPT-RAG umbrella-repo changes are **out of scope of this workspace**
+  (a different repository/session owns them); see "Cross-repo scope" below.
 
-The previously planned resource group `rg-gptrag-546val` is not present in subscription `mcaps-paulolacerda` as of this preparation pass:
+## Pinned contract identifiers
 
-- `az group show --name rg-gptrag-546val` returned `ResourceGroupNotFound`.
-- No matching Container Apps or App Configuration stores were found by read-only resource listing in this subscription.
+The shared v1 contract ships with a committed SHA-256 manifest
+(`contracts/audit-event-v1.sha256`) so any consumer (including
+`gpt-rag-ingestion`) can detect drift before trusting the schema:
 
-Candidate GPT-RAG resource groups found in the subscription:
-
-| Resource group | Location | Tags | Read-only finding |
-| --- | --- | --- | --- |
-| `rg-gptrag-fiqzt2-sdc06291745` | `swedencentral` | `azd-env-name=gptrag-fiqzt2-sdc06291745` | Candidate only, not selected. |
-| `rg-gptrag-az700-zta-063014` | `swedencentral` | `azd-env-name=gptrag-az700-zta-063014` | Candidate only, not selected. |
-| `rg-gptrag-fiqzt2-06290951` | `switzerlandnorth` | `azd-env-name=gptrag-fiqzt2-06290951` | Candidate only, not selected. |
-| `rg-gptrag-fiqzt-aue-06291815` | `australiaeast` | `azd-env-name=gptrag-fiqzt-aue-06291815` | Contains only `srch-2sud2hrjnye46`; not a complete orchestrator validation environment. |
-| `rg-gptragv342val` | `australiaeast` | `azd-env-name=gptragv342val` | Contains network/search resources; no Container App/App Configuration inventory was found in this pass. |
-
-Conclusion: do not assume the old validation environment is available. Validation should either:
-
-1. Recreate a new exact validation environment, for example `rg-gptrag-546val2`, from the main GPT-RAG infrastructure, or
-2. Use a user-approved existing environment only after confirming it has the orchestrator Container App, ACR, App Configuration, managed identity, Cosmos, and required GPT-RAG dependencies.
-
-## Entra application inventory
-
-Use the existing single-tenant app registration:
-
-- Display name: `gpt-rag-546val-dashboard`
-- Application (client) id: `b621d3a9-03e7-4cf1-80f6-47a263b751c1`
-- Application object id: `1c50cdd8-d331-4916-9279-80336bef98d2`
-- Enterprise application object id: `737526d9-dbae-4e28-934c-c582005cce94`
-- Tenant: `16b3c013-d300-468d-ac64-7eda0820b6d3`
-- Supported accounts: single tenant
-- Application ID URI: `api://b621d3a9-03e7-4cf1-80f6-47a263b751c1`
-- Scope: `access_as_user`
-- App role: value `Admin`, case-sensitive, users/groups, enabled
-- Enterprise Application `Assignment required?`: `No`
-- Known redirect URI:
-  - `https://ca-5hhmdzbxo4x4q-orchestrator.thankfulwave-c9aba52a.australiaeast.azurecontainerapps.io/dashboard/`
-
-Before E2E, update the SPA redirect URI if the recreated Container App gets a different FQDN. The redirect URI must exactly match the browser URL and include the trailing slash.
-
-## Runtime configuration required
-
-Set these Azure App Configuration key-values under label `gpt-rag-orchestrator` in the selected validation environment:
-
-| Key | Value |
+| Artifact | SHA-256 (raw bytes) |
 | --- | --- |
-| `ENABLE_DASHBOARD` | `true` |
-| `OAUTH_AZURE_AD_TENANT_ID` | `16b3c013-d300-468d-ac64-7eda0820b6d3` |
-| `OAUTH_AZURE_AD_CLIENT_ID` | `b621d3a9-03e7-4cf1-80f6-47a263b751c1` |
-| `OAUTH_AZURE_AD_API_SCOPE` | `api://b621d3a9-03e7-4cf1-80f6-47a263b751c1/access_as_user` |
+| `contracts/audit-event-v1.schema.json` | `825db8ef40a81e2c19e5d80d37c565b6b47fc9a6540e9881d35cc12b8fde5aab` |
+| `contracts/audit-event-v1.application-insights.schema.json` | `066c8f5408610ab839d5121d06ca5bc59e8797e551d5c47c875c5ba52f7e0588` |
 
-Also confirm the orchestrator Container App has:
+Both hashes were independently reproduced in this pass (raw file bytes,
+`\r\n` normalized to `\n`) and match the committed manifest and the values
+required by `Azure/GPT-RAG#571`. `tests/test_audit_contract.py::test_published_contract_hashes_match_artifacts`
+enforces this on every test run, so any future edit to either schema file
+without updating `contracts/audit-event-v1.sha256` fails CI instead of
+silently drifting from what `gpt-rag-ingestion` expects.
 
-- `APP_CONFIG_ENDPOINT=https://<store>.azconfig.io`
-- `AZURE_CLIENT_ID=<uami-client-id>` if a user-assigned managed identity is used
-- Managed identity permission to read App Configuration
-- If testing dashboard Configuration writes, managed identity permission equivalent to App Configuration Data Owner
+## Security
 
-Important: check whether the legacy label `orchestrator` contains any of the same keys. If it does, remove or align those values only with explicit approval, because legacy label precedence can override `gpt-rag-orchestrator`.
+- `AUDIT_HMAC_KEY` (the 256-bit pseudonymization key) is read only through the
+  existing Key Vault secret-reference pattern in App Configuration, exactly
+  like other orchestrator secrets. It is denylisted in
+  `src/api/config_settings.py::DENYLIST`, so it can never be read or written
+  through the admin dashboard, and it is never logged, echoed in an audit
+  event, or placed in documentation as a literal value.
+- Enabling `AUDIT_EVENTS_ENABLED=true` without a valid 256-bit key (base64,
+  base64url, or hex) fails startup (`AuditConfigurationError`) instead of
+  silently degrading to an unkeyed or predictable pseudonym.
+- Sensitive-content capture (`AUDIT_SENSITIVE_CONTENT_ENABLED`) stays
+  disabled by default and requires a non-empty allowlist
+  (`AUDIT_SENSITIVE_CONTENT_FIELDS`) drawn from a fixed, small set of fields.
+  Tokens, credentials, authorization headers, cookies, connection strings,
+  SAS values, and private keys are filtered before export even when
+  sensitive capture is enabled (defense in depth, not a DLP boundary).
+- Generation guidance (README "Audit event configuration") uses
+  `secrets.token_bytes(32)` locally, writes directly to Key Vault, and clears
+  the shell variable; no hardcoded secret exists anywhere in the repository.
 
-Restart or create a new Container App revision after changing `ENABLE_DASHBOARD`, because the dashboard route registration is evaluated at startup.
+## Migration and rollback
 
-## Validation deployment approach
+- All seven audit configuration keys are additive App Configuration
+  key-values with safe, documented defaults
+  (`AUDIT_EVENTS_ENABLED=false`, `AUDIT_SENSITIVE_CONTENT_ENABLED=false`,
+  `AUDIT_SENSITIVE_CONTENT_FIELDS=` (empty), `AUDIT_ACTOR_PSEUDONYM_ENABLED=false`,
+  `AUDIT_SOURCE_EVENT_LIMIT=25`, `AUDIT_HMAC_KEY_ID=v1`,
+  `AUDIT_ADDITIONAL_REDACTED_KEYS=` (empty)). Existing deployments upgrade to
+  the new image with no configuration changes and preserve current behavior
+  (`AUDIT_EVENTS_ENABLED` absent is treated the same as `false`).
+- Rollback: set `AUDIT_EVENTS_ENABLED=false` and restart/re-revision the
+  Container App, or roll back to the previous image. Neither action deletes
+  already-exported telemetry or requires any resource or index change.
+- No destructive schema/index recreation is part of this change; the
+  additive Azure AI Search index fields described in `Azure/GPT-RAG#571`
+  belong to `gpt-rag-ingestion` and are not implemented in this repository.
 
-1. Confirm the target environment choice with Paulo:
-   - Recreate a new validation environment from GPT-RAG infrastructure, or
-   - Use an existing complete environment after read-only inventory confirms it is safe.
-2. Build an orchestrator image from the rebased PR branch.
-3. Push the image to the environment ACR.
-4. Deploy a new orchestrator Container App revision using that image.
-5. Set or verify the App Configuration key-values above.
-6. Update the Entra SPA redirect URI to the final `/dashboard/` URL if needed.
-7. Run E2E checks below.
+## No destructive deployment
 
-## E2E test matrix
+- This pass performs no `azd provision`, `azd deploy`, resource creation, or
+  resource deletion.
+- No resource group is created, modified, or deleted by this plan.
+- Before any future deletion consideration in any environment, the safety
+  rules from the prior `#260` plan remain in force: check `tags` for
+  `keep=true`, never delete by `gpt-rag`/`gptrag` substring match, and only
+  delete an exact, explicitly approved resource group name.
 
-### Baseline auth opt-out
+## Cross-repo scope (explicitly not implemented here)
 
-Temporarily omit `OAUTH_AZURE_AD_TENANT_ID` in a non-production validation revision.
+`Azure/GPT-RAG#571` lists both `gpt-rag-orchestrator` and `gpt-rag-ingestion`
+as in-scope components. This workspace is the `gpt-rag-orchestrator`
+repository only. The following remain open and belong to other
+repositories/sessions:
 
-Expected:
+- `gpt-rag-ingestion` v2.5.0: ingestion-side audit events, ingestion
+  governance defaults (`INGESTION_PROVENANCE_ENABLED`,
+  `INGESTION_REQUIRE_GOVERNANCE_METADATA`, `INGESTION_DEFAULT_CLASSIFICATION`,
+  `INGESTION_DEFAULT_RIGHT_TO_USE`), and the additive Azure AI Search index
+  fields (`provenance_id`, `source_uri_id`, `source_version_id`,
+  `content_checksum_sha256`, `ingested_at`, `ingest_run_id`,
+  `data_classification`, `right_to_use`, `retention_class`, `delete_after`).
+  `delete_after` must be documented there as policy intent (a value read by
+  operator tooling/reporting), not an automatic purge mechanism.
+- `Azure/GPT-RAG` (umbrella repository): pinning `gpt-rag-orchestrator`
+  v3.8.0 and `gpt-rag-ingestion` v2.5.0 together for a future minor GPT-RAG
+  release, and the umbrella `CHANGELOG.md`/release notes for that release.
+- Stage 1, 4, and 5 governance/documentation deliverables from the issue
+  (governance statement, responsibility guidance, reconstruction query
+  examples, retention/deletion/access guidance) that are not specific to the
+  orchestrator's own README.
 
-- `/dashboard/` loads without MSAL sign-in.
-- `GET /api/dashboard/auth-config` returns `auth_enabled:false` or equivalent disabled state.
+## Validation performed in this pass
 
-### Admin user
+| Check | Command | Result |
+| --- | --- | --- |
+| Full unit test suite | `python -m pytest -q` | 533 passed, 0 failed (109.82s) |
+| Audit-contract lint scope | `python -m ruff check src/telemetry/audit*.py src/telemetry/__init__.py src/telemetry/telemetry.py src/main.py src/api/config_settings.py scripts/benchmark_audit.py tests/test_audit_*.py` | All checks passed |
+| Byte compile | `python -m compileall -q src tests scripts` | Exit code 0 |
+| Dependency consistency | `python -m pip check` | No broken requirements found |
+| Bicep stub build | `az bicep build --file infra/main.bicep --stdout` | Builds to an empty-resources ARM template (confirms the stub is syntactically valid; there is no other infra in this repo to validate) |
+| Docker image build | `docker build -t gpt-rag-orchestrator:validate-571 .` | Builds successfully (multi-stage Node 20 dashboard build + Python 3.12 runtime); image removed after validation |
+| Contract hash reproduction | raw SHA-256 of both `contracts/audit-event-v1*.schema.json` files | Matches `contracts/audit-event-v1.sha256` and the values required by `Azure/GPT-RAG#571` (see table above) |
 
-Use Paulo's tenant account with the `Admin` app role assigned.
+Repo-wide `ruff check src tests scripts` (unscoped) reports 78 pre-existing
+findings in files unrelated to the audit contract (for example unused
+imports in `tests/test_conversation_history.py` and
+`tests/test_maf_agent_service_strategy.py`). These predate this pass, are
+outside the `Azure/GPT-RAG#571` scope, and are not modified here to keep this
+change focused.
 
-Expected:
+Not run / explicit blocker:
 
-- Sign-in redirects back to `/dashboard/`.
-- `/api/dashboard/overview`, `/api/dashboard/conversations`, and `/api/dashboard/config` send `Authorization: Bearer <token>` and return 200.
-- Local JWT inspection shows:
-  - `aud` is `b621d3a9-03e7-4cf1-80f6-47a263b751c1` or `api://b621d3a9-03e7-4cf1-80f6-47a263b751c1`
-  - `scp` contains `access_as_user`
-  - `roles` contains `Admin`
-- Sign out clears the session and returns to the sign-in state.
+- `azd provision --preview` (or equivalent non-deploy preflight): this
+  repository's `infra/` intentionally has no standalone environment to
+  preview against (see "MODIFY mode and recipe" above); a meaningful preview
+  requires the main `Azure/GPT-RAG` environment/workspace, which is outside
+  this repository and this session. No preview was attempted against any
+  shared/real GPT-RAG environment to avoid unintended state changes to
+  infrastructure this workspace does not own. This is recorded as the
+  explicit blocker for that specific validation step; nothing was deployed.
 
-Do not paste tokens into external sites. Decode locally only.
+## Handoff proof
 
-### Non-admin user
-
-Use Gonzalo Becerra or another test user without the `Admin` app role. If Gonzalo currently has `Admin`, remove the assignment only for the test and restore it afterward with explicit approval.
-
-Expected with Enterprise Application `Assignment required? = No`:
-
-- Entra sign-in succeeds.
-- The first protected dashboard API call returns 403.
-- The SPA shows `Access denied`, the signed-in account, and `Sign out and try another account`.
-- No administrative dashboard data is rendered.
-
-### Optional 401 path
-
-Expire or invalidate the MSAL session and call a protected endpoint.
-
-Expected:
-
-- The SPA shows session-expired/sign-in-again behavior or redirects through MSAL.
-- The app never downgrades to an anonymous dashboard API call.
-
-## Documentation updates included in this PR
-
-README dashboard guidance now explains:
-
-- The required single App Registration model for SPA and API.
-- Where to define app roles: App registrations > application > App roles.
-- Where to assign app roles: Enterprise applications > application > Users and groups.
-- Why only `Admin` exists and why the value is case-sensitive.
-- Why `Assignment required? = No` is needed to test the app-level 403 path.
-- Why users must fully sign out and sign in after role assignment changes.
-
-## Merge and release sequence after validation
-
-1. Complete Azure E2E validation and record results in PR #260.
-2. Mark PR #260 ready for review if validation passes.
-3. Merge PR #260 into `develop`.
-4. Prepare the next `Azure/gpt-rag-orchestrator` release branch from `develop`, following this repository's `AGENTS.md` release rules.
-5. Tag and publish the orchestrator release with the GitHub Release title exactly equal to the tag, for example `vX.Y.Z`.
-6. If the parent `Azure/gpt-rag` repository pins or consumes the orchestrator version, update it in a follow-up PR/release after the orchestrator release is available.
+- Test/lint/build evidence: recorded in the table above, produced in this
+  session against `origin/develop` at commit `0fccab6` (`chore: sync main to
+  develop for v3.8.0`).
+- Release evidence: PR [#277](https://github.com/Azure/gpt-rag-orchestrator/pull/277)
+  merged; release [v3.8.0](https://github.com/Azure/gpt-rag-orchestrator/releases/tag/v3.8.0)
+  published; `VERSION` = `3.8.0` on `develop`/`main`.
+- Contract evidence: `contracts/audit-event-v1.sha256` hashes independently
+  reproduced and matched in this pass.
 
 ## Planning checklist
 
-- [x] Analyze workspace and deployment recipe.
-- [x] Inspect Azure context and prior environment read-only.
-- [x] Inventory reusable resources, tags, configuration, identity, and endpoints where available.
-- [x] Define Entra SPA/API and Admin-role prerequisites.
-- [x] Define admin, non-admin, and optional 401 E2E scenarios.
-- [x] Incorporate operator documentation improvements.
-- [x] Confirm that the prior `rg-gptrag-546val` environment is not currently available.
-- [x] Draft merge and release sequence.
-- [x] Finalize this plan for explicit approval before validation/deployment.
+- [x] Inspect the existing (stale) deployment plan and identify it as
+      unrelated to `#571`.
+- [x] Confirm MODIFY mode, existing AZD/Bicep recipe, and that no new Azure
+      resource is introduced.
+- [x] Document architecture, security, migration, and rollback for the
+      audit-event feature.
+- [x] Reproduce and record the pinned contract hash identifiers.
+- [x] Identify and record ingestion-repo and umbrella-repo scope that is not
+      implemented here.
+- [x] Run full test suite, scoped lint, compileall, pip check, Bicep stub
+      build, and Docker build; record results.
+- [x] Record the `azd provision --preview` blocker without attempting a live
+      preview or deployment.
+- [x] Finalize this plan and move status to Ready for Validation with
+      handoff proof recorded.


### PR DESCRIPTION
## Purpose

Finalizes the `.azure/deployment-plan.md` engineering-preparation artifact for
[Azure/GPT-RAG#571](https://github.com/Azure/GPT-RAG/issues/571) ("Establish
a practical governance baseline and auditable AI activity trail"). The file
previously still documented the unrelated, already-handled
`Azure/gpt-rag-orchestrator#260` (dashboard MSAL) preparation.

## Finding

The orchestrator-side implementation for `#571` (shared v1 audit event
contract, disabled-by-default instrumentation, admin-safe configuration
defaults, Key Vault-backed HMAC key) was already implemented, reviewed,
merged, and released before this pass:

- PR #277 (`feature/audit-events-v1` -> `develop`), merged.
- Release `v3.8.0`, published; `VERSION` already `3.8.0` on `develop`/`main`.

No new orchestrator application code is introduced by this PR. This PR only
finalizes the deployment-plan artifact and records validation evidence for
that already-released state.

## What this PR changes

- `.azure/deployment-plan.md`: replaced the stale `#260` content with a
  `#571`-scoped plan covering MODIFY mode, the existing AZD/Bicep recipe,
  architecture, pinned contract SHA-256 identifiers, security, migration and
  rollback, explicit no-destructive-deployment statement, cross-repo scope
  (`gpt-rag-ingestion` v2.5.0 and the `Azure/GPT-RAG` umbrella repo are out of
  scope of this workspace), and recorded validation results. Status:
  `Approved` -> `Ready for Validation` with handoff proof recorded.

## Validation (this session, against `develop` @ `0fccab6`)

- `pytest -q`: 533 passed, 0 failed.
- `ruff check` scoped to every audit-contract file: all checks passed
  (repo-wide `ruff check` still reports 78 pre-existing, unrelated findings
  that are out of scope here).
- `python -m compileall -q src tests scripts`: exit 0.
- `pip check`: no broken requirements found.
- `az bicep build --file infra/main.bicep --stdout`: builds (stub, empty
  resources - this repo's real infra lives in `Azure/GPT-RAG`).
- `docker build .`: succeeds (multi-stage Node 20 dashboard + Python 3.12
  runtime); validation image removed afterward.
- Reproduced raw-byte SHA-256 of both `contracts/audit-event-v1*.schema.json`
  files and confirmed they match `contracts/audit-event-v1.sha256` and the
  hash values required by `Azure/GPT-RAG#571`.

## Not run

- `azd provision --preview`: this repository does not own a standalone
  environment to preview against (`infra/` is a pointer to `Azure/GPT-RAG`).
  Recorded as an explicit blocker; nothing was deployed.

## Target branch

`develop`, per this repository's branching rules. Do not merge without
review.