### PR TITLE
feat: propagate Foundry Toolbox identity passthrough for hosted mcp retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,26 @@
   neither the call id nor the `Authorization` header value is ever emitted
   to application logs.
 
+### Fixed
+
+- **Hardened `x-agent-foundry-call-id` validation against trailing-newline
+  bypass.** `util.foundry_platform.require_foundry_call_id` validated the
+  call id with `re.match()` against an anchored `^[\x21-\x7e]+$` pattern.
+  Without `re.MULTILINE`, Python's `$` matches immediately before a single
+  trailing `\n`, so `.match()` would incorrectly accept a raw value like
+  `"call-id\n"`. `extract_foundry_call_id`'s `.strip()` happened to remove
+  such trailing whitespace before validation today, masking the defect
+  end-to-end, but the validation itself must not depend on that as its only
+  safeguard — a future direct call to `require_foundry_call_id`, or a
+  refactor of extraction, could bypass the strip and forward an
+  injection-bearing value to Toolbox. Switched to `.fullmatch()`, which
+  anchors to the true end of the string regardless of trailing newlines.
+  Added direct unit tests in `tests/test_foundry_platform.py` (bypassing the
+  strip via monkeypatching) proving the regex rejects a trailing `\n`/`\r`
+  even when extraction does not strip it, plus general direct-call
+  coverage for `require_foundry_call_id`/`extract_foundry_call_id` (valid,
+  missing, empty, too-long, and embedded-whitespace call ids).
+
 ## [v3.9.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Foundry Toolbox OAuth identity passthrough for hosted `mcp` retrieval.**
+  Added `util.foundry_platform` with the platform-injected header contract
+  for Microsoft Foundry hosted-agent protocol 2.0: `x-agent-user-id` (container
+  partition key, never forwarded) and `x-agent-foundry-call-id` (opaque
+  per-request call identifier — the only supported identity passthrough
+  correlation token). `POST /invocations` now captures and strictly validates
+  `x-agent-foundry-call-id` (printable ASCII, no whitespace/control
+  characters, 256-char max) whenever the resolved strategy is in the new
+  `strategies.hosted_strategies.HOSTED_TOOLBOX_STRATEGIES` set (currently
+  ``mcp``, the only strategy that calls Toolbox). Requests for a Toolbox
+  strategy with a missing or malformed call id are rejected with HTTP 401
+  before strategy construction — there is no service-identity or manual
+  group-filter fallback. The validated call id flows through the
+  runtime-neutral `TurnRequest.foundry_call_id` field into
+  `BaseAgentStrategy.foundry_call_id` and is echoed as the sole outbound
+  identity header by `connectors.mcp_client.open_mcp_tool` /
+  `build_mcp_headers` on every Toolbox MCP HTTP call, so Toolbox can resolve
+  the signed-in user and mint per-user credentials server-side. The
+  container never reads, stores, or forwards the `Authorization` header
+  (already stripped by the platform gateway) and never trusts caller/model
+  identity fields or `x-client` group claims for document-security decisions,
+  per
+  [ADR-0001](https://github.com/Azure/GPT-RAG/blob/main/docs/adr/ADR-0001-hosted-agents.md).
+  Non-Toolbox hosted strategies (`maf_lite`, `maf_agent_service`,
+  `single_agent_rag`) are unaffected and continue to run with
+  `foundry_call_id=None`. See
+  [Azure/GPT-RAG#591](https://github.com/Azure/GPT-RAG/issues/591).
+
+- **Focused Toolbox identity passthrough tests.** Added coverage proving:
+  outbound header propagation to the MCP client (present, absent, and
+  concurrent-call isolation); `/invocations` and `_hosted_stream` fail-closed
+  behavior for the `mcp` strategy when the call id is missing or malformed,
+  with the strategy factory never invoked; correct propagation of a valid
+  call id into the constructed strategy; classic (non-Toolbox) hosted
+  strategies remain unaffected; genuine concurrent-request isolation of call
+  ids at the HTTP boundary (`httpx.AsyncClient` + `ASGITransport`); and that
+  neither the call id nor the `Authorization` header value is ever emitted
+  to application logs.
+
 ## [v3.9.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,30 @@
   coverage for `require_foundry_call_id`/`extract_foundry_call_id` (valid,
   missing, empty, too-long, and embedded-whitespace call ids).
 
+- **`MissingFoundryCallContextError` could be silently downgraded to a
+  generic SSE `internal_error` frame.** `_hosted_stream`'s defense-in-depth
+  check (the fail-closed guard that exists in case a future/internal caller
+  invokes it directly, bypassing the `/invocations` HTTP handler's 401
+  precheck) raises `MissingFoundryCallContextError`, a `ValueError`
+  subclass. `_sse_generator`'s inner generator caught it only via its broad
+  `except Exception` clause, so it was indistinguishable from any other
+  internal failure and reported to the client as `{"code":
+  "internal_error"}`, losing its security-relevant classification. Added an
+  explicit `except MissingFoundryCallContextError` clause in `_sse_generator`,
+  ordered before the broad `except Exception`, that emits a distinctly coded
+  `{"code": "missing_call_context"}` SSE error frame instead. The primary
+  pre-`StreamingResponse` HTTP 401 guard in `/invocations` is unchanged and
+  remains the only path that can return a 401 — this fix only prevents a
+  hypothetical bypass of that guard from being misreported once the SSE
+  stream (HTTP 200) is already open; it does not claim a post-header 401 is
+  possible. Also unified the exception message text used at both raise sites
+  into a single `util.foundry_platform.MISSING_CALL_CONTEXT_MESSAGE`
+  constant, so the HTTP-level and defense-in-depth paths report identical,
+  already-vetted-safe text. Added a direct-generator regression test that
+  calls `_sse_generator` without going through `/invocations`, asserting the
+  distinct error code, the canonical message, and that
+  `AgentStrategyFactory.get_strategy` is never invoked.
+
 ## [v3.9.0] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,50 @@ or connection errors. Because the configuration names and SSE default are
 unchanged, you can roll back to the previous orchestrator image without
 rewriting the existing SSE configuration.
 
+### Foundry hosted-agent Toolbox identity passthrough
+
+When the orchestrator runs as a Microsoft Foundry hosted agent (`api.hosted_entrypoint`,
+`POST /invocations`) with `AGENT_STRATEGY=mcp`, document-security identity is
+established solely through the Foundry hosted-agent protocol 2.0 call context —
+per
+[Azure/GPT-RAG ADR-0001](https://github.com/Azure/GPT-RAG/blob/main/docs/adr/ADR-0001-hosted-agents.md),
+Toolbox OAuth identity passthrough is the required native path and a manual
+group-filter fallback is never the default.
+
+The platform injects two headers on every hosted-agent request:
+
+| Header | Purpose | Forwarded to Toolbox? |
+| --- | --- | --- |
+| `x-agent-user-id` | Per-user container partition key. | No — container-side only. |
+| `x-agent-foundry-call-id` | Opaque per-request call identifier. | Yes — the only supported identity passthrough correlation token. |
+
+`POST /invocations` captures and strictly validates `x-agent-foundry-call-id`
+(printable ASCII, no spaces or control characters, 256 characters max)
+whenever the resolved strategy is Toolbox-backed (currently only `mcp`). A
+missing or malformed value is rejected with **HTTP 401** before any strategy
+or Toolbox client is constructed — there is no fallback to service identity or
+to the legacy `metadata_security_id` manual filter. The validated call id
+then flows unchanged through the runtime-neutral `TurnRequest` into the
+strategy and is echoed as the sole outbound identity header on every Toolbox
+MCP HTTP call, so Toolbox can resolve the signed-in user and mint per-user
+credentials server side.
+
+The container never reads, stores, or forwards the `Authorization` header
+(the platform gateway strips it before the request reaches the container),
+and it never trusts caller- or model-supplied identity fields or `x-client`
+group claims for retrieval security decisions. Neither the call id nor any
+authorization material is ever written to application logs. Non-Toolbox
+hosted strategies (`maf_lite`, `maf_agent_service`, `single_agent_rag`) are
+unaffected and continue to run without a call id.
+
+> [!IMPORTANT]
+> Toolbox-side OAuth consent and RBAC grants for the signed-in user are an
+> external, platform-managed prerequisite. This orchestrator-side change
+> propagates the correlation identity Toolbox needs to resolve per-user
+> credentials; it does not itself grant, request, or manage that consent —
+> the Toolbox/ingestion service and the Foundry hosted-agent platform must be
+> configured and consented for the target user independently.
+
 ### Audit event configuration
 
 The orchestrator can emit a versioned, metadata-only-by-default activity trail through its

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -27,7 +27,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, Literal, Optional, Sequence
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -48,10 +48,12 @@ from strategies.agent_strategy_factory import AgentStrategyFactory
 from strategies.hosted_strategies import (
     HOSTED_ELIGIBLE_STRATEGIES,
     HOSTED_SERVER_THREAD_STRATEGIES,
+    HOSTED_TOOLBOX_STRATEGIES,
     HostedConversationMessage,
     build_hosted_conversation,
     guard_hosted_strategy,
 )
+from util.foundry_platform import MissingFoundryCallContextError, require_foundry_call_id
 
 logger = logging.getLogger(__name__)
 
@@ -129,9 +131,17 @@ async def _hosted_stream(
     invocation contract does not yet expose an authenticated Foundry identity.
 
     Raises :class:`ValueError` for unsupported strategies — never silently
-    falls back.
+    falls back. Raises :class:`~util.foundry_platform.MissingFoundryCallContextError`
+    (a :class:`ValueError` subclass) when *strategy_key* is Toolbox-integrated
+    and the turn carries no validated Foundry call id — hosted retrieval must
+    fail closed rather than fall back to service identity or a manual filter.
     """
     guard_hosted_strategy(strategy_key)
+    if strategy_key in HOSTED_TOOLBOX_STRATEGIES and not turn.foundry_call_id:
+        raise MissingFoundryCallContextError(
+            f"Strategy '{strategy_key}' requires a validated Foundry call id "
+            "to reach Toolbox; refusing to run without one."
+        )
     strategy = await AgentStrategyFactory.get_strategy(
         strategy_key,
         hosted_runtime=True,
@@ -149,6 +159,7 @@ async def _hosted_stream(
         strategy.set_context(conversation_id)
 
     strategy.user_context = {}
+    strategy.foundry_call_id = turn.foundry_call_id
     strategy.conversation = build_hosted_conversation(
         strategy_key,
         conversation_id,
@@ -271,6 +282,23 @@ async def health() -> HealthResponse:
             "description": "OK — Responses API SSE stream",
             "content": {"text/event-stream": {}},
         },
+        401: {
+            "description": (
+                "Missing or malformed platform call context — hosted "
+                "retrieval failed closed rather than falling back to "
+                "service identity or a manual filter."
+            ),
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": (
+                            "Missing or malformed platform call context "
+                            "('x-agent-foundry-call-id')."
+                        )
+                    }
+                }
+            },
+        },
         422: {
             "description": "Unsupported strategy or validation error",
             "content": {
@@ -281,13 +309,23 @@ async def health() -> HealthResponse:
         },
     },
 )
-async def invocations(body: InvocationRequest) -> StreamingResponse:
+async def invocations(request: Request, body: InvocationRequest) -> StreamingResponse:
     """Translate a Foundry invocation into a Responses API SSE stream.
 
     The final message must be the current user ask. Messages after the current
     ask are rejected rather than silently discarded. Responses-backed
     strategies validate a supplied ``conversation_id`` or create a real managed
     Conversation when it is absent.
+
+    Toolbox-integrated strategies additionally require the platform-injected
+    ``x-agent-foundry-call-id`` header (Foundry hosted-agent container
+    protocol 2.0). This container never reads or forwards ``Authorization``,
+    and never trusts caller/model identity fields or ``x-client`` group
+    claims — the opaque call id is the only supported identity-passthrough
+    correlation, echoed to Toolbox so it can resolve the signed-in user and
+    supply per-user credentials. When the header is absent or malformed,
+    hosted retrieval fails closed with HTTP 401 rather than falling back to
+    service identity or a manual ``metadata_security_id`` filter.
     """
     current_message = body.messages[-1]
     if current_message.role != "user":
@@ -314,6 +352,16 @@ async def invocations(body: InvocationRequest) -> StreamingResponse:
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+    # Toolbox-integrated strategies must carry a validated, platform-injected
+    # call id (ADR-0001, Azure/GPT-RAG#591). Never trust Authorization,
+    # caller/model identity fields, or x-client group claims here.
+    foundry_call_id: Optional[str] = None
+    if strategy_key in HOSTED_TOOLBOX_STRATEGIES:
+        try:
+            foundry_call_id = require_foundry_call_id(request.headers)
+        except MissingFoundryCallContextError as exc:
+            raise HTTPException(status_code=401, detail=str(exc)) from exc
+
     # Build the transport-neutral turn request.
     metadata = body.metadata or {}
     history: list[HostedConversationMessage] = [
@@ -326,6 +374,7 @@ async def invocations(body: InvocationRequest) -> StreamingResponse:
         question_id=metadata.get("question_id"),
         user_context={},
         correlation_id=metadata.get("correlation_id"),
+        foundry_call_id=foundry_call_id,
     )
 
     response_id = f"resp_{uuid.uuid4().hex}"

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -53,7 +53,11 @@ from strategies.hosted_strategies import (
     build_hosted_conversation,
     guard_hosted_strategy,
 )
-from util.foundry_platform import MissingFoundryCallContextError, require_foundry_call_id
+from util.foundry_platform import (
+    MISSING_CALL_CONTEXT_MESSAGE,
+    MissingFoundryCallContextError,
+    require_foundry_call_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -138,10 +142,7 @@ async def _hosted_stream(
     """
     guard_hosted_strategy(strategy_key)
     if strategy_key in HOSTED_TOOLBOX_STRATEGIES and not turn.foundry_call_id:
-        raise MissingFoundryCallContextError(
-            f"Strategy '{strategy_key}' requires a validated Foundry call id "
-            "to reach Toolbox; refusing to run without one."
-        )
+        raise MissingFoundryCallContextError(MISSING_CALL_CONTEXT_MESSAGE)
     strategy = await AgentStrategyFactory.get_strategy(
         strategy_key,
         hosted_runtime=True,
@@ -221,6 +222,37 @@ def _sse_generator(
                     full_text="".join(full_text),
                 ):
                     yield frame
+
+        except MissingFoundryCallContextError as exc:
+            # Defense-in-depth only: the normal ``/invocations`` path already
+            # rejects a missing/malformed call id with an HTTP 401 *before*
+            # ``StreamingResponse`` is constructed, so this branch cannot be
+            # reached from a real HTTP request today. It exists solely to
+            # correctly classify the error if some future/internal caller
+            # ever invokes ``_hosted_stream``/``_sse_generator`` directly and
+            # bypasses that precheck. By the time this generator body is
+            # running, SSE response headers (HTTP 200) are already committed
+            # to the client -- there is no way to retroactively send a 401
+            # here. We can only emit a distinctly-coded SSE error frame
+            # instead of silently downgrading it to a generic
+            # ``internal_error`` frame via the broad ``except Exception``
+            # below.
+            logger.warning(
+                "[hosted] Missing Foundry call context reached SSE generator "
+                "directly (bypassed /invocations precheck) for strategy=%s",
+                strategy_key,
+            )
+            if not error_emitted:
+                from api.responses_adapter import _sse
+                yield _sse(
+                    "error",
+                    {
+                        "type": "error",
+                        "code": "missing_call_context",
+                        "message": str(exc),
+                        "retryable": False,
+                    },
+                )
 
         except Exception:
             logger.exception("[hosted] Unhandled error in SSE generator")

--- a/src/connectors/mcp_client.py
+++ b/src/connectors/mcp_client.py
@@ -17,6 +17,8 @@ from opentelemetry.trace.propagation.tracecontext import (
     TraceContextTextMapPropagator,
 )
 
+from util.foundry_platform import FOUNDRY_CALL_ID_HEADER
+
 MCPTransport = Literal["sse", "streamable_http"]
 _SUPPORTED_TRANSPORTS = frozenset({"sse", "streamable_http"})
 _TRANSPORT_PATHS: dict[MCPTransport, str] = {
@@ -109,12 +111,23 @@ def resolve_mcp_endpoint(endpoint: str | None, transport: str | None) -> str:
 def build_mcp_headers(
     user_context: Mapping[str, Any] | None,
     api_key: str | None,
+    foundry_call_id: str | None = None,
 ) -> dict[str, str]:
-    """Create a fresh header mapping for one caller."""
+    """Create a fresh header mapping for one caller.
+
+    ``foundry_call_id`` is echoed outbound only: it is the opaque,
+    per-request call id the Foundry hosted-agent platform injects on the
+    inbound ``/invocations`` request. Toolbox uses it to resolve the
+    signed-in user and apply native document-level security -- this
+    codebase never reads or forwards an ``Authorization`` header, and never
+    sends caller/model identity fields or ``x-client`` group claims.
+    """
 
     headers = {"user-context": json.dumps(dict(user_context or {}))}
     if api_key:
         headers["X-API-KEY"] = api_key
+    if foundry_call_id:
+        headers[FOUNDRY_CALL_ID_HEADER] = foundry_call_id
     return headers
 
 
@@ -163,6 +176,7 @@ async def open_mcp_tool(
     timeout: int,
     user_context: Mapping[str, Any] | None,
     api_key: str | None,
+    foundry_call_id: str | None = None,
     http_client_factory: Callable[..., httpx.AsyncClient] = httpx.AsyncClient,
 ) -> AsyncIterator[MCPTool]:
     """Open one MCP tool and all of its request-scoped transport resources."""
@@ -172,7 +186,7 @@ async def open_mcp_tool(
 
     normalized_transport = normalize_mcp_transport(transport)
     url = resolve_mcp_endpoint(endpoint, normalized_transport)
-    headers = build_mcp_headers(user_context, api_key)
+    headers = build_mcp_headers(user_context, api_key, foundry_call_id)
 
     if normalized_transport == "sse":
         # The legacy SSE client is aiohttp-based and is not covered by the

--- a/src/orchestration/turn.py
+++ b/src/orchestration/turn.py
@@ -17,6 +17,12 @@ class TurnRequest:
     user_context: dict[str, Any] = field(default_factory=dict)
     request_access_token: str | None = None
     correlation_id: str | None = None
+    # Opaque, per-request Foundry hosted-agent call id
+    # ("x-agent-foundry-call-id"), validated at the HTTP boundary.
+    # Toolbox-integrated hosted strategies echo this outbound so Toolbox can
+    # resolve the signed-in user and apply native document-level security.
+    # Never log this value.
+    foundry_call_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/strategies/base_agent_strategy.py
+++ b/src/strategies/base_agent_strategy.py
@@ -39,6 +39,7 @@ class BaseAgentStrategy(ABC):
     strategy_type : AgentStrategies
     conversation : Dict
     user_context : Dict
+    foundry_call_id : Optional[str]
 
     def __init__(self):
         """
@@ -81,6 +82,10 @@ class BaseAgentStrategy(ABC):
         self.cosmos = None if self.hosted_runtime else get_cosmosdb_client()
 
         self.user_context = {}
+        # Opaque Foundry hosted-agent call id (x-agent-foundry-call-id),
+        # set only for Toolbox-integrated hosted strategies after HTTP-layer
+        # validation. See util.foundry_platform for the security rationale.
+        self.foundry_call_id: Optional[str] = None
 
     @classmethod
     async def create(cls):

--- a/src/strategies/hosted_strategies.py
+++ b/src/strategies/hosted_strategies.py
@@ -26,6 +26,14 @@ HOSTED_SERVER_THREAD_STRATEGIES: frozenset[str] = frozenset({
     "single_agent_rag",
 })
 
+# Strategies that call out to the Toolbox MCP server for retrieval and must
+# therefore carry a validated Foundry call id (ADR-0001, Azure/GPT-RAG#591).
+# Other hosted-eligible strategies use the classic Foundry IQ / OBO retrieval
+# path and are out of scope for this passthrough.
+HOSTED_TOOLBOX_STRATEGIES: frozenset[str] = frozenset({
+    "mcp",
+})
+
 
 class HostedConversationMessage(TypedDict):
     role: str

--- a/src/strategies/mcp_strategy.py
+++ b/src/strategies/mcp_strategy.py
@@ -153,6 +153,7 @@ class McpStrategy(BaseAgentStrategy):
                     timeout=self.mcp_server_timeout,
                     user_context=self.user_context,
                     api_key=self.mcp_server_api_key,
+                    foundry_call_id=self.foundry_call_id,
                 ) as mcp_tool:
                     connection_latency_ms = (
                         time.monotonic() - connection_started

--- a/src/util/foundry_platform.py
+++ b/src/util/foundry_platform.py
@@ -74,7 +74,14 @@ def require_foundry_call_id(headers: Mapping[str, str]) -> str:
     if (
         not call_id
         or len(call_id) > _MAX_CALL_ID_LENGTH
-        or not _VALID_CALL_ID.match(call_id)
+        # ``fullmatch`` (not ``match``) is required here: with ``^...$`` and
+        # no ``re.MULTILINE``, Python's ``$`` matches just before a single
+        # trailing "\n", so ``.match()`` would wrongly accept a value like
+        # "call-id\n". ``extract_foundry_call_id`` already strips such
+        # values, but validation must not rely on that as its only defense
+        # -- ``fullmatch`` anchors to the true end of the string so this
+        # check is safe even if called directly with an unstripped value.
+        or not _VALID_CALL_ID.fullmatch(call_id)
     ):
         raise MissingFoundryCallContextError(
             "Missing or malformed platform call context "

--- a/src/util/foundry_platform.py
+++ b/src/util/foundry_platform.py
@@ -1,0 +1,86 @@
+"""Foundry hosted-agent container protocol 2.0 header contract.
+
+The Foundry hosted-agent platform gateway drops caller headers outside a
+fixed allow-list before a request reaches this container -- most importantly,
+``Authorization`` never arrives here and can never be read or forwarded by
+this codebase. Two platform-injected headers survive the gateway:
+
+- ``x-agent-user-id``: an opaque *global partition key* for the caller, used
+  only for container-side state partitioning. It is not an authenticated
+  identity assertion, must never be forwarded to Toolbox or any other
+  downstream service, and must never be used to authorize document access.
+- ``x-agent-foundry-call-id``: an opaque *per-request* call identifier. Per
+  the Foundry hosted-agent contract this is the ONLY thing echoed on
+  outbound Foundry/Toolbox-bound HTTP calls. Toolbox resolves the signed-in
+  user from this call id server-side -- where the real OAuth context lives
+  -- and applies native, per-user document trimming.
+
+ADR-0001 (Azure/GPT-RAG) freezes this passthrough as the required hosted
+document-security path: a group-filter or manual ``metadata_security_id``
+fallback is not a hosted default. When the call id is absent or malformed,
+hosted retrieval must fail closed instead of silently falling back to
+service identity or a manual filter.
+
+Never log the call id value, nor whether it was present, above debug level.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Mapping, Optional
+
+# Platform-injected header carrying the opaque, per-request call id. This is
+# the ONLY header echoed outbound on Foundry/Toolbox-bound HTTP calls.
+FOUNDRY_CALL_ID_HEADER = "x-agent-foundry-call-id"
+
+# Platform-injected header carrying an opaque per-user partition key.
+# Container-side state partitioning only -- never forwarded downstream and
+# never treated as an identity or authorization assertion.
+FOUNDRY_USER_ID_HEADER = "x-agent-user-id"
+
+_MAX_CALL_ID_LENGTH = 256
+# Printable, visible ASCII only. This blocks header injection (no CR/LF or
+# other whitespace) when the value is echoed on an outbound request, while
+# still accepting any opaque platform-issued identifier (GUID, base64url
+# token, etc.).
+_VALID_CALL_ID = re.compile(r"^[\x21-\x7e]+$")
+
+
+class MissingFoundryCallContextError(ValueError):
+    """The platform-injected Foundry call context is absent or malformed.
+
+    Hosted retrieval must fail closed on this error rather than falling back
+    to service identity or a manual ``metadata_security_id`` filter.
+    """
+
+
+def extract_foundry_call_id(headers: Mapping[str, str]) -> Optional[str]:
+    """Return the raw, unvalidated ``x-agent-foundry-call-id`` header value."""
+    value = headers.get(FOUNDRY_CALL_ID_HEADER)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def require_foundry_call_id(headers: Mapping[str, str]) -> str:
+    """Return the validated opaque Foundry call id, or fail closed.
+
+    Raises :class:`MissingFoundryCallContextError` when the header is
+    missing, empty, too long, or contains characters that would allow
+    outbound header injection when echoed to Toolbox.
+    """
+    call_id = extract_foundry_call_id(headers)
+    if (
+        not call_id
+        or len(call_id) > _MAX_CALL_ID_LENGTH
+        or not _VALID_CALL_ID.match(call_id)
+    ):
+        raise MissingFoundryCallContextError(
+            "Missing or malformed platform call context "
+            f"('{FOUNDRY_CALL_ID_HEADER}'). Hosted retrieval requires the "
+            "Foundry-injected call id to resolve per-user document security "
+            "through Toolbox; refusing to fall back to service identity or "
+            "a manual metadata filter."
+        )
+    return call_id

--- a/src/util/foundry_platform.py
+++ b/src/util/foundry_platform.py
@@ -45,6 +45,22 @@ _MAX_CALL_ID_LENGTH = 256
 # token, etc.).
 _VALID_CALL_ID = re.compile(r"^[\x21-\x7e]+$")
 
+# Canonical, safe-to-expose message reused at every point that fails closed
+# on a missing/malformed Foundry call context: the pre-``StreamingResponse``
+# HTTP 401 guard in ``api.hosted_entrypoint.invocations`` and the
+# defense-in-depth check inside ``api.hosted_entrypoint._hosted_stream``
+# (which guards direct/internal callers that might bypass that HTTP
+# precheck). Keeping one shared string means every fail-closed path reports
+# identical, reviewable text -- never the call id value, never strategy
+# internals, never auth header content.
+MISSING_CALL_CONTEXT_MESSAGE = (
+    "Missing or malformed platform call context "
+    f"('{FOUNDRY_CALL_ID_HEADER}'). Hosted retrieval requires the "
+    "Foundry-injected call id to resolve per-user document security "
+    "through Toolbox; refusing to fall back to service identity or "
+    "a manual metadata filter."
+)
+
 
 class MissingFoundryCallContextError(ValueError):
     """The platform-injected Foundry call context is absent or malformed.
@@ -83,11 +99,5 @@ def require_foundry_call_id(headers: Mapping[str, str]) -> str:
         # check is safe even if called directly with an unstripped value.
         or not _VALID_CALL_ID.fullmatch(call_id)
     ):
-        raise MissingFoundryCallContextError(
-            "Missing or malformed platform call context "
-            f"('{FOUNDRY_CALL_ID_HEADER}'). Hosted retrieval requires the "
-            "Foundry-injected call id to resolve per-user document security "
-            "through Toolbox; refusing to fall back to service identity or "
-            "a manual metadata filter."
-        )
+        raise MissingFoundryCallContextError(MISSING_CALL_CONTEXT_MESSAGE)
     return call_id

--- a/tests/test_foundry_platform.py
+++ b/tests/test_foundry_platform.py
@@ -1,0 +1,123 @@
+"""Direct unit tests for the Foundry hosted-agent call-context contract.
+
+These exercise ``util.foundry_platform`` in isolation (no HTTP layer), so
+that the validation semantics are proven independent of how the header
+happens to be extracted. See ``tests/test_hosted_responses.py`` for
+integration-level coverage through the ``/invocations`` endpoint.
+"""
+
+import pytest
+
+from util import foundry_platform
+from util.foundry_platform import (
+    FOUNDRY_CALL_ID_HEADER,
+    MissingFoundryCallContextError,
+    extract_foundry_call_id,
+    require_foundry_call_id,
+)
+
+
+class TestExtractFoundryCallId:
+    def test_returns_none_when_header_absent(self):
+        assert extract_foundry_call_id({}) is None
+
+    def test_returns_none_for_whitespace_only_value(self):
+        assert extract_foundry_call_id({FOUNDRY_CALL_ID_HEADER: "   "}) is None
+
+    def test_strips_surrounding_whitespace(self):
+        headers = {FOUNDRY_CALL_ID_HEADER: "  call-abc-123  "}
+        assert extract_foundry_call_id(headers) == "call-abc-123"
+
+
+class TestRequireFoundryCallId:
+    def test_returns_validated_call_id(self):
+        headers = {FOUNDRY_CALL_ID_HEADER: "call-abc-123"}
+        assert require_foundry_call_id(headers) == "call-abc-123"
+
+    def test_raises_when_header_missing(self):
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id({})
+
+    def test_raises_when_header_empty(self):
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id({FOUNDRY_CALL_ID_HEADER: ""})
+
+    def test_raises_when_header_whitespace_only(self):
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id({FOUNDRY_CALL_ID_HEADER: "   "})
+
+    def test_raises_when_too_long(self):
+        headers = {FOUNDRY_CALL_ID_HEADER: "x" * 257}
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id(headers)
+
+    def test_accepts_max_length(self):
+        headers = {FOUNDRY_CALL_ID_HEADER: "x" * 256}
+        assert require_foundry_call_id(headers) == "x" * 256
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "has spaces",
+            "embedded\nnewline",
+            "embedded\rcarriage",
+            "embedded\ttab",
+        ],
+    )
+    def test_raises_for_embedded_whitespace(self, bad_value):
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id({FOUNDRY_CALL_ID_HEADER: bad_value})
+
+    def test_error_message_never_includes_the_call_id_value(self):
+        """The failure message documents the header name, not any value --
+        even a rejected one must not be echoed into logs/errors."""
+        secret_looking_value = "super-secret-token-should-not-leak"
+        with pytest.raises(MissingFoundryCallContextError) as exc_info:
+            require_foundry_call_id(
+                {FOUNDRY_CALL_ID_HEADER: f"{secret_looking_value} has spaces"}
+            )
+        assert secret_looking_value not in str(exc_info.value)
+
+    def test_rejects_trailing_newline_even_when_extraction_does_not_strip(
+        self, monkeypatch
+    ):
+        """Regression test.
+
+        ``_VALID_CALL_ID`` is anchored with ``^...$`` and no
+        ``re.MULTILINE``. Used with ``.match()``, Python's ``$`` matches
+        just before a single trailing "\\n", so a raw value of
+        "call-id\\n" would incorrectly pass validation. Today
+        ``extract_foundry_call_id`` strips such values before they reach
+        the regex, masking the defect end-to-end -- but validation must
+        not depend on that as its only safeguard, since a future direct
+        call to ``require_foundry_call_id`` (or a refactor of
+        extraction) could bypass the strip. This test forces exactly
+        that scenario by making extraction hand back an unstripped,
+        trailing-newline value, proving the regex check itself
+        (``fullmatch``) rejects it.
+        """
+        monkeypatch.setattr(
+            foundry_platform, "extract_foundry_call_id", lambda headers: "call-id\n"
+        )
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id({})
+
+    def test_rejects_trailing_carriage_return_even_when_extraction_does_not_strip(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            foundry_platform, "extract_foundry_call_id", lambda headers: "call-id\r"
+        )
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id({})
+
+    def test_validation_regex_uses_fullmatch_not_match_semantics(self):
+        """Direct regression test on the compiled pattern itself: proves
+        the historical ``.match()`` leniency (trailing "\\n" accepted)
+        is no longer how validation behaves, by asserting ``fullmatch``
+        -- which ``require_foundry_call_id`` now uses -- rejects it even
+        though ``.match()`` on the very same pattern object would not.
+        """
+        pattern = foundry_platform._VALID_CALL_ID
+        assert pattern.match("call-id\n") is not None  # historical leniency
+        assert pattern.fullmatch("call-id\n") is None  # fixed validation path

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -836,6 +836,51 @@ class TestHostedStream:
         ]
 
 
+class TestSseGeneratorErrorClassification:
+    """Regression coverage for the SSE error-classification gap: a
+    ``MissingFoundryCallContextError`` raised inside ``_hosted_stream`` must
+    be reported with a distinct, non-generic SSE error code -- it must never
+    be silently downgraded to ``internal_error`` by ``_sse_generator``'s
+    broad ``except Exception`` clause.
+
+    Exercises ``_sse_generator`` directly (not just ``_hosted_stream``),
+    bypassing the ``/invocations`` HTTP handler's precheck entirely, to
+    simulate a hypothetical future/internal caller that reaches the
+    generator without that HTTP-level 401 guard ever running."""
+
+    @pytest.mark.asyncio
+    async def test_missing_call_context_is_not_downgraded_to_internal_error(self):
+        from api.hosted_entrypoint import _sse_generator
+        from util.foundry_platform import MISSING_CALL_CONTEXT_MESSAGE
+
+        turn = TurnRequest(ask="Hi", conversation_id="conv-1")  # no foundry_call_id
+        factory = AsyncMock()
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=factory,
+        ):
+            frames = [
+                frame
+                async for frame in _sse_generator(turn, "mcp", _RESP_ID, _ITEM_ID)
+            ]
+
+        # Fail closed before any strategy/Toolbox call is even attempted.
+        factory.assert_not_called()
+
+        parsed = _parse_frames(frames)
+        error_frames = [frame for frame in parsed if frame["event"] == "error"]
+        assert len(error_frames) == 1
+        error_data = error_frames[0]["data"]
+        assert error_data["code"] == "missing_call_context"
+        assert error_data["code"] != "internal_error"
+        assert error_data["message"] == MISSING_CALL_CONTEXT_MESSAGE
+
+        # Nothing else was emitted: no partial content, no terminal/closing
+        # frames after the error (consistent with error_emitted semantics).
+        assert parsed == error_frames
+
+
 class TestHostedConstruction:
     @pytest.mark.parametrize("strategy_key", sorted(HOSTED_ELIGIBLE_STRATEGIES))
     @pytest.mark.asyncio

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
@@ -411,6 +412,70 @@ class TestHostedStream:
                 pass  # pragma: no cover
 
     @pytest.mark.asyncio
+    async def test_toolbox_strategy_fails_closed_without_foundry_call_id(self):
+        """ADR-0001: the mcp/Toolbox path must refuse to run without a
+        validated platform call id rather than silently using service
+        identity or a manual metadata filter."""
+        from api.hosted_entrypoint import _hosted_stream
+        from util.foundry_platform import MissingFoundryCallContextError
+
+        turn = TurnRequest(ask="Hi", conversation_id="conv-1")  # no foundry_call_id
+        factory = AsyncMock()
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=factory,
+        ):
+            with pytest.raises(MissingFoundryCallContextError):
+                async for _ in _hosted_stream(turn, "mcp"):
+                    pass  # pragma: no cover
+
+        # No fallback: the strategy must never even be constructed.
+        factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_toolbox_strategy_propagates_validated_call_id(self):
+        from api.hosted_entrypoint import _hosted_stream
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+        turn = TurnRequest(ask="Hi", conversation_id="conv-1", foundry_call_id="call-abc")
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            [e async for e in _hosted_stream(turn, "mcp")]
+
+        assert strategy.foundry_call_id == "call-abc"
+
+    @pytest.mark.asyncio
+    async def test_non_toolbox_strategy_does_not_require_foundry_call_id(self):
+        """Classic hosted-eligible strategies that don't call Toolbox (e.g.
+        maf_lite, which uses the OBO-based Foundry IQ path) are unaffected
+        by the Toolbox call-id guard."""
+        from api.hosted_entrypoint import _hosted_stream
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+        turn = TurnRequest(ask="Hi", conversation_id="conv-1")  # no foundry_call_id
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            events = [e async for e in _hosted_stream(turn, "maf_lite")]
+
+        assert any(isinstance(e, TurnTextEvent) for e in events)
+        assert strategy.foundry_call_id is None
+
+    @pytest.mark.asyncio
     async def test_generates_conversation_id_when_none_provided(self):
         from api.hosted_entrypoint import _hosted_stream
 
@@ -444,7 +509,9 @@ class TestHostedStream:
 
         strategy = MagicMock()
         strategy.initiate_agent_flow = flow_with_citation
-        turn = TurnRequest(ask="Hi", conversation_id="conv-1")
+        turn = TurnRequest(
+            ask="Hi", conversation_id="conv-1", foundry_call_id="call-1"
+        )
 
         with patch(
             "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
@@ -495,14 +562,22 @@ class TestHostedStream:
                 new=AsyncMock(return_value="conv-1"),
             ),
         ):
-            first_turn = TurnRequest(ask="first question", conversation_id="conv-1")
+            first_turn = TurnRequest(
+                ask="first question",
+                conversation_id="conv-1",
+                foundry_call_id="call-1",
+            )
             [event async for event in _hosted_stream(first_turn, strategy_key)]
 
             prior_history = [
                 {"role": "user", "text": "first question"},
                 {"role": "assistant", "text": "answer to first question"},
             ]
-            second_turn = TurnRequest(ask="follow-up", conversation_id="conv-1")
+            second_turn = TurnRequest(
+                ask="follow-up",
+                conversation_id="conv-1",
+                foundry_call_id="call-1",
+            )
             [event async for event in _hosted_stream(
                 second_turn,
                 strategy_key,
@@ -1061,6 +1136,208 @@ class TestHostedEntrypointAPI:
             },
             "user_context": {},
         }
+
+    # ── ADR-0001 Foundry Toolbox call-id passthrough (Azure/GPT-RAG#591) ────
+
+    @staticmethod
+    def _use_strategy(mock_config, strategy_key: str) -> None:
+        original = mock_config.get.side_effect
+        mock_config.get.side_effect = (
+            lambda key, default=None, type=str:
+            strategy_key if key == "AGENT_STRATEGY" else original(key, default, type)
+        )
+
+    def test_invocations_rejects_missing_foundry_call_id_for_toolbox_strategy(
+        self, client, mock_config
+    ):
+        """The mcp strategy talks to Toolbox and must fail closed (401) when
+        the platform-injected call id is absent, instead of silently
+        proceeding with service identity or a manual metadata filter."""
+        self._use_strategy(mock_config, "mcp")
+
+        factory = AsyncMock()
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=factory,
+        ):
+            resp = client.post(
+                "/invocations",
+                json={"messages": [{"role": "user", "content": "Hello"}]},
+            )
+
+        assert resp.status_code == 401
+        assert "x-agent-foundry-call-id" in resp.json()["detail"]
+        # No fallback: the strategy must never even be constructed.
+        factory.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "bad_call_id",
+        [
+            "has spaces",
+            "line\nbreak",
+            "carriage\rreturn",
+            "x" * 257,
+        ],
+    )
+    def test_invocations_rejects_malformed_foundry_call_id(
+        self, client, mock_config, bad_call_id
+    ):
+        self._use_strategy(mock_config, "mcp")
+
+        factory = AsyncMock()
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=factory,
+        ):
+            resp = client.post(
+                "/invocations",
+                json={"messages": [{"role": "user", "content": "Hello"}]},
+                headers={"x-agent-foundry-call-id": bad_call_id},
+            )
+
+        assert resp.status_code == 401
+        factory.assert_not_called()
+
+    def test_invocations_accepts_valid_foundry_call_id_for_toolbox_strategy(
+        self, client, mock_config
+    ):
+        self._use_strategy(mock_config, "mcp")
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            resp = client.post(
+                "/invocations",
+                json={"messages": [{"role": "user", "content": "Hello"}]},
+                headers={"x-agent-foundry-call-id": "call-abc-123"},
+            )
+
+        assert resp.status_code == 200
+        assert strategy.foundry_call_id == "call-abc-123"
+
+    def test_invocations_non_toolbox_strategy_does_not_require_foundry_call_id(
+        self, client, mock_config
+    ):
+        """Classic behavior unchanged: strategies that don't call Toolbox
+        (e.g. maf_lite) still work with no call-id header at all."""
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            resp = client.post(
+                "/invocations",
+                json={"messages": [{"role": "user", "content": "Hello"}]},
+            )
+
+        assert resp.status_code == 200
+        assert strategy.foundry_call_id is None
+
+    def test_invocations_never_logs_foundry_call_id_or_authorization(
+        self, client, mock_config, caplog
+    ):
+        """Neither the opaque call id nor a (never-forwarded) Authorization
+        header value may ever appear in application logs."""
+        self._use_strategy(mock_config, "mcp")
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        secret_call_id = "super-secret-call-id-000"
+        secret_bearer = "Bearer should-never-be-read-or-forwarded"
+
+        with (
+            patch(
+                "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+                new=AsyncMock(return_value=strategy),
+            ),
+            caplog.at_level(logging.DEBUG),
+        ):
+            resp = client.post(
+                "/invocations",
+                json={"messages": [{"role": "user", "content": "Hello"}]},
+                headers={
+                    "x-agent-foundry-call-id": secret_call_id,
+                    "Authorization": secret_bearer,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert secret_call_id not in caplog.text
+        assert secret_bearer not in caplog.text
+        assert "should-never-be-read-or-forwarded" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_invocations_concurrent_requests_isolate_foundry_call_ids(
+        self, mock_config, mock_cosmos
+    ):
+        """Two concurrent /invocations requests for the mcp strategy must
+        never cross-contaminate each other's Foundry call id."""
+        from httpx import ASGITransport, AsyncClient
+
+        from api.hosted_entrypoint import app
+
+        self._use_strategy(mock_config, "mcp")
+        captured: dict[str, str | None] = {}
+
+        class RecordingStrategy:
+            def __init__(self, delay: float):
+                self._delay = delay
+
+            def set_context(self, _conversation_id):
+                pass
+
+            async def initiate_agent_flow(self, ask):
+                await asyncio.sleep(self._delay)
+                captured[ask] = self.foundry_call_id
+                yield "answer"
+
+        strategies = iter([RecordingStrategy(0.05), RecordingStrategy(0.0)])
+
+        async def fake_get_strategy(_strategy_key, hosted_runtime=False):
+            return next(strategies)
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=fake_get_strategy,
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+                responses = await asyncio.gather(
+                    async_client.post(
+                        "/invocations",
+                        json={"messages": [{"role": "user", "content": "ask-a"}]},
+                        headers={"x-agent-foundry-call-id": "call-a"},
+                    ),
+                    async_client.post(
+                        "/invocations",
+                        json={"messages": [{"role": "user", "content": "ask-b"}]},
+                        headers={"x-agent-foundry-call-id": "call-b"},
+                    ),
+                )
+
+        for resp in responses:
+            assert resp.status_code == 200
+            assert resp.text  # force full body consumption
+
+        assert captured == {"ask-a": "call-a", "ask-b": "call-b"}
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -97,6 +97,32 @@ def test_build_mcp_headers_only_sets_request_identity_and_optional_key():
     assert build_mcp_headers(None, None) == {"user-context": "{}"}
 
 
+def test_build_mcp_headers_echoes_foundry_call_id_when_present():
+    """The opaque Foundry call id is echoed outbound so Toolbox can resolve
+    the signed-in user's identity (ADR-0001 / Azure/GPT-RAG#591)."""
+
+    headers = build_mcp_headers(
+        {"principal_id": "user-1"},
+        "secret",
+        foundry_call_id="call-abc-123",
+    )
+
+    assert headers["x-agent-foundry-call-id"] == "call-abc-123"
+    # No caller/model identity or Authorization ever gets echoed outbound.
+    assert "Authorization" not in headers
+    assert "x-agent-user-id" not in headers
+    assert "x-client" not in headers
+
+
+@pytest.mark.parametrize("foundry_call_id", [None, ""])
+def test_build_mcp_headers_omits_foundry_call_id_when_absent(foundry_call_id):
+    headers = build_mcp_headers(
+        {"principal_id": "user-1"}, "secret", foundry_call_id=foundry_call_id
+    )
+
+    assert "x-agent-foundry-call-id" not in headers
+
+
 def test_legacy_sse_adapter_uses_request_scoped_headers(monkeypatch):
     captured = {}
 
@@ -194,6 +220,61 @@ async def test_streamable_http_clients_isolate_concurrent_users(monkeypatch):
     }
     assert all(client.closed for client in clients)
     assert all(tool.closed for tool in tools)
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_clients_isolate_concurrent_foundry_call_ids(
+    monkeypatch,
+):
+    """Two concurrent Toolbox-bound requests must never cross-contaminate
+    each other's per-request call id (ADR-0001 / Azure/GPT-RAG#591)."""
+
+    clients = []
+
+    class FakeHTTPClient:
+        def __init__(self, **kwargs):
+            self.headers = kwargs["headers"]
+
+        async def __aenter__(self):
+            clients.append(self)
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            return None
+
+    class FakeMCPTool:
+        def __init__(self, **kwargs):
+            self.functions = []
+
+        async def __aenter__(self):
+            await asyncio.sleep(0)
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            return None
+
+    monkeypatch.setattr(mcp_client, "MCPStreamableHTTPTool", FakeMCPTool)
+
+    async def connect(call_id):
+        async with open_mcp_tool(
+            endpoint="https://example.test",
+            transport="streamable_http",
+            timeout=30,
+            user_context={"principal_id": call_id},
+            api_key=None,
+            foundry_call_id=call_id,
+            http_client_factory=FakeHTTPClient,
+        ):
+            await asyncio.sleep(0)
+
+    await asyncio.gather(connect("call-one"), connect("call-two"))
+
+    assert len(clients) == 2
+    observed = {
+        client.headers["x-agent-foundry-call-id"] for client in clients
+    }
+    assert observed == {"call-one", "call-two"}
+    assert clients[0].headers is not clients[1].headers
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_strategy.py
+++ b/tests/test_mcp_strategy.py
@@ -187,6 +187,87 @@ async def test_mcp_strategy_streams_assistant_text_and_sums_usage(
 
 
 @pytest.mark.asyncio
+async def test_mcp_strategy_propagates_foundry_call_id_to_open_mcp_tool(
+    patch_dependencies,
+    mock_config,
+):
+    """The strategy must echo the validated Foundry call id outbound to
+    Toolbox via ``open_mcp_tool`` (ADR-0001 / Azure/GPT-RAG#591)."""
+
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {"id": "conversation"}
+    strategy.user_context = {}
+    strategy.foundry_call_id = "call-xyz-789"
+    state = {}
+    chat_client = _FakeChatClient()
+    fake_agent = _FakeAgent(
+        [AgentResponseUpdate(role="assistant", text="answer")]
+    )
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ),
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=chat_client,
+        ),
+    ):
+        _ = [
+            chunk
+            async for chunk in strategy.initiate_agent_flow("prompt")
+        ]
+
+    assert state["open_kwargs"]["foundry_call_id"] == "call-xyz-789"
+
+
+@pytest.mark.asyncio
+async def test_mcp_strategy_defaults_foundry_call_id_to_none(
+    patch_dependencies,
+    mock_config,
+):
+    """Classic (non-hosted) invocations never set ``foundry_call_id``; the
+    strategy must still function and pass ``None`` through unchanged."""
+
+    strategy = await _create_strategy(mock_config)
+    strategy.conversation = {"id": "conversation"}
+    strategy.user_context = {}
+    state = {}
+    chat_client = _FakeChatClient()
+    fake_agent = _FakeAgent(
+        [AgentResponseUpdate(role="assistant", text="answer")]
+    )
+
+    with (
+        patch(
+            "strategies.mcp_strategy.open_mcp_tool",
+            _fake_mcp_context(state),
+        ),
+        patch(
+            "strategies.mcp_strategy.ChatAgent",
+            return_value=fake_agent,
+        ),
+        patch.object(
+            strategy,
+            "_create_chat_client",
+            return_value=chat_client,
+        ),
+    ):
+        _ = [
+            chunk
+            async for chunk in strategy.initiate_agent_flow("prompt")
+        ]
+
+    assert state["open_kwargs"]["foundry_call_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_mcp_strategy_replays_ordered_hosted_history(
     patch_dependencies,
     mock_config,


### PR DESCRIPTION
## Summary

Fixes the concrete hosted Toolbox identity defect: the exact-released `v3.9.0`
`hosted_entrypoint.py` intentionally hardcodes `user_context={}` for hosted
retrieval, so every hosted `mcp`-strategy Toolbox call currently runs under
service identity instead of the signed-in user's own document-security
context.

Per [ADR-0001](https://github.com/Azure/GPT-RAG/blob/main/docs/adr/ADR-0001-hosted-agents.md),
Foundry Toolbox OAuth identity passthrough is the **required native**
document-security path for hosted agents — a manual group-filter fallback
(the legacy `metadata_security_id` mechanism used by `foundry_iq.py` for
classic OBO strategies) must never be the default for Toolbox-backed
retrieval.

## Security rationale

Microsoft Foundry hosted-agent protocol 2.0 injects two headers on every
hosted-agent request, and the platform gateway strips `Authorization` before
it ever reaches the container:

| Header | Purpose | Forwarded to Toolbox? |
| --- | --- | --- |
| `x-agent-user-id` | Per-user container partition key. | **No** — container-side only. |
| `x-agent-foundry-call-id` | Opaque per-request call identifier. | **Yes** — the only supported identity passthrough correlation token. |

This PR:

- Adds `util.foundry_platform`: header name constants,
  `MissingFoundryCallContextError`, and strict call-id validation
  (printable ASCII only, no CR/LF/space injection, 256-char max).
- Makes `POST /invocations` capture and validate `x-agent-foundry-call-id`
  whenever the resolved strategy is Toolbox-backed
  (`strategies.hosted_strategies.HOSTED_TOOLBOX_STRATEGIES = {"mcp"}`, the
  only strategy that talks to Toolbox today). **A missing or malformed call
  id is rejected with HTTP 401 before the strategy or any Toolbox client is
  constructed** — there is no service-identity or manual-filter fallback.
- Propagates the validated call id unchanged through the runtime-neutral
  `TurnRequest.foundry_call_id` → `BaseAgentStrategy.foundry_call_id` →
  `connectors.mcp_client.open_mcp_tool` / `build_mcp_headers`, which echo it
  as the **sole** outbound identity header on every Toolbox MCP HTTP call, so
  Toolbox can resolve the signed-in user and mint per-user credentials
  server-side.
- Adds defense-in-depth: `_hosted_stream` re-checks the call id for Toolbox
  strategies even though `/invocations` already validated it at the HTTP
  boundary.
- Never reads, stores, or forwards `Authorization`. Never trusts
  caller-/model-supplied identity fields or `x-client` group claims for
  retrieval security decisions. Never logs the call id or any authorization
  material.
- Leaves non-Toolbox hosted strategies (`maf_lite`, `maf_agent_service`,
  `single_agent_rag`) and the classic `foundry_iq.py` OBO/`metadata_security_id`
  path completely untouched — they keep running exactly as released in
  `v3.9.0`.

## Tests

Full suite: **632 passed**, 0 failed (`PYTHONPATH=src pytest -q`).

New/updated coverage proves:
- **Outbound header propagation** — call id present → echoed exactly on the
  outbound Toolbox HTTP request; call id absent/empty → header omitted, not
  sent as an empty/None value (`tests/test_mcp_client.py`).
- **Concurrent user isolation** — two concurrent MCP-client calls with
  different call ids never leak into each other's outbound headers
  (`tests/test_mcp_client.py`); a true concurrent `httpx.AsyncClient` +
  `ASGITransport` + `asyncio.gather` test at the `/invocations` HTTP boundary
  proves per-request isolation end-to-end (`tests/test_hosted_responses.py`).
- **Missing/malformed-context fail-closed** — no header, or a header with
  spaces/`\n`/`\r`/>256 chars, is rejected with 401 at `/invocations` and
  with `MissingFoundryCallContextError` at `_hosted_stream`, and the strategy
  factory is asserted **never called** (no fallback construction happens).
- **No service-identity / manual-filter fallback** — proven via the
  factory-never-called assertions above; the classic `metadata_security_id`
  path is untouched and has its own unaffected tests.
- **No sensitive logging** — a `caplog`-based test sends a secret call id and
  a secret `Authorization` header and asserts neither value (nor a substring
  of the bearer token) ever appears in emitted logs.
- **Unchanged classic behavior** — non-Toolbox hosted strategies
  (`maf_lite`) succeed with `foundry_call_id=None` and unchanged streamed
  output, both at the `_hosted_stream` level and the `/invocations` HTTP
  level.

## Toolbox / ingestion configuration required

No new orchestrator-side configuration keys are introduced — the existing
`MCP_APP_ENDPOINT`, `MCP_SERVER_TRANSPORT`, `MCP_CLIENT_TIMEOUT`, and
`MCP_APP_APIKEY` settings are unchanged. What's required operationally:

- The Foundry hosted-agent runtime must be running under **protocol 2.0**
  (or later) so `x-agent-foundry-call-id` is actually injected on
  `/invocations` requests. On older protocol versions this header will be
  absent and every Toolbox-backed (`mcp`) hosted request will fail closed
  with 401 — this is intentional (no silent service-identity fallback).
- The Toolbox/ingestion endpoint the `mcp` strategy points at
  (`MCP_APP_ENDPOINT`) must be the identity-aware Toolbox surface that
  understands the opaque `x-agent-foundry-call-id` correlation token and can
  resolve it back to a signed-in user and mint per-user credentials
  server-side. A Toolbox endpoint that does not understand this header will
  simply ignore it and continue to serve under its own default identity —
  this PR only guarantees the orchestrator *sends* the correct token, not
  that the downstream Toolbox implementation *honors* it.
- `AGENT_STRATEGY=mcp` (or another future entry added to
  `HOSTED_TOOLBOX_STRATEGIES`) selects the Toolbox-backed hosted path that
  now requires this header; other hosted strategies are unaffected.

## Remaining live consent/RBAC gate

**Toolbox-side OAuth consent and RBAC grants for the signed-in user remain an
external, platform-managed prerequisite** and are explicitly out of scope for
this repo. This PR guarantees the orchestrator captures, validates, and
faithfully propagates the correlation identity (the opaque call id) Toolbox
needs — it does **not** grant, request, or manage OAuth consent, nor does it
provision RBAC on the underlying document store. For the passthrough to
actually restrict retrieval per-user in production, the Toolbox/ingestion
service and the Foundry hosted-agent platform must independently:
1. Have completed the signed-in user's OAuth consent flow for document
   access, and
2. Have that user correctly RBAC-scoped against the underlying content
   security trimming (e.g. ACL/group-based document permissions) on the
   ingestion side.

Related: Azure/GPT-RAG#591