### PR TITLE
Fix release PR policy for main

### DIFF
--- a/.github/workflows/block-pr-to-main.yml
+++ b/.github/workflows/block-pr-to-main.yml
@@ -15,8 +15,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate source branch
+        id: branch-policy
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HEAD_REF" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Post comment on opened or reopened PRs
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        if: steps.branch-policy.outputs.allowed != 'true' && (github.event.action == 'opened' || github.event.action == 'reopened')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,9 +37,9 @@ jobs:
 
             This repository follows a branching strategy where:
             - \`develop\` is the integration branch for all contributions
-            - \`main\` is updated only via merges from \`develop\`
+            - \`main\` accepts pull requests only from release branches named exactly \`release/<MAJOR>.<MINOR>.<PATCH>\`
 
-            **Please change the base branch of this pull request to \`develop\`.**
+            **Unless this is a release pull request, please change the base branch of this pull request to \`develop\`.**
 
             You can do this by clicking **Edit** at the top right of the PR and changing the base branch dropdown from \`main\` to \`develop\`.
 
@@ -42,6 +53,7 @@ jobs:
             });
 
       - name: Fail the workflow
+        if: steps.branch-policy.outputs.allowed != 'true'
         run: |
-          echo "::error::Pull requests targeting 'main' are not allowed. Please change the base branch to 'develop'."
+          echo "::error::Only release branches named exactly 'release/<MAJOR>.<MINOR>.<PATCH>' may target 'main'. Please change the base branch to 'develop'."
           exit 1


### PR DESCRIPTION
## Purpose
Correct the target-branch policy so release PRs can follow the required `release/X.Y.Z -> main` flow while ordinary feature PRs remain blocked.

## Work type
Workflow policy bug fix (authorized direct-to-main correction).

## Target branch
`main`

## Changes
- Allow only head refs matching exactly `release/<MAJOR>.<MINOR>.<PATCH>`, with decimal-digit components.
- Keep the policy job present and green for valid release branches.
- Continue commenting on and failing invalid PRs, with corrected guidance.

## Validation
- `git diff --check`
- Parsed `.github/workflows/block-pr-to-main.yml` with PyYAML.
- Exercised the extracted branch regex against 14 representative valid and invalid refs.
- Confirmed the branch started at current `origin/main`.

## Documentation
No published documentation impact; the workflow's explanatory comment is updated in place.

## Compatibility and security
No runtime, API, SSE, persistence, configuration, strategy, deployment, package, release, tag, or Azure-resource changes. The untrusted PR head ref is passed through an environment variable rather than interpolated into shell code.

## Merge note and follow-up
The old `Block PRs to main / block-pr` check is expected to fail because `pull_request_target` evaluates the workflow from the current base branch. A one-time administrative bypass is authorized for this correction. After merge, synchronize PR #289 so this corrected base workflow is reevaluated.