### PR TITLE
fix(hosted-agent): add Foundry readiness endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Microsoft Foundry hosted-agent readiness probe contract.** Added
+  `GET /readiness` to `api.hosted_entrypoint` so the platform readiness probe no
+  longer receives HTTP 404 after Uvicorn starts. The existing `GET /health`
+  compatibility route remains available, and both endpoints return the same
+  immutable image version and hosted-eligible strategy set.
+
 ### Added
 
 - **Repository-local release skill with publication safety gates.**

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ per
 Toolbox OAuth identity passthrough is the required native path and a manual
 group-filter fallback is never the default.
 
+The hosted entrypoint exposes `GET /readiness` for Microsoft Foundry readiness
+probes. The compatibility `GET /health` route returns the same immutable image
+version and hosted-eligible strategy set.
+
 The platform injects two headers on every hosted-agent request:
 
 | Header | Purpose | Forwarded to Toolbox? |

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -9,7 +9,8 @@ classic ``main.py`` so that:
 - Only ADR-eligible strategies are admitted; unsupported strategies fail
   explicitly rather than silently falling back.
 - The hosted image is immutable: the ``VERSION`` file is read once at startup
-  and served on the ``GET /health`` endpoint.
+  and served on the ``GET /readiness`` and compatibility ``GET /health``
+  endpoints.
 
 Usage::
 
@@ -290,6 +291,15 @@ app = FastAPI(
     description=(
         "Returns the immutable image version and the set of strategies "
         "eligible for this hosted runtime.  Use for container readiness probes."
+    ),
+)
+@app.get(
+    "/readiness",
+    response_model=HealthResponse,
+    summary="Readiness check",
+    description=(
+        "Returns the immutable image version and the set of strategies "
+        "eligible for this hosted runtime."
     ),
 )
 async def health() -> HealthResponse:

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -997,21 +997,30 @@ class TestHostedEntrypointAPI:
 
         return TestClient(app, raise_server_exceptions=False)
 
-    def test_health_returns_ok(self, client):
-        resp = client.get("/health")
+    def test_health_and_readiness_return_same_health_response(self, client):
+        from api.hosted_entrypoint import HealthResponse, _APP_VERSION
+
+        expected = HealthResponse(
+            status="ok",
+            version=_APP_VERSION,
+            eligible_strategies=sorted(HOSTED_ELIGIBLE_STRATEGIES),
+        ).model_dump()
+
+        health = client.get("/health")
+        readiness = client.get("/readiness")
+
+        assert health.status_code == 200
+        assert readiness.status_code == 200
+        assert health.json() == expected
+        assert readiness.json() == expected
+        assert readiness.json() == health.json()
+
+    @pytest.mark.parametrize("route", ["/health", "/readiness"])
+    def test_readiness_routes_match_hosted_eligible_strategies(self, client, route):
+        resp = client.get(route)
 
         assert resp.status_code == 200
-        body = resp.json()
-        assert body["status"] == "ok"
-        assert "version" in body
-        assert isinstance(body["eligible_strategies"], list)
-        assert "maf_lite" in body["eligible_strategies"]
-
-    def test_health_eligible_strategies_matches_guard_set(self, client):
-        resp = client.get("/health")
-        body = resp.json()
-
-        assert set(body["eligible_strategies"]) == HOSTED_ELIGIBLE_STRATEGIES
+        assert set(resp.json()["eligible_strategies"]) == HOSTED_ELIGIBLE_STRATEGIES
 
     def test_invocations_rejects_unsupported_strategy(self, client, mock_config):
         original = mock_config.get.side_effect


### PR DESCRIPTION
## Summary
- expose GET /readiness from the hosted FastAPI entrypoint
- preserve GET /health compatibility with an identical immutable HealthResponse`n- document the hosted readiness contract and add route-parity regression coverage

## Validation
- python -m pytest tests\\test_hosted_responses.py -q (71 passed)
- python -m pytest -q (654 passed)