### PR TITLE
fix(hosted-agent): add Foundry responses endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- **Microsoft Foundry hosted-agent Responses route contract.** Added canonical
+  `POST /responses` routing to `api.hosted_entrypoint` so real Foundry Responses
+  requests no longer receive HTTP 404. The existing `POST /invocations` route
+  remains as a compatibility alias over the same request validation, identity
+  guard, and Responses API SSE handler.
+
 - **Microsoft Foundry hosted-agent readiness probe contract.** Added
   `GET /readiness` to `api.hosted_entrypoint` so the platform readiness probe no
   longer receives HTTP 404 after Uvicorn starts. The existing `GET /health`

--- a/README.md
+++ b/README.md
@@ -79,13 +79,16 @@ rewriting the existing SSE configuration.
 
 ### Foundry hosted-agent Toolbox identity passthrough
 
-When the orchestrator runs as a Microsoft Foundry hosted agent (`api.hosted_entrypoint`,
-`POST /invocations`) with `AGENT_STRATEGY=mcp`, document-security identity is
-established solely through the Foundry hosted-agent protocol 2.0 call context —
-per
+When the orchestrator runs as a Microsoft Foundry hosted agent
+(`api.hosted_entrypoint`, canonical `POST /responses`) with
+`AGENT_STRATEGY=mcp`, document-security identity is established solely through
+the Foundry hosted-agent protocol 2.0 call context — per
 [Azure/GPT-RAG ADR-0001](https://github.com/Azure/GPT-RAG/blob/main/docs/adr/ADR-0001-hosted-agents.md),
 Toolbox OAuth identity passthrough is the required native path and a manual
 group-filter fallback is never the default.
+
+The compatibility `POST /invocations` route uses the same request validation,
+identity guard, and Responses API SSE handler as `POST /responses`.
 
 The hosted entrypoint exposes `GET /readiness` for Microsoft Foundry readiness
 probes. The compatibility `GET /health` route returns the same immutable image
@@ -98,7 +101,8 @@ The platform injects two headers on every hosted-agent request:
 | `x-agent-user-id` | Per-user container partition key. | No — container-side only. |
 | `x-agent-foundry-call-id` | Opaque per-request call identifier. | Yes — the only supported identity passthrough correlation token. |
 
-`POST /invocations` captures and strictly validates `x-agent-foundry-call-id`
+`POST /responses` and its `POST /invocations` compatibility alias capture and
+strictly validate `x-agent-foundry-call-id`
 (printable ASCII, no spaces or control characters, 256 characters max)
 whenever the resolved strategy is Toolbox-backed (currently only `mcp`). A
 missing or malformed value is rejected with **HTTP 401** before any strategy

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -310,16 +310,15 @@ async def health() -> HealthResponse:
     )
 
 
-@app.post(
-    "/invocations",
-    summary="Handle a Foundry invocation",
-    description=(
+_HOSTED_RESPONSES_ROUTE_OPTIONS: dict[str, Any] = {
+    "summary": "Handle a Foundry response",
+    "description": (
         "Accepts one conversation turn from the Foundry runtime and streams "
         "a response in the Azure AI Foundry Responses API SSE format.  "
         "Only hosted-eligible strategies are admitted; unsupported strategies "
         "return HTTP 422."
     ),
-    responses={
+    "responses": {
         200: {
             "description": "OK — Responses API SSE stream",
             "content": {"text/event-stream": {}},
@@ -350,9 +349,22 @@ async def health() -> HealthResponse:
             },
         },
     },
+}
+
+
+@app.post(
+    "/invocations",
+    **_HOSTED_RESPONSES_ROUTE_OPTIONS,
+)
+@app.post(
+    "/responses",
+    **_HOSTED_RESPONSES_ROUTE_OPTIONS,
 )
 async def invocations(request: Request, body: InvocationRequest) -> StreamingResponse:
-    """Translate a Foundry invocation into a Responses API SSE stream.
+    """Translate a Foundry Responses request into a Responses API SSE stream.
+
+    ``POST /responses`` is the canonical Microsoft Foundry route.
+    ``POST /invocations`` remains as a compatibility alias.
 
     The final message must be the current user ask. Messages after the current
     ask are rejected rather than silently discarded. Responses-backed

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -5,7 +5,7 @@ Covers:
 - Terminal closing frames after the text stream
 - Hosted strategy guard (explicit failure for unsupported strategies)
 - Hosted stream execution without Cosmos dependency
-- Hosted FastAPI endpoints (health and invocations)
+- Hosted FastAPI endpoints (health, readiness, responses, and invocations)
 """
 
 from __future__ import annotations
@@ -1021,6 +1021,59 @@ class TestHostedEntrypointAPI:
 
         assert resp.status_code == 200
         assert set(resp.json()["eligible_strategies"]) == HOSTED_ELIGIBLE_STRATEGIES
+
+    def test_responses_and_invocations_share_route_contract(self, client):
+        paths = client.get("/openapi.json").json()["paths"]
+        responses_contract = paths["/responses"]["post"]
+        invocations_contract = paths["/invocations"]["post"]
+
+        assert responses_contract["requestBody"] == invocations_contract["requestBody"]
+        assert responses_contract["responses"] == invocations_contract["responses"]
+
+    def test_responses_and_invocations_reject_same_invalid_request(self, client):
+        payload = {"messages": [{"role": "assistant", "content": "Hi"}]}
+
+        responses = client.post("/responses", json=payload)
+        invocations = client.post("/invocations", json=payload)
+
+        assert responses.status_code == 422
+        assert responses.json() == invocations.json()
+
+    def test_responses_and_invocations_stream_identical_sse(self, client, mock_config):
+        original = mock_config.get.side_effect
+        mock_config.get.side_effect = (
+            lambda key, default=None, type=str:
+            "maf_lite" if key == "AGENT_STRATEGY" else original(key, default, type)
+        )
+
+        async def fake_flow(_ask):
+            yield "Hello "
+            yield "world"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+        payload = {
+            "messages": [{"role": "user", "content": "What is the policy?"}],
+            "conversation_id": "conv-route-parity",
+        }
+
+        with (
+            patch(
+                "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+                new=AsyncMock(return_value=strategy),
+            ),
+            patch(
+                "api.hosted_entrypoint.uuid.uuid4",
+                return_value=SimpleNamespace(hex="fixed-response-id"),
+            ),
+        ):
+            responses = client.post("/responses", json=payload)
+            invocations = client.post("/invocations", json=payload)
+
+        assert responses.status_code == 200
+        assert responses.headers["content-type"] == invocations.headers["content-type"]
+        assert responses.headers["X-Response-ID"] == invocations.headers["X-Response-ID"]
+        assert responses.text == invocations.text
 
     def test_invocations_rejects_unsupported_strategy(self, client, mock_config):
         original = mock_config.get.side_effect


### PR DESCRIPTION
## Summary
- expose canonical `POST /responses` for Microsoft Foundry hosted-agent requests
- preserve `POST /invocations` as an identical compatibility alias
- add OpenAPI, validation, and Responses SSE parity regression coverage

## Validation
- `python -m pytest tests\test_hosted_responses.py -q` (74 passed)
- `python -m pytest -q` (657 passed)