### PR TITLE
fix: accept Foundry Responses request schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@
 ### Fixed
 
 - **Microsoft Foundry hosted-agent Responses route contract.** Added canonical
-  `POST /responses` routing to `api.hosted_entrypoint` so real Foundry Responses
-  requests no longer receive HTTP 404. The existing `POST /invocations` route
-  remains as a compatibility alias over the same request validation, identity
-  guard, and Responses API SSE handler.
+  `POST /responses` handling for string `input`, `stream: true`, `store: true`,
+  optional string/object `conversation`, and optional `metadata`, so live
+  Foundry Responses requests no longer fail against the invocation-only
+  schema. Unsupported array/multimodal input, non-streaming requests, and
+  non-storing managed requests fail explicitly with HTTP 422. The existing
+  `POST /invocations` message-history contract remains compatible; both routes
+  share the strategy and call-id security guards, managed Conversation
+  handling, transport-neutral turn construction, and Responses API SSE
+  lifecycle.
 
 - **Microsoft Foundry hosted-agent readiness probe contract.** Added
   `GET /readiness` to `api.hosted_entrypoint` so the platform readiness probe no

--- a/README.md
+++ b/README.md
@@ -87,8 +87,19 @@ the Foundry hosted-agent protocol 2.0 call context — per
 Toolbox OAuth identity passthrough is the required native path and a manual
 group-filter fallback is never the default.
 
-The compatibility `POST /invocations` route uses the same request validation,
-identity guard, and Responses API SSE handler as `POST /responses`.
+The routes use distinct Microsoft Foundry request contracts:
+
+- Canonical `POST /responses` accepts a string `input`, `stream: true`,
+  `store: true`, optional `conversation` as either an id string or
+  `{"id": "..."}`, and optional `metadata`. Array/multimodal input,
+  non-streaming requests, and non-storing managed requests return HTTP 422.
+- Compatibility `POST /invocations` retains ordered
+  `messages`, optional `conversation_id`, and optional `metadata`, including
+  projection of prior message history.
+
+Both routes map to the same transport-neutral hosted turn execution, strategy
+guard, call-id security validation, managed Conversation handling, response
+identifiers, and Responses API SSE lifecycle.
 
 The hosted entrypoint exposes `GET /readiness` for Microsoft Foundry readiness
 probes. The compatibility `GET /health` route returns the same immutable image
@@ -101,8 +112,8 @@ The platform injects two headers on every hosted-agent request:
 | `x-agent-user-id` | Per-user container partition key. | No — container-side only. |
 | `x-agent-foundry-call-id` | Opaque per-request call identifier. | Yes — the only supported identity passthrough correlation token. |
 
-`POST /responses` and its `POST /invocations` compatibility alias capture and
-strictly validate `x-agent-foundry-call-id`
+`POST /responses` and compatibility `POST /invocations` capture and strictly
+validate `x-agent-foundry-call-id`
 (printable ASCII, no spaces or control characters, 256 characters max)
 whenever the resolved strategy is Toolbox-backed (currently only `mcp`). A
 missing or malformed value is rejected with **HTTP 401** before any strategy

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -30,7 +30,7 @@ from typing import Any, Literal, Optional, Sequence
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.responses_adapter import responses_terminal_events, serialize_responses_events
 from connectors.foundry_conversations import resolve_managed_conversation_id
@@ -70,7 +70,93 @@ except FileNotFoundError:
     _APP_VERSION = "0.0.0"
 
 
-# ── Pydantic schemas for the Foundry invocation contract ────────────────────
+# ── Pydantic schemas for the Foundry hosted-agent contracts ─────────────────
+
+
+class ResponseConversation(BaseModel):
+    """Conversation reference accepted by the Responses API."""
+
+    id: str = Field(..., description="Foundry-managed Conversation id")
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def validate_id(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError("Conversation id must be a string.")
+        value = value.strip()
+        if not value:
+            raise ValueError("Conversation id must not be empty.")
+        return value
+
+
+class ResponsesRequest(BaseModel):
+    """Supported subset of a canonical Microsoft Foundry Responses request.
+
+    Unknown standard Responses fields are ignored, matching the existing
+    Pydantic request-model convention. This adapter currently supports only
+    string input and SSE responses that may be stored by Foundry.
+    """
+
+    input: str = Field(..., description="Current user ask as plain text")
+    stream: bool = Field(..., description="Must be true; hosted execution is SSE-only")
+    store: bool = Field(
+        True,
+        description="Must be true; non-storing managed execution is not supported",
+    )
+    conversation: str | ResponseConversation | None = Field(
+        None,
+        description="Foundry-managed Conversation id or an object containing its id",
+    )
+    metadata: Optional[dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Request metadata such as correlation_id and question_id",
+    )
+
+    @field_validator("input", mode="before")
+    @classmethod
+    def validate_input(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError(
+                "Only string input is supported; array and multimodal input are not supported."
+            )
+        value = value.strip()
+        if not value:
+            raise ValueError("Input must not be empty or whitespace.")
+        return value
+
+    @field_validator("stream", mode="before")
+    @classmethod
+    def validate_stream(cls, value: Any) -> bool:
+        if value is not True:
+            raise ValueError(
+                "Only stream=true is supported; this hosted endpoint returns "
+                "an SSE stream."
+            )
+        return True
+
+    @field_validator("store", mode="before")
+    @classmethod
+    def validate_store(cls, value: Any) -> bool:
+        if value is not True:
+            raise ValueError(
+                "Only store=true is supported; non-storing managed execution is not supported."
+            )
+        return True
+
+    @field_validator("conversation", mode="before")
+    @classmethod
+    def validate_conversation(cls, value: Any) -> Any:
+        if value is None or isinstance(value, dict):
+            return value
+        if not isinstance(value, str):
+            raise ValueError(
+                "Conversation must be a string id or an object containing an id."
+            )
+        value = value.strip()
+        if not value:
+            raise ValueError("Conversation id must not be empty.")
+        return value
+
 
 class InvocationMessage(BaseModel):
     """One message turn in the inbound invocation request."""
@@ -225,8 +311,8 @@ def _sse_generator(
                     yield frame
 
         except MissingFoundryCallContextError as exc:
-            # Defense-in-depth only: the normal ``/invocations`` path already
-            # rejects a missing/malformed call id with an HTTP 401 *before*
+            # Defense-in-depth only: the normal hosted HTTP paths already
+            # reject a missing/malformed call id with an HTTP 401 *before*
             # ``StreamingResponse`` is constructed, so this branch cannot be
             # reached from a real HTTP request today. It exists solely to
             # correctly classify the error if some future/internal caller
@@ -240,7 +326,7 @@ def _sse_generator(
             # below.
             logger.warning(
                 "[hosted] Missing Foundry call context reached SSE generator "
-                "directly (bypassed /invocations precheck) for strategy=%s",
+                "directly (bypassed hosted route precheck) for strategy=%s",
                 strategy_key,
             )
             if not error_emitted:
@@ -310,93 +396,50 @@ async def health() -> HealthResponse:
     )
 
 
-_HOSTED_RESPONSES_ROUTE_OPTIONS: dict[str, Any] = {
-    "summary": "Handle a Foundry response",
-    "description": (
-        "Accepts one conversation turn from the Foundry runtime and streams "
-        "a response in the Azure AI Foundry Responses API SSE format.  "
-        "Only hosted-eligible strategies are admitted; unsupported strategies "
-        "return HTTP 422."
-    ),
-    "responses": {
-        200: {
-            "description": "OK — Responses API SSE stream",
-            "content": {"text/event-stream": {}},
-        },
-        401: {
-            "description": (
-                "Missing or malformed platform call context — hosted "
-                "retrieval failed closed rather than falling back to "
-                "service identity or a manual filter."
-            ),
-            "content": {
-                "application/json": {
-                    "example": {
-                        "detail": (
-                            "Missing or malformed platform call context "
-                            "('x-agent-foundry-call-id')."
-                        )
-                    }
+_HOSTED_STREAM_RESPONSES: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": "OK — Responses API SSE stream",
+        "content": {"text/event-stream": {}},
+    },
+    401: {
+        "description": (
+            "Missing or malformed platform call context — hosted retrieval "
+            "failed closed rather than falling back to service identity or a "
+            "manual filter."
+        ),
+        "content": {
+            "application/json": {
+                "example": {
+                    "detail": (
+                        "Missing or malformed platform call context "
+                        "('x-agent-foundry-call-id')."
+                    )
                 }
-            },
+            }
         },
-        422: {
-            "description": "Unsupported strategy or validation error",
-            "content": {
-                "application/json": {
-                    "example": {"detail": "Strategy 'multimodal' is not supported in the hosted runtime."}
+    },
+    422: {
+        "description": "Unsupported request value, strategy, or validation error",
+        "content": {
+            "application/json": {
+                "example": {
+                    "detail": "Strategy 'multimodal' is not supported in the hosted runtime."
                 }
-            },
+            }
         },
     },
 }
 
 
-@app.post(
-    "/invocations",
-    **_HOSTED_RESPONSES_ROUTE_OPTIONS,
-)
-@app.post(
-    "/responses",
-    **_HOSTED_RESPONSES_ROUTE_OPTIONS,
-)
-async def invocations(request: Request, body: InvocationRequest) -> StreamingResponse:
-    """Translate a Foundry Responses request into a Responses API SSE stream.
-
-    ``POST /responses`` is the canonical Microsoft Foundry route.
-    ``POST /invocations`` remains as a compatibility alias.
-
-    The final message must be the current user ask. Messages after the current
-    ask are rejected rather than silently discarded. Responses-backed
-    strategies validate a supplied ``conversation_id`` or create a real managed
-    Conversation when it is absent.
-
-    Toolbox-integrated strategies additionally require the platform-injected
-    ``x-agent-foundry-call-id`` header (Foundry hosted-agent container
-    protocol 2.0). This container never reads or forwards ``Authorization``,
-    and never trusts caller/model identity fields or ``x-client`` group
-    claims — the opaque call id is the only supported identity-passthrough
-    correlation, echoed to Toolbox so it can resolve the signed-in user and
-    supply per-user credentials. When the header is absent or malformed,
-    hosted retrieval fails closed with HTTP 401 rather than falling back to
-    service identity or a manual ``metadata_security_id`` filter.
-    """
-    current_message = body.messages[-1]
-    if current_message.role != "user":
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                "The final message must have role='user'; messages after the "
-                "current ask are not allowed."
-            ),
-        )
-    ask = current_message.content.strip()
-    if not ask:
-        raise HTTPException(
-            status_code=422,
-            detail="The last user message must not be empty.",
-        )
-
+def _handle_hosted_request(
+    request: Request,
+    *,
+    ask: str,
+    conversation_id: str | None,
+    metadata: dict[str, Any] | None,
+    history: Sequence[HostedConversationMessage] = (),
+) -> StreamingResponse:
+    """Apply shared hosted execution and security behavior to one turn."""
     # Resolve and guard the strategy.
     cfg = get_config()
     strategy_key = cfg.get("AGENT_STRATEGY", "maf_lite")
@@ -417,14 +460,10 @@ async def invocations(request: Request, body: InvocationRequest) -> StreamingRes
             raise HTTPException(status_code=401, detail=str(exc)) from exc
 
     # Build the transport-neutral turn request.
-    metadata = body.metadata or {}
-    history: list[HostedConversationMessage] = [
-        {"role": message.role, "text": message.content}
-        for message in body.messages[:-1]
-    ]
+    metadata = metadata or {}
     turn = TurnRequest(
         ask=ask,
-        conversation_id=body.conversation_id,
+        conversation_id=conversation_id,
         question_id=metadata.get("question_id"),
         user_context={},
         correlation_id=metadata.get("correlation_id"),
@@ -437,7 +476,7 @@ async def invocations(request: Request, body: InvocationRequest) -> StreamingRes
     logger.info(
         "[hosted] invocation: strategy=%s conversation_id=%s response_id=%s",
         strategy_key,
-        body.conversation_id or "∅",
+        conversation_id or "∅",
         response_id,
     )
 
@@ -445,4 +484,75 @@ async def invocations(request: Request, body: InvocationRequest) -> StreamingRes
         _sse_generator(turn, strategy_key, response_id, item_id, history),
         media_type="text/event-stream",
         headers={"X-Response-ID": response_id},
+    )
+
+
+@app.post(
+    "/responses",
+    summary="Handle a canonical Foundry Responses request",
+    description=(
+        "Accepts canonical string input with stream=true and store=true, then "
+        "streams Azure AI Foundry Responses API SSE events. Conversation may "
+        "be a string id or an object containing id."
+    ),
+    responses=_HOSTED_STREAM_RESPONSES,
+)
+async def responses(request: Request, body: ResponsesRequest) -> StreamingResponse:
+    """Map a canonical Microsoft Foundry Responses request to hosted execution."""
+    conversation_id = (
+        body.conversation.id
+        if isinstance(body.conversation, ResponseConversation)
+        else body.conversation
+    )
+    return _handle_hosted_request(
+        request,
+        ask=body.input,
+        conversation_id=conversation_id,
+        metadata=body.metadata,
+    )
+
+
+@app.post(
+    "/invocations",
+    summary="Handle a compatible Foundry invocation",
+    description=(
+        "Accepts ordered invocation message history, projects prior messages "
+        "into hosted execution, and streams Responses API SSE events."
+    ),
+    responses=_HOSTED_STREAM_RESPONSES,
+)
+async def invocations(request: Request, body: InvocationRequest) -> StreamingResponse:
+    """Translate the compatibility invocation contract to hosted execution.
+
+    The final message must be the current user ask. Messages after the current
+    ask are rejected rather than silently discarded. Toolbox-integrated
+    strategies require the validated platform ``x-agent-foundry-call-id`` in
+    the shared handler; neither route reads or forwards ``Authorization``.
+    """
+    current_message = body.messages[-1]
+    if current_message.role != "user":
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "The final message must have role='user'; messages after the "
+                "current ask are not allowed."
+            ),
+        )
+    ask = current_message.content.strip()
+    if not ask:
+        raise HTTPException(
+            status_code=422,
+            detail="The last user message must not be empty.",
+        )
+
+    history: list[HostedConversationMessage] = [
+        {"role": message.role, "text": message.content}
+        for message in body.messages[:-1]
+    ]
+    return _handle_hosted_request(
+        request,
+        ask=ask,
+        conversation_id=body.conversation_id,
+        metadata=body.metadata,
+        history=history,
     )

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -1022,40 +1022,79 @@ class TestHostedEntrypointAPI:
         assert resp.status_code == 200
         assert set(resp.json()["eligible_strategies"]) == HOSTED_ELIGIBLE_STRATEGIES
 
-    def test_responses_and_invocations_share_route_contract(self, client):
+    def test_responses_and_invocations_expose_distinct_request_contracts(self, client):
         paths = client.get("/openapi.json").json()["paths"]
         responses_contract = paths["/responses"]["post"]
         invocations_contract = paths["/invocations"]["post"]
 
-        assert responses_contract["requestBody"] == invocations_contract["requestBody"]
+        assert responses_contract["requestBody"] != invocations_contract["requestBody"]
+        assert (
+            responses_contract["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+            .endswith("/ResponsesRequest")
+        )
+        assert (
+            invocations_contract["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+            .endswith("/InvocationRequest")
+        )
         assert responses_contract["responses"] == invocations_contract["responses"]
 
-    def test_responses_and_invocations_reject_same_invalid_request(self, client):
-        payload = {"messages": [{"role": "assistant", "content": "Hi"}]}
+    def test_responses_accepts_live_payload_and_streams_full_lifecycle(
+        self, client, mock_config
+    ):
+        self._use_strategy(mock_config, "maf_lite")
+        received = {}
 
-        responses = client.post("/responses", json=payload)
-        invocations = client.post("/invocations", json=payload)
-
-        assert responses.status_code == 422
-        assert responses.json() == invocations.json()
-
-    def test_responses_and_invocations_stream_identical_sse(self, client, mock_config):
-        original = mock_config.get.side_effect
-        mock_config.get.side_effect = (
-            lambda key, default=None, type=str:
-            "maf_lite" if key == "AGENT_STRATEGY" else original(key, default, type)
-        )
-
-        async def fake_flow(_ask):
+        async def fake_flow(ask):
+            received["ask"] = ask
             yield "Hello "
             yield "world"
 
         strategy = MagicMock()
         strategy.initiate_agent_flow = fake_flow
-        payload = {
-            "messages": [{"role": "user", "content": "What is the policy?"}],
-            "conversation_id": "conv-route-parity",
-        }
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            response = client.post(
+                "/responses",
+                json={
+                    "input": "Remember ...",
+                    "stream": True,
+                    "store": True,
+                },
+            )
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        assert received == {"ask": "Remember ..."}
+        created = response.text.index("event: response.created")
+        delta = response.text.index("event: response.output_text.delta")
+        completed = response.text.index("event: response.completed")
+        assert created < delta < completed
+
+    @pytest.mark.parametrize(
+        ("conversation", "expected_id"),
+        [
+            ("conv-string", "conv-string"),
+            ({"id": "conv-object"}, "conv-object"),
+        ],
+    )
+    def test_responses_maps_conversation_to_managed_conversation_path(
+        self,
+        client,
+        mock_config,
+        conversation,
+        expected_id,
+    ):
+        self._use_strategy(mock_config, "maf_agent_service")
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+        resolve_conversation = AsyncMock(return_value=expected_id)
 
         with (
             patch(
@@ -1063,17 +1102,127 @@ class TestHostedEntrypointAPI:
                 new=AsyncMock(return_value=strategy),
             ),
             patch(
-                "api.hosted_entrypoint.uuid.uuid4",
-                return_value=SimpleNamespace(hex="fixed-response-id"),
+                "api.hosted_entrypoint.resolve_managed_conversation_id",
+                new=resolve_conversation,
             ),
         ):
-            responses = client.post("/responses", json=payload)
-            invocations = client.post("/invocations", json=payload)
+            response = client.post(
+                "/responses",
+                json={
+                    "input": "Continue",
+                    "stream": True,
+                    "store": True,
+                    "conversation": conversation,
+                },
+            )
 
-        assert responses.status_code == 200
-        assert responses.headers["content-type"] == invocations.headers["content-type"]
-        assert responses.headers["X-Response-ID"] == invocations.headers["X-Response-ID"]
-        assert responses.text == invocations.text
+        assert response.status_code == 200
+        resolve_conversation.assert_awaited_once_with(
+            strategy.project_client,
+            expected_id,
+        )
+        assert expected_id in response.text
+        assert "event: response.created" in response.text
+        assert "event: response.output_text.delta" in response.text
+        assert "event: response.completed" in response.text
+
+    def test_responses_maps_metadata_without_projecting_legacy_history(
+        self, client, mock_config
+    ):
+        self._use_strategy(mock_config, "maf_lite")
+        captured = {}
+
+        def fake_sse(turn, strategy_key, response_id, item_id, history):
+            captured.update(
+                turn=turn,
+                strategy_key=strategy_key,
+                response_id=response_id,
+                item_id=item_id,
+                history=history,
+            )
+            return _async_gen(["event: response.completed\ndata: {}\n\n"])
+
+        with patch("api.hosted_entrypoint._sse_generator", new=fake_sse):
+            response = client.post(
+                "/responses",
+                json={
+                    "input": "Question",
+                    "stream": True,
+                    "store": True,
+                    "metadata": {
+                        "question_id": "question-1",
+                        "correlation_id": "correlation-1",
+                    },
+                    "model": "ignored-standard-field",
+                },
+            )
+
+        assert response.status_code == 200
+        assert captured["turn"].question_id == "question-1"
+        assert captured["turn"].correlation_id == "correlation-1"
+        assert captured["history"] == ()
+
+    @pytest.mark.parametrize(
+        "unsupported_input",
+        [
+            ["plain array input"],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_image",
+                            "image_url": "https://example.invalid",
+                        }
+                    ],
+                }
+            ],
+        ],
+    )
+    def test_responses_rejects_array_and_multimodal_input(
+        self, client, unsupported_input
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "input": unsupported_input,
+                "stream": True,
+                "store": True,
+            },
+        )
+
+        assert response.status_code == 422
+        assert (
+            "Only string input is supported; array and multimodal input are not supported."
+            in str(response.json())
+        )
+
+    def test_responses_rejects_empty_string_input(self, client):
+        response = client.post(
+            "/responses",
+            json={"input": "   ", "stream": True, "store": True},
+        )
+
+        assert response.status_code == 422
+        assert "Input must not be empty or whitespace." in str(response.json())
+
+    def test_responses_rejects_non_streaming_request(self, client):
+        response = client.post(
+            "/responses",
+            json={"input": "Hello", "stream": False, "store": True},
+        )
+
+        assert response.status_code == 422
+        assert "Only stream=true is supported" in str(response.json())
+
+    def test_responses_rejects_non_storing_managed_request(self, client):
+        response = client.post(
+            "/responses",
+            json={"input": "Hello", "stream": True, "store": False},
+        )
+
+        assert response.status_code == 422
+        assert "Only store=true is supported" in str(response.json())
 
     def test_invocations_rejects_unsupported_strategy(self, client, mock_config):
         original = mock_config.get.side_effect


### PR DESCRIPTION
## Purpose

Fix the canonical Microsoft Foundry hosted-agent Responses protocol after PRs #294/#295 added the route but left it bound to the legacy invocation schema.

## Work type

Bug fix targeting develop.

## Changes

- Accept canonical POST /responses string input with stream: true, store: true, optional conversation string/object, and metadata.
- Reject unsupported array/multimodal input and unsupported execution modes with explicit HTTP 422 responses.
- Preserve the separate legacy POST /invocations messages/conversation_id contract.
- Share strategy validation, call-context security, managed conversation mapping, turn construction, response IDs, and SSE execution between both routes.
- Cover the live Foundry payload and complete response.created/delta/completed lifecycle.

## Validation

- python -m pytest tests/test_hosted_responses.py -q — 81 passed
- python -m pytest — 664 passed
- Independent code-review agent — no findings

## Documentation

Updated the service README and Unreleased changelog. No separate published-doc page was affected because this corrects the service-local hosted container wire contract.

## Compatibility and security

/invocations remains backward compatible. Existing strategy eligibility and x-agent-foundry-call-id fail-closed validation are reused unchanged.

## Follow-up

No tag, release, or deployment is included.