### PR TITLE
fix: emit standard Responses SSE events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@
   optional string/object `conversation`, and optional `metadata`, so live
   Foundry Responses requests no longer fail against the invocation-only
   schema. Unsupported array/multimodal input, non-streaming requests, and
-  non-storing managed requests fail explicitly with HTTP 422. The existing
-  `POST /invocations` message-history contract remains compatible; both routes
-  share the strategy and call-id security guards, managed Conversation
-  handling, transport-neutral turn construction, and Responses API SSE
-  lifecycle.
+  non-storing managed requests fail explicitly with HTTP 422. Unsupported
+  Responses fields are also rejected instead of being ignored. Streaming
+  events now match the pinned OpenAI SDK models, carry stream-wide sequence
+  numbers, and return the managed Conversation in standard response objects.
+  The existing `POST /invocations` message-history contract remains
+  compatible; both routes share the strategy and call-id security guards,
+  managed Conversation handling, transport-neutral turn construction, and
+  Responses API SSE lifecycle.
 
 - **Microsoft Foundry hosted-agent readiness probe contract.** Added
   `GET /readiness` to `api.hosted_entrypoint` so the platform readiness probe no

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ The routes use distinct Microsoft Foundry request contracts:
 - Canonical `POST /responses` accepts a string `input`, `stream: true`,
   `store: true`, optional `conversation` as either an id string or
   `{"id": "..."}`, and optional `metadata`. Array/multimodal input,
-  non-streaming requests, and non-storing managed requests return HTTP 422.
+  non-streaming requests, non-storing managed requests, and unsupported
+  Responses fields such as `previous_response_id`, `instructions`, or `tools`
+  return HTTP 422 rather than being ignored.
 - Compatibility `POST /invocations` retains ordered
   `messages`, optional `conversation_id`, and optional `metadata`, including
   projection of prior message history.

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -30,7 +31,7 @@ from typing import Any, Literal, Optional, Sequence
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from api.responses_adapter import responses_terminal_events, serialize_responses_events
 from connectors.foundry_conversations import resolve_managed_conversation_id
@@ -92,10 +93,12 @@ class ResponseConversation(BaseModel):
 class ResponsesRequest(BaseModel):
     """Supported subset of a canonical Microsoft Foundry Responses request.
 
-    Unknown standard Responses fields are ignored, matching the existing
-    Pydantic request-model convention. This adapter currently supports only
-    string input and SSE responses that may be stored by Foundry.
+    Unsupported Responses fields are rejected explicitly. This adapter
+    currently supports only string input and SSE responses that may be stored
+    by Foundry.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     input: str = Field(..., description="Current user ask as plain text")
     stream: bool = Field(..., description="Must be true; hosted execution is SSE-only")
@@ -280,33 +283,56 @@ def _sse_generator(
     response_id: str,
     item_id: str,
     history: Sequence[HostedConversationMessage] = (),
+    *,
+    model: str = "unknown",
 ) -> AsyncIterator[str]:
     """Wrap ``_hosted_stream`` and serialize events to Responses API SSE."""
 
     async def _gen() -> AsyncIterator[str]:
         full_text: list[str] = []
         error_emitted = False
+        managed_conversation_id: str | None = None
+        annotation_index = 0
+        sequence_number = 0
+        created_at = time.time()
 
         try:
             async for event in _hosted_stream(turn, strategy_key, history):
+                if isinstance(event, TurnConversationEvent):
+                    managed_conversation_id = event.conversation_id
                 frames = serialize_responses_events(
                     event,
                     response_id=response_id,
                     item_id=item_id,
+                    annotation_index=annotation_index,
+                    sequence_number=sequence_number,
+                    created_at=created_at,
+                    model=model,
                 )
-                if isinstance(event, TurnErrorEvent):
+                if isinstance(event, (TurnErrorEvent, TurnCancelledEvent)):
                     error_emitted = True
                 if isinstance(event, TurnTextEvent):
                     full_text.append(event.text)
+                if isinstance(event, TurnCitationEvent):
+                    annotation_index += 1
                 for frame in frames:
                     yield frame
+                sequence_number += len(frames)
 
             # Emit closing frames only when no error occurred.
             if not error_emitted:
+                if managed_conversation_id is None:
+                    raise ValueError(
+                        "Hosted stream ended without a managed conversation id."
+                    )
                 for frame in responses_terminal_events(
                     response_id=response_id,
                     item_id=item_id,
+                    conversation_id=managed_conversation_id,
                     full_text="".join(full_text),
+                    created_at=created_at,
+                    model=model,
+                    sequence_number=sequence_number,
                 ):
                     yield frame
 
@@ -330,30 +356,32 @@ def _sse_generator(
                 strategy_key,
             )
             if not error_emitted:
-                from api.responses_adapter import _sse
-                yield _sse(
-                    "error",
-                    {
-                        "type": "error",
-                        "code": "missing_call_context",
-                        "message": str(exc),
-                        "retryable": False,
-                    },
-                )
+                for frame in serialize_responses_events(
+                    TurnErrorEvent(
+                        code="missing_call_context",
+                        message=str(exc),
+                        retryable=False,
+                    ),
+                    response_id=response_id,
+                    item_id=item_id,
+                    sequence_number=sequence_number,
+                ):
+                    yield frame
 
         except Exception:
             logger.exception("[hosted] Unhandled error in SSE generator")
             if not error_emitted:
-                from api.responses_adapter import _sse
-                yield _sse(
-                    "error",
-                    {
-                        "type": "error",
-                        "code": "internal_error",
-                        "message": "An internal server error occurred.",
-                        "retryable": False,
-                    },
-                )
+                for frame in serialize_responses_events(
+                    TurnErrorEvent(
+                        code="internal_error",
+                        message="An internal server error occurred.",
+                        retryable=False,
+                    ),
+                    response_id=response_id,
+                    item_id=item_id,
+                    sequence_number=sequence_number,
+                ):
+                    yield frame
 
     return _gen()
 
@@ -443,6 +471,7 @@ def _handle_hosted_request(
     # Resolve and guard the strategy.
     cfg = get_config()
     strategy_key = cfg.get("AGENT_STRATEGY", "maf_lite")
+    model = cfg.get("CHAT_DEPLOYMENT_NAME", "unknown")
 
     try:
         guard_hosted_strategy(strategy_key)
@@ -481,7 +510,14 @@ def _handle_hosted_request(
     )
 
     return StreamingResponse(
-        _sse_generator(turn, strategy_key, response_id, item_id, history),
+        _sse_generator(
+            turn,
+            strategy_key,
+            response_id,
+            item_id,
+            history,
+            model=model,
+        ),
         media_type="text/event-stream",
         headers={"X-Response-ID": response_id},
     )

--- a/src/api/responses_adapter.py
+++ b/src/api/responses_adapter.py
@@ -31,6 +31,51 @@ def _sse(event_type: str, data: dict) -> str:
     return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
 
+def _output_text(text: str) -> dict:
+    """Build an SDK-compatible Responses output-text content part."""
+    return {
+        "type": "output_text",
+        "text": text,
+        "annotations": [],
+        "logprobs": [],
+    }
+
+
+def _output_message(item_id: str, text: str, status: str) -> dict:
+    """Build an SDK-compatible assistant output item."""
+    return {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "status": status,
+        "content": [] if status == "in_progress" else [_output_text(text)],
+    }
+
+
+def _response(
+    *,
+    response_id: str,
+    conversation_id: str,
+    created_at: float,
+    model: str,
+    status: str,
+    output: list[dict],
+) -> dict:
+    """Build the required common fields of an SDK Responses object."""
+    return {
+        "id": response_id,
+        "created_at": created_at,
+        "model": model,
+        "object": "response",
+        "status": status,
+        "conversation": {"id": conversation_id},
+        "output": output,
+        "tools": [],
+        "tool_choice": "none",
+        "parallel_tool_calls": False,
+    }
+
+
 def serialize_responses_events(
     event: TurnOutputEvent,
     *,
@@ -38,6 +83,10 @@ def serialize_responses_events(
     item_id: str,
     output_index: int = 0,
     content_index: int = 0,
+    annotation_index: int = 0,
+    sequence_number: int = 0,
+    created_at: float = 0.0,
+    model: str = "unknown",
 ) -> list[str]:
     """Translate one typed turn event into Foundry Responses API SSE frames.
 
@@ -54,38 +103,35 @@ def serialize_responses_events(
                 "response.created",
                 {
                     "type": "response.created",
-                    "response": {
-                        "id": response_id,
-                        "object": "response",
-                        "status": "in_progress",
-                        "conversation_id": event.conversation_id,
-                        "output": [],
-                    },
+                    "sequence_number": sequence_number,
+                    "response": _response(
+                        response_id=response_id,
+                        conversation_id=event.conversation_id,
+                        created_at=created_at,
+                        model=model,
+                        status="in_progress",
+                        output=[],
+                    ),
                 },
             ),
             _sse(
                 "response.output_item.added",
                 {
                     "type": "response.output_item.added",
-                    "response_id": response_id,
+                    "sequence_number": sequence_number + 1,
                     "output_index": output_index,
-                    "item": {
-                        "id": item_id,
-                        "type": "message",
-                        "role": "assistant",
-                        "status": "in_progress",
-                        "content": [],
-                    },
+                    "item": _output_message(item_id, "", "in_progress"),
                 },
             ),
             _sse(
                 "response.content_part.added",
                 {
                     "type": "response.content_part.added",
+                    "sequence_number": sequence_number + 2,
                     "item_id": item_id,
                     "output_index": output_index,
                     "content_index": content_index,
-                    "part": {"type": "output_text", "text": ""},
+                    "part": _output_text(""),
                 },
             ),
         ]
@@ -96,10 +142,12 @@ def serialize_responses_events(
                 "response.output_text.delta",
                 {
                     "type": "response.output_text.delta",
+                    "sequence_number": sequence_number,
                     "item_id": item_id,
                     "output_index": output_index,
                     "content_index": content_index,
                     "delta": event.text,
+                    "logprobs": [],
                 },
             )
         ]
@@ -121,9 +169,11 @@ def serialize_responses_events(
                 "response.output_text.annotation.added",
                 {
                     "type": "response.output_text.annotation.added",
+                    "sequence_number": sequence_number,
                     "item_id": item_id,
                     "output_index": output_index,
                     "content_index": content_index,
+                    "annotation_index": annotation_index,
                     "annotation": annotation,
                 },
             )
@@ -138,6 +188,9 @@ def serialize_responses_events(
                     "response.function_call_arguments.delta",
                     {
                         "type": "response.function_call_arguments.delta",
+                        "sequence_number": sequence_number,
+                        "item_id": item_id,
+                        "output_index": output_index,
                         "call_id": a.call_id or "",
                         "name": a.tool_name,
                         "delta": "",
@@ -150,8 +203,12 @@ def serialize_responses_events(
                 "response.function_call_arguments.done",
                 {
                     "type": "response.function_call_arguments.done",
+                    "sequence_number": sequence_number,
+                    "item_id": item_id,
+                    "output_index": output_index,
                     "call_id": a.call_id or "",
                     "name": a.tool_name,
+                    "arguments": "",
                     "status": status,
                     **({"message": a.message} if a.message else {}),
                 },
@@ -164,6 +221,7 @@ def serialize_responses_events(
                 "error",
                 {
                     "type": "error",
+                    "sequence_number": sequence_number,
                     "code": event.code,
                     "message": event.message,
                     "retryable": event.retryable,
@@ -174,10 +232,12 @@ def serialize_responses_events(
     if isinstance(event, TurnCancelledEvent):
         return [
             _sse(
-                "response.cancelled",
+                "error",
                 {
-                    "type": "response.cancelled",
-                    "reason": event.reason,
+                    "type": "error",
+                    "sequence_number": sequence_number,
+                    "code": "cancelled",
+                    "message": event.reason,
                 },
             )
         ]
@@ -189,9 +249,13 @@ def responses_terminal_events(
     *,
     response_id: str,
     item_id: str,
+    conversation_id: str,
     full_text: str,
+    created_at: float = 0.0,
+    model: str = "unknown",
     output_index: int = 0,
     content_index: int = 0,
+    sequence_number: int = 0,
 ) -> list[str]:
     """Return the closing SSE frames emitted after all deltas have been sent.
 
@@ -204,46 +268,47 @@ def responses_terminal_events(
             "response.output_text.done",
             {
                 "type": "response.output_text.done",
+                "sequence_number": sequence_number,
                 "item_id": item_id,
                 "output_index": output_index,
                 "content_index": content_index,
                 "text": full_text,
+                "logprobs": [],
             },
         ),
         _sse(
             "response.content_part.done",
             {
                 "type": "response.content_part.done",
+                "sequence_number": sequence_number + 1,
                 "item_id": item_id,
                 "output_index": output_index,
                 "content_index": content_index,
-                "part": {"type": "output_text", "text": full_text},
+                "part": _output_text(full_text),
             },
         ),
         _sse(
             "response.output_item.done",
             {
                 "type": "response.output_item.done",
-                "response_id": response_id,
+                "sequence_number": sequence_number + 2,
                 "output_index": output_index,
-                "item": {
-                    "id": item_id,
-                    "type": "message",
-                    "role": "assistant",
-                    "status": "completed",
-                    "content": [{"type": "output_text", "text": full_text}],
-                },
+                "item": _output_message(item_id, full_text, "completed"),
             },
         ),
         _sse(
             "response.completed",
             {
                 "type": "response.completed",
-                "response": {
-                    "id": response_id,
-                    "object": "response",
-                    "status": "completed",
-                },
+                "sequence_number": sequence_number + 3,
+                "response": _response(
+                    response_id=response_id,
+                    conversation_id=conversation_id,
+                    created_at=created_at,
+                    model=model,
+                    status="completed",
+                    output=[_output_message(item_id, full_text, "completed")],
+                ),
             },
         ),
     ]

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -19,6 +19,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai.types.responses import ResponseStreamEvent
+from pydantic import TypeAdapter
 
 from api.responses_adapter import responses_terminal_events, serialize_responses_events
 from orchestration.turn import (
@@ -43,6 +45,10 @@ from strategies.hosted_strategies import (
 
 _RESP_ID = "resp_testresponse"
 _ITEM_ID = "item_testitem"
+_CONVERSATION_ID = "conv-testconversation"
+_CREATED_AT = 1_786_012_345.0
+_MODEL = "gpt-4o"
+_RESPONSE_EVENT_ADAPTER = TypeAdapter(ResponseStreamEvent)
 
 
 def _parse_frames(frames: list[str]) -> list[dict[str, Any]]:
@@ -67,6 +73,8 @@ def _serialize(event, **kwargs):
             event,
             response_id=_RESP_ID,
             item_id=_ITEM_ID,
+            created_at=_CREATED_AT,
+            model=_MODEL,
             **kwargs,
         )
     )
@@ -80,14 +88,21 @@ class TestResponsesAdapterConversationEvent:
 
         assert len(frames) == 3
 
-    def test_response_created_has_conversation_id(self):
+    def test_response_created_has_standard_required_response_fields(self):
         frames = _serialize(TurnConversationEvent("conv-abc"))
 
         created = frames[0]
+        response = created["data"]["response"]
         assert created["event"] == "response.created"
-        assert created["data"]["response"]["conversation_id"] == "conv-abc"
-        assert created["data"]["response"]["id"] == _RESP_ID
-        assert created["data"]["response"]["status"] == "in_progress"
+        assert response["conversation"] == {"id": "conv-abc"}
+        assert "conversation_id" not in response
+        assert response["id"] == _RESP_ID
+        assert response["status"] == "in_progress"
+        assert response["created_at"] == _CREATED_AT
+        assert response["model"] == _MODEL
+        assert response["tools"] == []
+        assert response["tool_choice"] == "none"
+        assert response["parallel_tool_calls"] is False
 
     def test_output_item_added_follows_response_created(self):
         frames = _serialize(TurnConversationEvent("conv-abc"))
@@ -103,6 +118,7 @@ class TestResponsesAdapterConversationEvent:
         part = frames[2]
         assert part["event"] == "response.content_part.added"
         assert part["data"]["part"]["type"] == "output_text"
+        assert part["data"]["part"]["logprobs"] == []
 
 
 class TestResponsesAdapterTextEvent:
@@ -113,6 +129,7 @@ class TestResponsesAdapterTextEvent:
         assert frames[0]["event"] == "response.output_text.delta"
         assert frames[0]["data"]["delta"] == "Hello"
         assert frames[0]["data"]["item_id"] == _ITEM_ID
+        assert frames[0]["data"]["logprobs"] == []
 
     def test_empty_text_is_allowed(self):
         frames = _serialize(TurnTextEvent(""))
@@ -196,12 +213,73 @@ class TestResponsesAdapterErrorEvent:
 
 
 class TestResponsesAdapterCancelledEvent:
-    def test_emits_response_cancelled(self):
+    def test_emits_standard_error_event(self):
         frames = _serialize(TurnCancelledEvent(reason="cancelled"))
 
         assert len(frames) == 1
-        assert frames[0]["event"] == "response.cancelled"
-        assert frames[0]["data"]["reason"] == "cancelled"
+        assert frames[0]["event"] == "error"
+        assert frames[0]["data"]["code"] == "cancelled"
+        assert frames[0]["data"]["message"] == "cancelled"
+
+
+class TestResponsesAdapterSDKModels:
+    def test_every_emitted_event_validates_against_pinned_sdk_models(self):
+        events = [
+            TurnConversationEvent(_CONVERSATION_ID),
+            TurnTextEvent("Hello"),
+            TurnCitationEvent(
+                TurnCitation(
+                    "src-1",
+                    title="Policy",
+                    url="https://example.com/policy",
+                )
+            ),
+            TurnToolActivityEvent(
+                TurnToolActivity(
+                    "search_kb",
+                    TurnToolStatus.STARTED,
+                    call_id="call-1",
+                )
+            ),
+            TurnToolActivityEvent(
+                TurnToolActivity(
+                    "search_kb",
+                    TurnToolStatus.COMPLETED,
+                    call_id="call-1",
+                )
+            ),
+            TurnToolActivityEvent(
+                TurnToolActivity(
+                    "search_kb",
+                    TurnToolStatus.FAILED,
+                    call_id="call-1",
+                    message="Tool execution failed",
+                )
+            ),
+            TurnErrorEvent(),
+            TurnCancelledEvent(),
+        ]
+        frames = [
+            frame
+            for event in events
+            for frame in _serialize(event)
+        ]
+        frames.extend(
+            _parse_frames(
+                responses_terminal_events(
+                    response_id=_RESP_ID,
+                    item_id=_ITEM_ID,
+                    conversation_id=_CONVERSATION_ID,
+                    full_text="Hello",
+                    created_at=_CREATED_AT,
+                    model=_MODEL,
+                )
+            )
+        )
+
+        for frame in frames:
+            validated = _RESPONSE_EVENT_ADAPTER.validate_python(frame["data"])
+            assert validated.type == frame["event"]
 
 
 class TestResponsesTerminalEvents:
@@ -210,6 +288,7 @@ class TestResponsesTerminalEvents:
             responses_terminal_events(
                 response_id=_RESP_ID,
                 item_id=_ITEM_ID,
+                conversation_id=_CONVERSATION_ID,
                 full_text="Hello world",
             )
         )
@@ -225,6 +304,7 @@ class TestResponsesTerminalEvents:
             responses_terminal_events(
                 response_id=_RESP_ID,
                 item_id=_ITEM_ID,
+                conversation_id=_CONVERSATION_ID,
                 full_text="Final answer.",
             )
         )
@@ -232,18 +312,31 @@ class TestResponsesTerminalEvents:
         assert frames[0]["data"]["text"] == "Final answer."
         assert frames[1]["data"]["part"]["text"] == "Final answer."
         assert frames[2]["data"]["item"]["content"][0]["text"] == "Final answer."
+        assert frames[0]["data"]["logprobs"] == []
+        assert frames[1]["data"]["part"]["logprobs"] == []
+        assert frames[2]["data"]["item"]["content"][0]["logprobs"] == []
 
     def test_response_completed_carries_response_id(self):
         frames = _parse_frames(
             responses_terminal_events(
                 response_id=_RESP_ID,
                 item_id=_ITEM_ID,
+                conversation_id=_CONVERSATION_ID,
                 full_text="",
+                created_at=_CREATED_AT,
+                model=_MODEL,
             )
         )
 
-        assert frames[3]["data"]["response"]["id"] == _RESP_ID
-        assert frames[3]["data"]["response"]["status"] == "completed"
+        response = frames[3]["data"]["response"]
+        assert response["id"] == _RESP_ID
+        assert response["status"] == "completed"
+        assert response["conversation"] == {"id": _CONVERSATION_ID}
+        assert response["created_at"] == _CREATED_AT
+        assert response["model"] == _MODEL
+        assert response["tools"] == []
+        assert response["tool_choice"] == "none"
+        assert response["parallel_tool_calls"] is False
 
 
 # ── Strategy guard ───────────────────────────────────────────────────────────
@@ -881,6 +974,62 @@ class TestSseGeneratorErrorClassification:
         assert parsed == error_frames
 
 
+class TestSseGeneratorLifecycle:
+    @pytest.mark.asyncio
+    async def test_sequence_numbers_increase_across_complete_stream(self):
+        from api.hosted_entrypoint import _sse_generator
+
+        async def fake_stream(*_args):
+            yield TurnConversationEvent("conv-managed")
+            yield TurnTextEvent("Hello ")
+            yield TurnCitationEvent(TurnCitation("src-1"))
+            yield TurnTextEvent("world")
+
+        with patch("api.hosted_entrypoint._hosted_stream", new=fake_stream):
+            frames = [
+                frame
+                async for frame in _sse_generator(
+                    TurnRequest(ask="Hi"),
+                    "maf_lite",
+                    _RESP_ID,
+                    _ITEM_ID,
+                    model=_MODEL,
+                )
+            ]
+
+        parsed = _parse_frames(frames)
+        assert [frame["data"]["sequence_number"] for frame in parsed] == list(
+            range(len(parsed))
+        )
+
+    @pytest.mark.asyncio
+    async def test_completed_response_recovers_managed_conversation_from_stream(self):
+        from api.hosted_entrypoint import _sse_generator
+
+        async def fake_stream(*_args):
+            yield TurnConversationEvent("conv-created-by-foundry")
+            yield TurnTextEvent("answer")
+
+        with patch("api.hosted_entrypoint._hosted_stream", new=fake_stream):
+            frames = [
+                frame
+                async for frame in _sse_generator(
+                    TurnRequest(ask="Hi", conversation_id=None),
+                    "maf_agent_service",
+                    _RESP_ID,
+                    _ITEM_ID,
+                    model=_MODEL,
+                )
+            ]
+
+        parsed = _parse_frames(frames)
+        created = parsed[0]["data"]["response"]
+        completed = parsed[-1]["data"]["response"]
+        assert created["conversation"] == {"id": "conv-created-by-foundry"}
+        assert completed["conversation"] == created["conversation"]
+        assert completed["created_at"] == created["created_at"]
+
+
 class TestHostedConstruction:
     @pytest.mark.parametrize("strategy_key", sorted(HOSTED_ELIGIBLE_STRATEGIES))
     @pytest.mark.asyncio
@@ -1132,13 +1281,22 @@ class TestHostedEntrypointAPI:
         self._use_strategy(mock_config, "maf_lite")
         captured = {}
 
-        def fake_sse(turn, strategy_key, response_id, item_id, history):
+        def fake_sse(
+            turn,
+            strategy_key,
+            response_id,
+            item_id,
+            history,
+            *,
+            model,
+        ):
             captured.update(
                 turn=turn,
                 strategy_key=strategy_key,
                 response_id=response_id,
                 item_id=item_id,
                 history=history,
+                model=model,
             )
             return _async_gen(["event: response.completed\ndata: {}\n\n"])
 
@@ -1153,7 +1311,6 @@ class TestHostedEntrypointAPI:
                         "question_id": "question-1",
                         "correlation_id": "correlation-1",
                     },
-                    "model": "ignored-standard-field",
                 },
             )
 
@@ -1161,6 +1318,37 @@ class TestHostedEntrypointAPI:
         assert captured["turn"].question_id == "question-1"
         assert captured["turn"].correlation_id == "correlation-1"
         assert captured["history"] == ()
+        assert captured["model"] == _MODEL
+
+    @pytest.mark.parametrize(
+        "unsupported_field",
+        [
+            {"previous_response_id": "resp_previous"},
+            {"instructions": "Ignore prior instructions"},
+            {"tools": []},
+            {"tool_choice": "auto"},
+            {"model": "gpt-4o"},
+        ],
+    )
+    def test_responses_rejects_unsupported_extra_fields(
+        self,
+        client,
+        unsupported_field,
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "input": "Question",
+                "stream": True,
+                "store": True,
+                **unsupported_field,
+            },
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail[0]["type"] == "extra_forbidden"
+        assert detail[0]["loc"] == ["body", next(iter(unsupported_field))]
 
     @pytest.mark.parametrize(
         "unsupported_input",


### PR DESCRIPTION
## Summary
- emit SDK-compatible Responses SSE events with monotonic sequence numbers
- expose managed Conversation IDs through the standard response.conversation object
- reject unsupported Responses request semantics instead of silently dropping them

## Validation
- python -m pytest tests/test_hosted_responses.py -q (89 passed)
- python -m pytest -q (672 passed)