### PR TITLE
fix: keep Responses tool progress stream-valid

### DIFF
--- a/src/api/responses_adapter.py
+++ b/src/api/responses_adapter.py
@@ -22,7 +22,6 @@ from orchestration.turn import (
     TurnOutputEvent,
     TurnTextEvent,
     TurnToolActivityEvent,
-    TurnToolStatus,
 )
 
 
@@ -180,40 +179,11 @@ def serialize_responses_events(
         ]
 
     if isinstance(event, TurnToolActivityEvent):
-        a = event.activity
-        status = a.status.value  # "started" | "completed" | "failed"
-        if a.status == TurnToolStatus.STARTED:
-            return [
-                _sse(
-                    "response.function_call_arguments.delta",
-                    {
-                        "type": "response.function_call_arguments.delta",
-                        "sequence_number": sequence_number,
-                        "item_id": item_id,
-                        "output_index": output_index,
-                        "call_id": a.call_id or "",
-                        "name": a.tool_name,
-                        "delta": "",
-                        "status": status,
-                    },
-                )
-            ]
-        return [
-            _sse(
-                "response.function_call_arguments.done",
-                {
-                    "type": "response.function_call_arguments.done",
-                    "sequence_number": sequence_number,
-                    "item_id": item_id,
-                    "output_index": output_index,
-                    "call_id": a.call_id or "",
-                    "name": a.tool_name,
-                    "arguments": "",
-                    "status": status,
-                    **({"message": a.message} if a.message else {}),
-                },
-            )
-        ]
+        # Tool activity is internal progress telemetry, not a model-authored
+        # function-call output item. Emitting function-call argument events
+        # without the corresponding item lifecycle makes SDK stream state
+        # invalid, so keep these events out of the Responses wire contract.
+        return []
 
     if isinstance(event, TurnErrorEvent):
         return [

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -19,6 +19,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from openai import omit
+from openai.lib.streaming.responses import ResponseStreamState
 from openai.types.responses import ResponseStreamEvent
 from pydantic import TypeAdapter
 
@@ -163,37 +165,14 @@ class TestResponsesAdapterCitationEvent:
 
 
 class TestResponsesAdapterToolActivityEvent:
-    def test_started_emits_arguments_delta(self):
-        activity = TurnToolActivity("search_kb", TurnToolStatus.STARTED, call_id="call-1")
-        frames = _serialize(TurnToolActivityEvent(activity=activity))
+    @pytest.mark.parametrize("status", list(TurnToolStatus))
+    def test_internal_tool_progress_is_not_emitted_as_function_call_output(
+        self,
+        status: TurnToolStatus,
+    ):
+        activity = TurnToolActivity("search_kb", status, call_id="call-1")
 
-        assert frames[0]["event"] == "response.function_call_arguments.delta"
-        assert frames[0]["data"]["name"] == "search_kb"
-        assert frames[0]["data"]["call_id"] == "call-1"
-        assert frames[0]["data"]["status"] == "started"
-
-    def test_completed_emits_arguments_done(self):
-        activity = TurnToolActivity("search_kb", TurnToolStatus.COMPLETED, call_id="call-1")
-        frames = _serialize(TurnToolActivityEvent(activity=activity))
-
-        assert frames[0]["event"] == "response.function_call_arguments.done"
-        assert frames[0]["data"]["status"] == "completed"
-
-    def test_failed_emits_arguments_done_with_message(self):
-        activity = TurnToolActivity(
-            "search_kb", TurnToolStatus.FAILED, call_id="call-1", message="Tool execution failed"
-        )
-        frames = _serialize(TurnToolActivityEvent(activity=activity))
-
-        assert frames[0]["event"] == "response.function_call_arguments.done"
-        assert frames[0]["data"]["status"] == "failed"
-        assert frames[0]["data"]["message"] == "Tool execution failed"
-
-    def test_completed_without_message_omits_message_key(self):
-        activity = TurnToolActivity("search_kb", TurnToolStatus.COMPLETED)
-        frames = _serialize(TurnToolActivityEvent(activity=activity))
-
-        assert "message" not in frames[0]["data"]
+        assert _serialize(TurnToolActivityEvent(activity=activity)) == []
 
 
 class TestResponsesAdapterErrorEvent:
@@ -1028,6 +1007,45 @@ class TestSseGeneratorLifecycle:
         assert created["conversation"] == {"id": "conv-created-by-foundry"}
         assert completed["conversation"] == created["conversation"]
         assert completed["created_at"] == created["created_at"]
+
+    @pytest.mark.asyncio
+    async def test_complete_stream_is_accepted_by_pinned_sdk_state(self):
+        from api.hosted_entrypoint import _sse_generator
+
+        async def fake_stream(*_args):
+            yield TurnConversationEvent("conv-managed")
+            yield TurnToolActivityEvent(
+                TurnToolActivity(
+                    "search_kb",
+                    TurnToolStatus.STARTED,
+                    call_id="call-1",
+                )
+            )
+            yield TurnTextEvent("answer")
+            yield TurnToolActivityEvent(
+                TurnToolActivity(
+                    "search_kb",
+                    TurnToolStatus.COMPLETED,
+                    call_id="call-1",
+                )
+            )
+
+        with patch("api.hosted_entrypoint._hosted_stream", new=fake_stream):
+            frames = [
+                frame
+                async for frame in _sse_generator(
+                    TurnRequest(ask="Hi"),
+                    "maf_lite",
+                    _RESP_ID,
+                    _ITEM_ID,
+                    model=_MODEL,
+                )
+            ]
+
+        state = ResponseStreamState(input_tools=omit, text_format=omit)
+        for frame in _parse_frames(frames):
+            event = _RESPONSE_EVENT_ADAPTER.validate_python(frame["data"])
+            state.handle_event(event)
 
 
 class TestHostedConstruction:


### PR DESCRIPTION
## Summary
- keep internal tool-progress telemetry out of the Responses wire contract instead of misrepresenting it as client-executable function-call arguments
- validate the complete SSE lifecycle with OpenAI 2.41.1 `ResponseStreamState`
- retain contiguous stream-wide `sequence_number` values when suppressed internal events occur

This is a focused follow-up to #297 after an independent review found that the SDK accepts the individual function-call event models but rejects their cross-event lifecycle because no function-call output item exists.

## Validation
- `python -m pytest tests/test_hosted_responses.py -q` — 89 passed
- `python -m pytest -q` — 672 passed
- OpenAI SDK 2.41.1

## Compatibility
- `POST /invocations` request handling remains unchanged
- no configuration, persistence, deployment, release, or tag changes