### PR TITLE
fix: accept Foundry agent reference metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
   Foundry Responses requests no longer fail against the invocation-only
   schema. Unsupported array/multimodal input, non-streaming requests, and
   non-storing managed requests fail explicitly with HTTP 422. Unsupported
-  Responses fields are also rejected instead of being ignored. Streaming
+  Responses fields are also rejected instead of being ignored, while the
+  platform-injected `agent_reference` routing object is accepted without
+  projecting it into execution state. Streaming
   events now match the pinned OpenAI SDK models, carry stream-wide sequence
   numbers, and return the managed Conversation in standard response objects.
   The existing `POST /invocations` message-history contract remains

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ The routes use distinct Microsoft Foundry request contracts:
 
 - Canonical `POST /responses` accepts a string `input`, `stream: true`,
   `store: true`, optional `conversation` as either an id string or
-  `{"id": "..."}`, and optional `metadata`. Array/multimodal input,
+  `{"id": "..."}`, optional `metadata`, and the platform-injected
+  `agent_reference` routing object. Array/multimodal input,
   non-streaming requests, non-storing managed requests, and unsupported
   Responses fields such as `previous_response_id`, `instructions`, or `tools`
   return HTTP 422 rather than being ignored.

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -90,6 +90,16 @@ class ResponseConversation(BaseModel):
         return value
 
 
+class ResponseAgentReference(BaseModel):
+    """Foundry routing metadata injected into hosted Responses requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["agent_reference"]
+    name: str
+    version: str
+
+
 class ResponsesRequest(BaseModel):
     """Supported subset of a canonical Microsoft Foundry Responses request.
 
@@ -113,6 +123,10 @@ class ResponsesRequest(BaseModel):
     metadata: Optional[dict[str, Any]] = Field(
         default_factory=dict,
         description="Request metadata such as correlation_id and question_id",
+    )
+    agent_reference: ResponseAgentReference | None = Field(
+        None,
+        description="Foundry-injected routing metadata; not projected into execution state",
     )
 
     @field_validator("input", mode="before")

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -1368,6 +1368,54 @@ class TestHostedEntrypointAPI:
         assert detail[0]["type"] == "extra_forbidden"
         assert detail[0]["loc"] == ["body", next(iter(unsupported_field))]
 
+    def test_responses_accepts_foundry_injected_agent_reference(
+        self, client, mock_config
+    ):
+        self._use_strategy(mock_config, "maf_lite")
+
+        with patch(
+            "api.hosted_entrypoint._sse_generator",
+            new=lambda *args, **kwargs: _async_gen(
+                ["event: response.completed\ndata: {}\n\n"]
+            ),
+        ):
+            response = client.post(
+                "/responses",
+                json={
+                    "input": "Question",
+                    "stream": True,
+                    "store": True,
+                    "agent_reference": {
+                        "type": "agent_reference",
+                        "name": "gpt-rag-orchestrator",
+                        "version": "3",
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+
+    def test_responses_rejects_malformed_agent_reference(
+        self, client, mock_config
+    ):
+        self._use_strategy(mock_config, "maf_lite")
+
+        response = client.post(
+            "/responses",
+            json={
+                "input": "Question",
+                "stream": True,
+                "store": True,
+                "agent_reference": {
+                    "type": "unexpected",
+                    "name": "gpt-rag-orchestrator",
+                    "version": "3",
+                },
+            },
+        )
+
+        assert response.status_code == 422
+
     @pytest.mark.parametrize(
         "unsupported_input",
         [


### PR DESCRIPTION
## Summary
- accept the strictly validated agent_reference routing object injected by Foundry
- keep unsupported Responses semantic fields forbidden
- preserve the standard SSE and managed Conversation contract

## Live evidence
Foundry routed a real Responses request to hosted version 3 and injected agent_reference; the strict adapter returned 422 before this fix.

## Validation
- python -m pytest tests/test_hosted_responses.py -q (91 passed)
- python -m pytest -q (674 passed)