### PR TITLE
fix: tighten Responses wire conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@
 
 - **Microsoft Foundry hosted-agent Responses route contract.** Added canonical
   `POST /responses` handling for string `input`, `stream: true`, `store: true`,
-  optional string/object `conversation`, and optional `metadata`, so live
+  optional string/object `conversation`, and optional string-valued `metadata`,
+  so live
   Foundry Responses requests no longer fail against the invocation-only
   schema. Unsupported array/multimodal input, non-streaming requests, and
   non-storing managed requests fail explicitly with HTTP 422. Unsupported
   Responses fields are also rejected instead of being ignored. Streaming
-  events now match the pinned OpenAI SDK models, carry stream-wide sequence
-  numbers, and return the managed Conversation in standard response objects.
+  events now match pinned `openai==2.41.1` SDK models, carry stream-wide
+  sequence numbers, echo canonical metadata, and return the managed
+  Conversation in standard response objects. Internal orchestration citations
+  and tool progress are withheld from the public stream rather than emitting
+  incomplete or uncorrelatable Responses item lifecycles.
   The existing `POST /invocations` message-history contract remains
   compatible; both routes share the strategy and call-id security guards,
   managed Conversation handling, transport-neutral turn construction, and

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The routes use distinct Microsoft Foundry request contracts:
 
 - Canonical `POST /responses` accepts a string `input`, `stream: true`,
   `store: true`, optional `conversation` as either an id string or
-  `{"id": "..."}`, and optional `metadata`. Array/multimodal input,
+  `{"id": "..."}`, and optional string-valued `metadata`. Array/multimodal input,
   non-streaming requests, non-storing managed requests, and unsupported
   Responses fields such as `previous_response_id`, `instructions`, or `tools`
   return HTTP 422 rather than being ignored.
@@ -101,7 +101,12 @@ The routes use distinct Microsoft Foundry request contracts:
 
 Both routes map to the same transport-neutral hosted turn execution, strategy
 guard, call-id security validation, managed Conversation handling, response
-identifiers, and Responses API SSE lifecycle.
+identifiers, and Responses API SSE lifecycle. The lifecycle uses contiguous
+sequence numbers and returns the same managed Conversation as
+`{"conversation": {"id": "..."}}` in its opening and completed Response
+objects. Internal orchestration tool progress and citations remain internal
+until they can be represented with complete standards-compliant public item
+lifecycles.
 
 The hosted entrypoint exposes `GET /readiness` for Microsoft Foundry readiness
 probes. The compatibility `GET /health` route returns the same immutable image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.60b0",
     
     # AI/ML
-    "openai>=2.9.0",
+    "openai==2.41.1",
     "tiktoken>=0.7.0",
     
     # Data validation

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -77,6 +77,8 @@ except FileNotFoundError:
 class ResponseConversation(BaseModel):
     """Conversation reference accepted by the Responses API."""
 
+    model_config = ConfigDict(extra="forbid")
+
     id: str = Field(..., description="Foundry-managed Conversation id")
 
     @field_validator("id", mode="before")
@@ -110,9 +112,9 @@ class ResponsesRequest(BaseModel):
         None,
         description="Foundry-managed Conversation id or an object containing its id",
     )
-    metadata: Optional[dict[str, Any]] = Field(
+    metadata: Optional[dict[str, str]] = Field(
         default_factory=dict,
-        description="Request metadata such as correlation_id and question_id",
+        description="String-valued request metadata",
     )
 
     @field_validator("input", mode="before")
@@ -285,6 +287,7 @@ def _sse_generator(
     history: Sequence[HostedConversationMessage] = (),
     *,
     model: str = "unknown",
+    response_metadata: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
     """Wrap ``_hosted_stream`` and serialize events to Responses API SSE."""
 
@@ -292,7 +295,6 @@ def _sse_generator(
         full_text: list[str] = []
         error_emitted = False
         managed_conversation_id: str | None = None
-        annotation_index = 0
         sequence_number = 0
         created_at = time.time()
 
@@ -304,17 +306,15 @@ def _sse_generator(
                     event,
                     response_id=response_id,
                     item_id=item_id,
-                    annotation_index=annotation_index,
                     sequence_number=sequence_number,
                     created_at=created_at,
                     model=model,
+                    response_metadata=response_metadata,
                 )
                 if isinstance(event, (TurnErrorEvent, TurnCancelledEvent)):
                     error_emitted = True
                 if isinstance(event, TurnTextEvent):
                     full_text.append(event.text)
-                if isinstance(event, TurnCitationEvent):
-                    annotation_index += 1
                 for frame in frames:
                     yield frame
                 sequence_number += len(frames)
@@ -333,6 +333,7 @@ def _sse_generator(
                     created_at=created_at,
                     model=model,
                     sequence_number=sequence_number,
+                    response_metadata=response_metadata,
                 ):
                     yield frame
 
@@ -466,6 +467,7 @@ def _handle_hosted_request(
     conversation_id: str | None,
     metadata: dict[str, Any] | None,
     history: Sequence[HostedConversationMessage] = (),
+    response_metadata: dict[str, str] | None = None,
 ) -> StreamingResponse:
     """Apply shared hosted execution and security behavior to one turn."""
     # Resolve and guard the strategy.
@@ -517,6 +519,7 @@ def _handle_hosted_request(
             item_id,
             history,
             model=model,
+            response_metadata=response_metadata,
         ),
         media_type="text/event-stream",
         headers={"X-Response-ID": response_id},
@@ -545,6 +548,7 @@ async def responses(request: Request, body: ResponsesRequest) -> StreamingRespon
         ask=body.input,
         conversation_id=conversation_id,
         metadata=body.metadata,
+        response_metadata=body.metadata,
     )
 
 

--- a/src/api/responses_adapter.py
+++ b/src/api/responses_adapter.py
@@ -59,9 +59,10 @@ def _response(
     model: str,
     status: str,
     output: list[dict],
+    metadata: dict[str, str] | None = None,
 ) -> dict:
     """Build the required common fields of an SDK Responses object."""
-    return {
+    response = {
         "id": response_id,
         "created_at": created_at,
         "model": model,
@@ -73,6 +74,9 @@ def _response(
         "tool_choice": "none",
         "parallel_tool_calls": False,
     }
+    if metadata is not None:
+        response["metadata"] = metadata
+    return response
 
 
 def serialize_responses_events(
@@ -82,10 +86,10 @@ def serialize_responses_events(
     item_id: str,
     output_index: int = 0,
     content_index: int = 0,
-    annotation_index: int = 0,
     sequence_number: int = 0,
     created_at: float = 0.0,
     model: str = "unknown",
+    response_metadata: dict[str, str] | None = None,
 ) -> list[str]:
     """Translate one typed turn event into Foundry Responses API SSE frames.
 
@@ -110,6 +114,7 @@ def serialize_responses_events(
                         model=model,
                         status="in_progress",
                         output=[],
+                        metadata=response_metadata,
                     ),
                 },
             ),
@@ -152,31 +157,10 @@ def serialize_responses_events(
         ]
 
     if isinstance(event, TurnCitationEvent):
-        c = event.citation
-        annotation: dict = {
-            "type": "url_citation",
-            "citation_id": c.citation_id,
-        }
-        if c.title is not None:
-            annotation["title"] = c.title
-        if c.url is not None:
-            annotation["url"] = c.url
-        if c.snippet is not None:
-            annotation["snippet"] = c.snippet
-        return [
-            _sse(
-                "response.output_text.annotation.added",
-                {
-                    "type": "response.output_text.annotation.added",
-                    "sequence_number": sequence_number,
-                    "item_id": item_id,
-                    "output_index": output_index,
-                    "content_index": content_index,
-                    "annotation_index": annotation_index,
-                    "annotation": annotation,
-                },
-            )
-        ]
+        # Turn citations do not carry the character offsets required by public
+        # Responses annotations. Keep them internal rather than emitting an
+        # annotation that cannot be reconciled with the terminal output text.
+        return []
 
     if isinstance(event, TurnToolActivityEvent):
         # Tool activity is internal progress telemetry, not a model-authored
@@ -194,7 +178,7 @@ def serialize_responses_events(
                     "sequence_number": sequence_number,
                     "code": event.code,
                     "message": event.message,
-                    "retryable": event.retryable,
+                    "param": None,
                 },
             )
         ]
@@ -208,6 +192,7 @@ def serialize_responses_events(
                     "sequence_number": sequence_number,
                     "code": "cancelled",
                     "message": event.reason,
+                    "param": None,
                 },
             )
         ]
@@ -226,6 +211,7 @@ def responses_terminal_events(
     output_index: int = 0,
     content_index: int = 0,
     sequence_number: int = 0,
+    response_metadata: dict[str, str] | None = None,
 ) -> list[str]:
     """Return the closing SSE frames emitted after all deltas have been sent.
 
@@ -278,6 +264,7 @@ def responses_terminal_events(
                     model=model,
                     status="completed",
                     output=[_output_message(item_id, full_text, "completed")],
+                    metadata=response_metadata,
                 ),
             },
         ),

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -69,6 +69,13 @@ def _parse_frames(frames: list[str]) -> list[dict[str, Any]]:
     return result
 
 
+def _parse_sse_stream(body: str) -> list[dict[str, Any]]:
+    """Parse a complete SSE response body into typed frame dictionaries."""
+    return _parse_frames(
+        [f"{frame}\n\n" for frame in body.strip().split("\n\n") if frame]
+    )
+
+
 def _serialize(event, **kwargs):
     return _parse_frames(
         serialize_responses_events(
@@ -140,28 +147,20 @@ class TestResponsesAdapterTextEvent:
 
 
 class TestResponsesAdapterCitationEvent:
-    def test_emits_annotation_added(self):
-        citation = TurnCitation(
-            "src-1", title="Policy Doc", url="https://example.com/policy", snippet="Relevant excerpt"
-        )
-        frames = _serialize(TurnCitationEvent(citation=citation))
-
-        assert len(frames) == 1
-        assert frames[0]["event"] == "response.output_text.annotation.added"
-        ann = frames[0]["data"]["annotation"]
-        assert ann["citation_id"] == "src-1"
-        assert ann["title"] == "Policy Doc"
-        assert ann["url"] == "https://example.com/policy"
-        assert ann["snippet"] == "Relevant excerpt"
-
-    def test_omits_none_optional_fields(self):
-        citation = TurnCitation("src-2")
-        frames = _serialize(TurnCitationEvent(citation=citation))
-
-        ann = frames[0]["data"]["annotation"]
-        assert "title" not in ann
-        assert "url" not in ann
-        assert "snippet" not in ann
+    @pytest.mark.parametrize(
+        "citation",
+        [
+            TurnCitation(
+                "src-1",
+                title="Policy Doc",
+                url="https://example.com/policy",
+                snippet="Relevant excerpt",
+            ),
+            TurnCitation("src-2"),
+        ],
+    )
+    def test_internal_citation_without_text_offsets_is_not_emitted(self, citation):
+        assert _serialize(TurnCitationEvent(citation=citation)) == []
 
 
 class TestResponsesAdapterToolActivityEvent:
@@ -183,12 +182,13 @@ class TestResponsesAdapterErrorEvent:
         assert frames[0]["event"] == "error"
         assert frames[0]["data"]["code"] == "internal_error"
         assert frames[0]["data"]["message"] == "Something broke"
-        assert frames[0]["data"]["retryable"] is False
+        assert frames[0]["data"]["param"] is None
+        assert "retryable" not in frames[0]["data"]
 
-    def test_retryable_flag_is_preserved(self):
+    def test_internal_retryable_flag_is_not_added_to_standard_error(self):
         frames = _serialize(TurnErrorEvent(retryable=True))
 
-        assert frames[0]["data"]["retryable"] is True
+        assert "retryable" not in frames[0]["data"]
 
 
 class TestResponsesAdapterCancelledEvent:
@@ -199,6 +199,7 @@ class TestResponsesAdapterCancelledEvent:
         assert frames[0]["event"] == "error"
         assert frames[0]["data"]["code"] == "cancelled"
         assert frames[0]["data"]["message"] == "cancelled"
+        assert frames[0]["data"]["param"] is None
 
 
 class TestResponsesAdapterSDKModels:
@@ -316,6 +317,21 @@ class TestResponsesTerminalEvents:
         assert response["tools"] == []
         assert response["tool_choice"] == "none"
         assert response["parallel_tool_calls"] is False
+
+    def test_response_completed_echoes_canonical_metadata(self):
+        frames = _parse_frames(
+            responses_terminal_events(
+                response_id=_RESP_ID,
+                item_id=_ITEM_ID,
+                conversation_id=_CONVERSATION_ID,
+                full_text="",
+                response_metadata={"question_id": "question-1"},
+            )
+        )
+
+        assert frames[-1]["data"]["response"]["metadata"] == {
+            "question_id": "question-1"
+        }
 
 
 # ── Strategy guard ───────────────────────────────────────────────────────────
@@ -980,6 +996,10 @@ class TestSseGeneratorLifecycle:
         assert [frame["data"]["sequence_number"] for frame in parsed] == list(
             range(len(parsed))
         )
+        assert not any(
+            frame["event"] == "response.output_text.annotation.added"
+            for frame in parsed
+        )
 
     @pytest.mark.asyncio
     async def test_completed_response_recovers_managed_conversation_from_stream(self):
@@ -1019,6 +1039,13 @@ class TestSseGeneratorLifecycle:
                     "search_kb",
                     TurnToolStatus.STARTED,
                     call_id="call-1",
+                )
+            )
+            yield TurnCitationEvent(
+                TurnCitation(
+                    "src-internal",
+                    title="Internal source",
+                    url="https://example.invalid/source",
                 )
             )
             yield TurnTextEvent("answer")
@@ -1214,6 +1241,20 @@ class TestHostedEntrypointAPI:
         async def fake_flow(ask):
             received["ask"] = ask
             yield "Hello "
+            yield TurnCitationEvent(
+                TurnCitation(
+                    "src-internal",
+                    title="Internal source",
+                    url="https://example.invalid/source",
+                )
+            )
+            yield TurnToolActivityEvent(
+                TurnToolActivity(
+                    "search_kb",
+                    TurnToolStatus.STARTED,
+                    call_id="call-internal",
+                )
+            )
             yield "world"
 
         strategy = MagicMock()
@@ -1239,6 +1280,20 @@ class TestHostedEntrypointAPI:
         delta = response.text.index("event: response.output_text.delta")
         completed = response.text.index("event: response.completed")
         assert created < delta < completed
+        frames = _parse_sse_stream(response.text)
+        assert [frame["data"]["sequence_number"] for frame in frames] == list(
+            range(len(frames))
+        )
+        assert not any(
+            frame["event"] in {
+                "response.output_text.annotation.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+            }
+            for frame in frames
+        )
+        for frame in frames:
+            _RESPONSE_EVENT_ADAPTER.validate_python(frame["data"])
 
     @pytest.mark.parametrize(
         ("conversation", "expected_id"),
@@ -1293,6 +1348,25 @@ class TestHostedEntrypointAPI:
         assert "event: response.output_text.delta" in response.text
         assert "event: response.completed" in response.text
 
+    def test_responses_rejects_extra_conversation_object_fields(self, client):
+        response = client.post(
+            "/responses",
+            json={
+                "input": "Continue",
+                "stream": True,
+                "store": True,
+                "conversation": {"id": "conv-object", "unexpected": "value"},
+            },
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any(
+            error["type"] == "extra_forbidden"
+            and error["loc"][-2:] == ["ResponseConversation", "unexpected"]
+            for error in detail
+        )
+
     def test_responses_maps_metadata_without_projecting_legacy_history(
         self, client, mock_config
     ):
@@ -1307,6 +1381,7 @@ class TestHostedEntrypointAPI:
             history,
             *,
             model,
+            response_metadata,
         ):
             captured.update(
                 turn=turn,
@@ -1315,6 +1390,7 @@ class TestHostedEntrypointAPI:
                 item_id=item_id,
                 history=history,
                 model=model,
+                response_metadata=response_metadata,
             )
             return _async_gen(["event: response.completed\ndata: {}\n\n"])
 
@@ -1337,6 +1413,26 @@ class TestHostedEntrypointAPI:
         assert captured["turn"].correlation_id == "correlation-1"
         assert captured["history"] == ()
         assert captured["model"] == _MODEL
+        assert captured["response_metadata"] == {
+            "question_id": "question-1",
+            "correlation_id": "correlation-1",
+        }
+
+    def test_responses_rejects_non_string_metadata_values(self, client):
+        response = client.post(
+            "/responses",
+            json={
+                "input": "Question",
+                "stream": True,
+                "store": True,
+                "metadata": {"nested": {"unsupported": True}},
+            },
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail[0]["type"] == "string_type"
+        assert detail[0]["loc"] == ["body", "metadata", "nested"]
 
     @pytest.mark.parametrize(
         "unsupported_field",
@@ -1598,6 +1694,11 @@ class TestHostedEntrypointAPI:
             },
             "user_context": {},
         }
+        frames = _parse_sse_stream(resp.text)
+        for frame in frames:
+            _RESPONSE_EVENT_ADAPTER.validate_python(frame["data"])
+        assert frames[0]["data"]["response"].get("metadata") is None
+        assert frames[-1]["data"]["response"].get("metadata") is None
 
     # ── ADR-0001 Foundry Toolbox call-id passthrough (Azure/GPT-RAG#591) ────
 


### PR DESCRIPTION
## Summary
- tighten the canonical `/responses` request schema so nested conversation objects and metadata follow the supported OpenAI Responses subset
- echo canonical metadata in created/completed Response objects while keeping arbitrary legacy `/invocations` metadata out of the public wire response
- suppress internal citations that lack public annotation offsets and emit only standard SDK-compatible error fields
- pin the reviewed OpenAI SDK wire contract to 2.41.1

## Validation
- `PYTHONPATH=<isolated openai-2.41.1> python -m pytest tests/test_hosted_responses.py -q` — 92 passed
- `PYTHONPATH=<isolated openai-2.41.1> python -m pytest -q` — 675 passed
- `python -m ruff check src/api/hosted_entrypoint.py src/api/responses_adapter.py tests/test_hosted_responses.py` — passed
- independent code review — no findings

## Compatibility
- preserves the legacy `POST /invocations` request schema and shared execution/security path
- no release, tag, package, image, or deployment changes