### PR TITLE
fix: pre-cache tokenizer for private runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- **Offline tokenizer initialization for network-isolated hosted agents.**
+  Runtime images now pre-cache the `o200k_base` tokenizer during the image
+  build, preventing the first hosted request from attempting public Blob
+  Storage egress in private-only deployments.
+
 - **Microsoft Foundry hosted-agent Responses route contract.** Added canonical
   `POST /responses` handling for string `input`, `stream: true`, `store: true`,
   optional string/object `conversation`, and optional string-valued `metadata`,

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,13 @@ COPY requirements.txt .
 RUN pip install --upgrade pip \
     && pip install -r requirements.txt
 
+# Hosted runtimes may not have public egress. Cache the tokenizer needed by
+# current chat models while the image is built so requests never download it.
+ENV TIKTOKEN_CACHE_DIR="/app/.cache/tiktoken"
+RUN mkdir -p "$TIKTOKEN_CACHE_DIR" \
+    && python -c "import tiktoken; tiktoken.get_encoding('o200k_base')" \
+    && chmod -R a+rX "$TIKTOKEN_CACHE_DIR"
+
 # 7. Copy app code, expose port, and launch
 COPY . .
 # Copy the pre-built dashboard bundle from the frontend stage. When

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ The routes use distinct Microsoft Foundry request contracts:
 Both routes map to the same transport-neutral hosted turn execution, strategy
 guard, call-id security validation, managed Conversation handling, response
 identifiers, and Responses API SSE lifecycle. The lifecycle uses contiguous
+
+The runtime image pre-caches its tokenizer during the build so hosted requests
+do not require public Blob Storage egress in network-isolated environments. The lifecycle uses contiguous
 sequence numbers and returns the same managed Conversation as
 `{"conversation": {"id": "..."}}` in its opening and completed Response
 objects. Internal orchestration tool progress and citations remain internal

--- a/tests/test_container_contract.py
+++ b/tests/test_container_contract.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_runtime_image_precaches_tokenizer_for_private_hosted_execution():
+    dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'ENV TIKTOKEN_CACHE_DIR="/app/.cache/tiktoken"' in dockerfile
+    assert "tiktoken.get_encoding('o200k_base')" in dockerfile
+    assert 'chmod -R a+rX "$TIKTOKEN_CACHE_DIR"' in dockerfile


### PR DESCRIPTION
## Summary
- pre-cache o200k_base during the container build
- make the cache readable by any runtime user
- remove first-request public Blob Storage egress in network-isolated hosted agents

## Live evidence
A real NETWORK_ISOLATION=true hosted request failed while tiktoken attempted to download openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken. The container had no permitted public runtime route.

## Validation
- python -m pytest tests/test_container_contract.py -q (1 passed)
- python -m pytest -q (678 passed)
- independent code review: no findings