### PR TITLE
Fix Foundry Responses v2 hosting contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,25 @@
   Storage egress in private-only deployments.
 
 - **Microsoft Foundry hosted-agent Responses route contract.** Added canonical
-  `POST /responses` handling for string `input`, `stream: true`, `store: true`,
-  optional string/object `conversation`, and optional string-valued `metadata`,
-  so live
-  Foundry Responses requests no longer fail against the invocation-only
-  schema. Unsupported array/multimodal input, non-streaming requests, and
-  non-storing managed requests fail explicitly with HTTP 422. Unsupported
-  Responses fields are also rejected instead of being ignored, while the
-  platform-injected `agent_reference` routing object is accepted without
-  projecting it into execution state. Streaming
-  events now match pinned `openai==2.41.1` SDK models, carry stream-wide
-  sequence numbers, echo canonical metadata, and return the managed
-  Conversation in standard response objects. Internal orchestration citations
-  and tool progress are withheld from the public stream rather than emitting
-  incomplete or uncorrelatable Responses item lifecycles.
-  The existing `POST /invocations` message-history contract remains
-  compatible; both routes share the strategy and call-id security guards,
-  managed Conversation handling, transport-neutral turn construction, and
-  Responses API SSE lifecycle.
+  Responses v2 hosting through `azure-ai-agentserver-responses`, so real
+  Foundry requests to `POST /responses` no longer receive HTTP 404 or require
+  the separate Invocations schema. The adapter accepts standard string `input`,
+  streaming and synchronous execution, storage controls, managed
+  `conversation` identity, `previous_response_id`, metadata, and the
+  platform-injected `agent_reference`, and supplies protocol retrieval,
+  input-items, cancellation, and deletion routes. List input and unsupported
+  request fields are rejected instead of silently dropping semantics, and
+  mutually exclusive `conversation` and `previous_response_id` inputs cannot
+  contaminate each other's history. The
+  existing `POST /invocations` route retains its distinct message-list schema
+  and compatibility behavior. Toolbox-backed deployments validate the Foundry
+  call context before any create or stored-response route can reach the
+  platform storage provider. Invalid managed-conversation identifiers are
+  rejected instead of creating a new thread, and generative-AI content capture
+  is disabled by default unless explicitly enabled by the operator. Shutdown,
+  client cancellation, and malformed call-id boundaries now stop upstream
+  strategy work without leaking tasks or forwarding a different value than the
+  one validated.
 
 - **Microsoft Foundry hosted-agent readiness probe contract.** Added
   `GET /readiness` to `api.hosted_entrypoint` so the platform readiness probe no

--- a/README.md
+++ b/README.md
@@ -87,30 +87,28 @@ the Foundry hosted-agent protocol 2.0 call context — per
 Toolbox OAuth identity passthrough is the required native path and a manual
 group-filter fallback is never the default.
 
-The routes use distinct Microsoft Foundry request contracts:
-
-- Canonical `POST /responses` accepts a string `input`, `stream: true`,
-  `store: true`, optional `conversation` as either an id string or
-  `{"id": "..."}`, optional string-valued `metadata`, and the platform-injected
-  `agent_reference` routing object. Array/multimodal input,
-  non-streaming requests, non-storing managed requests, and unsupported
-  Responses fields such as `previous_response_id`, `instructions`, or `tools`
-  return HTTP 422 rather than being ignored.
-- Compatibility `POST /invocations` retains ordered
-  `messages`, optional `conversation_id`, and optional `metadata`, including
-  projection of prior message history.
-
-Both routes map to the same transport-neutral hosted turn execution, strategy
-guard, call-id security validation, managed Conversation handling, response
-identifiers, and Responses API SSE lifecycle. The lifecycle uses contiguous
+`POST /responses` is hosted by Microsoft's
+`azure-ai-agentserver-responses` implementation of the Foundry Responses v2
+protocol. The orchestrator adapter accepts the documented string `input`
+contract with streaming or synchronous execution, storage controls, managed
+`conversation` identity, `previous_response_id`, metadata, and the
+platform-injected `agent_reference`; list input is rejected rather than
+silently losing role semantics in server-thread strategies. Other Responses
+request fields are rejected rather than silently ignored, and `conversation`
+cannot be combined with `previous_response_id`. The protocol host also owns
+response retrieval, input-item listing, cancellation, and deletion.
+`POST /invocations` remains a separate compatibility protocol for the existing
+`messages` request schema. Both protocols reuse the same hosted strategy
+execution and identity guard after parsing their distinct request contracts.
 
 The runtime image pre-caches its tokenizer during the build so hosted requests
-do not require public Blob Storage egress in network-isolated environments. The lifecycle uses contiguous
-sequence numbers and returns the same managed Conversation as
-`{"conversation": {"id": "..."}}` in its opening and completed Response
-objects. Internal orchestration tool progress and citations remain internal
-until they can be represented with complete standards-compliant public item
-lifecycles.
+do not require public Blob Storage egress in network-isolated environments.
+
+The hosted Responses server disables generative-AI prompt and completion
+capture in OpenTelemetry by default. Set
+`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` only when the
+deployment's data-handling policy explicitly permits sensitive content
+telemetry.
 
 The hosted entrypoint exposes `GET /readiness` for Microsoft Foundry readiness
 probes. The compatibility `GET /health` route returns the same immutable image
@@ -123,13 +121,15 @@ The platform injects two headers on every hosted-agent request:
 | `x-agent-user-id` | Per-user container partition key. | No — container-side only. |
 | `x-agent-foundry-call-id` | Opaque per-request call identifier. | Yes — the only supported identity passthrough correlation token. |
 
-`POST /responses` and compatibility `POST /invocations` capture and strictly
-validate `x-agent-foundry-call-id`
+Both `POST /responses` and `POST /invocations` capture and strictly validate
+`x-agent-foundry-call-id`
 (printable ASCII, no spaces or control characters, 256 characters max)
 whenever the resolved strategy is Toolbox-backed (currently only `mcp`). A
-missing or malformed value is rejected with **HTTP 401** before any strategy
-or Toolbox client is constructed — there is no fallback to service identity or
-to the legacy `metadata_security_id` manual filter. The validated call id
+missing or malformed value is rejected with HTTP 401 before the Responses
+storage provider, strategy, or Toolbox client is reached; the same guard covers
+response retrieval, input-item listing, cancellation, and deletion. There is no
+fallback to service identity or to the legacy `metadata_security_id` manual
+filter. The validated call id
 then flows unchanged through the runtime-neutral `TurnRequest` into the
 strategy and is echoed as the sole outbound identity header on every Toolbox
 MCP HTTP call, so Toolbox can resolve the signed-in user and mint per-user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,14 @@ dependencies = [
     
     # Azure SDKs
     "azure-ai-agents>=1.2.0b5",
+    "azure-ai-agentserver-responses==2.0.0b1",
     "azure-ai-projects==2.0.0b3",
     "azure-appconfiguration>=1.7.1",
     "azure-appconfiguration-provider>=2.3.1",
     "azure-cosmos>=4.5.1",
     "azure-identity>=1.21.0",
     "azure-keyvault-secrets>=4.8.0",
-    "azure-monitor-opentelemetry>=1.8.4",
+    "azure-monitor-opentelemetry>=1.8.9",
     "azure-search-documents>=11.7.0b2",
     "azure-storage-blob>=12.25.1",
     
@@ -33,10 +34,10 @@ dependencies = [
     "httpx-sse>=0.4.3",
     
     # OpenTelemetry
-    "opentelemetry-api>=1.39.0",
-    "opentelemetry-sdk>=1.39.0",
-    "opentelemetry-instrumentation-fastapi>=0.60b0",
-    "opentelemetry-instrumentation-httpx>=0.60b0",
+    "opentelemetry-api>=1.43.0",
+    "opentelemetry-sdk>=1.43.0",
+    "opentelemetry-instrumentation-fastapi>=0.64b0",
+    "opentelemetry-instrumentation-httpx>=0.64b0",
     
     # AI/ML
     "openai==2.41.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ azure-appconfiguration==1.7.1
 azure.appconfiguration.provider
 azure-ai-projects==2.0.0b3
 azure-ai-agents>=1.2.0b4
+azure-ai-agentserver-responses==2.0.0b1
 azure-search-documents==11.7.0b2
 
 # AI and NLP dependencies
@@ -51,7 +52,7 @@ uvicorn==0.49.0
 sqlparse==0.5.5
 pyodbc==5.1.0
 #opentelemetry
-azure-monitor-opentelemetry==1.8.7
-azure-monitor-opentelemetry-exporter==1.0.0b53
-opentelemetry-instrumentation-httpx==0.61b0
-opentelemetry-instrumentation-fastapi==0.61b0
+azure-monitor-opentelemetry==1.8.9
+azure-monitor-opentelemetry-exporter==1.0.0b56
+opentelemetry-instrumentation-httpx==0.64b0
+opentelemetry-instrumentation-fastapi==0.64b0

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -1,7 +1,7 @@
 """Hosted agent entrypoint for Azure AI Foundry.
 
-This FastAPI application wires the runtime-neutral orchestration core to the
-Foundry Responses API streaming format.  It is intentionally separate from the
+This ASGI application wires the runtime-neutral orchestration core to the
+Foundry Responses protocol.  It is intentionally separate from the
 classic ``main.py`` so that:
 
 - No Cosmos DB or orchestrator Container Apps dependency exists in the hosted
@@ -22,16 +22,32 @@ Or via Docker by overriding the entrypoint command.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
 import time
 import uuid
 from collections.abc import AsyncIterator
+from contextlib import suppress
 from pathlib import Path
-from typing import Any, Literal, Optional, Sequence
+from typing import Any, Awaitable, Callable, Literal, Optional, Sequence, cast
 
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from azure.ai.agentserver.core import (
+    configure_observability as configure_agentserver_observability,
+)
+from azure.ai.agentserver.responses import (
+    CreateResponse,
+    ResponseContext,
+    ResponseEventStream,
+    ResponseProviderProtocol,
+    ResponsesAgentServerHost,
+    ResponsesServerOptions,
+)
+from pydantic import BaseModel, Field, ValidationError
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
 
 from api.responses_adapter import responses_terminal_events, serialize_responses_events
 from connectors.foundry_conversations import resolve_managed_conversation_id
@@ -71,111 +87,7 @@ except FileNotFoundError:
     _APP_VERSION = "0.0.0"
 
 
-# ── Pydantic schemas for the Foundry hosted-agent contracts ─────────────────
-
-
-class ResponseConversation(BaseModel):
-    """Conversation reference accepted by the Responses API."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    id: str = Field(..., description="Foundry-managed Conversation id")
-
-    @field_validator("id", mode="before")
-    @classmethod
-    def validate_id(cls, value: Any) -> str:
-        if not isinstance(value, str):
-            raise ValueError("Conversation id must be a string.")
-        value = value.strip()
-        if not value:
-            raise ValueError("Conversation id must not be empty.")
-        return value
-
-
-class ResponseAgentReference(BaseModel):
-    """Foundry routing metadata injected into hosted Responses requests."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    type: Literal["agent_reference"]
-    name: str
-    version: str
-
-
-class ResponsesRequest(BaseModel):
-    """Supported subset of a canonical Microsoft Foundry Responses request.
-
-    Unsupported Responses fields are rejected explicitly. This adapter
-    currently supports only string input and SSE responses that may be stored
-    by Foundry.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    input: str = Field(..., description="Current user ask as plain text")
-    stream: bool = Field(..., description="Must be true; hosted execution is SSE-only")
-    store: bool = Field(
-        True,
-        description="Must be true; non-storing managed execution is not supported",
-    )
-    conversation: str | ResponseConversation | None = Field(
-        None,
-        description="Foundry-managed Conversation id or an object containing its id",
-    )
-    metadata: Optional[dict[str, str]] = Field(
-        default_factory=dict,
-        description="String-valued request metadata",
-    )
-    agent_reference: ResponseAgentReference | None = Field(
-        None,
-        description="Foundry-injected routing metadata; not projected into execution state",
-    )
-
-    @field_validator("input", mode="before")
-    @classmethod
-    def validate_input(cls, value: Any) -> str:
-        if not isinstance(value, str):
-            raise ValueError(
-                "Only string input is supported; array and multimodal input are not supported."
-            )
-        value = value.strip()
-        if not value:
-            raise ValueError("Input must not be empty or whitespace.")
-        return value
-
-    @field_validator("stream", mode="before")
-    @classmethod
-    def validate_stream(cls, value: Any) -> bool:
-        if value is not True:
-            raise ValueError(
-                "Only stream=true is supported; this hosted endpoint returns "
-                "an SSE stream."
-            )
-        return True
-
-    @field_validator("store", mode="before")
-    @classmethod
-    def validate_store(cls, value: Any) -> bool:
-        if value is not True:
-            raise ValueError(
-                "Only store=true is supported; non-storing managed execution is not supported."
-            )
-        return True
-
-    @field_validator("conversation", mode="before")
-    @classmethod
-    def validate_conversation(cls, value: Any) -> Any:
-        if value is None or isinstance(value, dict):
-            return value
-        if not isinstance(value, str):
-            raise ValueError(
-                "Conversation must be a string id or an object containing an id."
-            )
-        value = value.strip()
-        if not value:
-            raise ValueError("Conversation id must not be empty.")
-        return value
-
+# ── Pydantic schema for the legacy Invocations protocol ─────────────────────
 
 class InvocationMessage(BaseModel):
     """One message turn in the inbound invocation request."""
@@ -352,8 +264,8 @@ def _sse_generator(
                     yield frame
 
         except MissingFoundryCallContextError as exc:
-            # Defense-in-depth only: the normal hosted HTTP paths already
-            # reject a missing/malformed call id with an HTTP 401 *before*
+            # Defense-in-depth only: the normal ``/invocations`` route rejects a
+            # missing/malformed call id with an HTTP 401 *before*
             # ``StreamingResponse`` is constructed, so this branch cannot be
             # reached from a real HTTP request today. It exists solely to
             # correctly classify the error if some future/internal caller
@@ -367,7 +279,7 @@ def _sse_generator(
             # below.
             logger.warning(
                 "[hosted] Missing Foundry call context reached SSE generator "
-                "directly (bypassed hosted route precheck) for strategy=%s",
+                "directly (bypassed /invocations precheck) for strategy=%s",
                 strategy_key,
             )
             if not error_emitted:
@@ -401,36 +313,8 @@ def _sse_generator(
     return _gen()
 
 
-# ── FastAPI application ──────────────────────────────────────────────────────
+# ── Hosted protocol application ──────────────────────────────────────────────
 
-app = FastAPI(
-    title="GPT-RAG Hosted Agent",
-    description=(
-        "Foundry-hosted execution of the GPT-RAG orchestration core "
-        "over the Responses API streaming contract."
-    ),
-    version=_APP_VERSION,
-)
-
-
-@app.get(
-    "/health",
-    response_model=HealthResponse,
-    summary="Liveness check",
-    description=(
-        "Returns the immutable image version and the set of strategies "
-        "eligible for this hosted runtime.  Use for container readiness probes."
-    ),
-)
-@app.get(
-    "/readiness",
-    response_model=HealthResponse,
-    summary="Readiness check",
-    description=(
-        "Returns the immutable image version and the set of strategies "
-        "eligible for this hosted runtime."
-    ),
-)
 async def health() -> HealthResponse:
     return HealthResponse(
         status="ok",
@@ -439,51 +323,20 @@ async def health() -> HealthResponse:
     )
 
 
-_HOSTED_STREAM_RESPONSES: dict[int | str, dict[str, Any]] = {
-    200: {
-        "description": "OK — Responses API SSE stream",
-        "content": {"text/event-stream": {}},
-    },
-    401: {
-        "description": (
-            "Missing or malformed platform call context — hosted retrieval "
-            "failed closed rather than falling back to service identity or a "
-            "manual filter."
-        ),
-        "content": {
-            "application/json": {
-                "example": {
-                    "detail": (
-                        "Missing or malformed platform call context "
-                        "('x-agent-foundry-call-id')."
-                    )
-                }
-            }
-        },
-    },
-    422: {
-        "description": "Unsupported request value, strategy, or validation error",
-        "content": {
-            "application/json": {
-                "example": {
-                    "detail": "Strategy 'multimodal' is not supported in the hosted runtime."
-                }
-            }
-        },
-    },
-}
+async def _health_endpoint(_request: Request) -> JSONResponse:
+    return JSONResponse((await health()).model_dump())
 
 
-def _handle_hosted_request(
+async def _create_hosted_streaming_response(
     request: Request,
     *,
     ask: str,
-    conversation_id: str | None,
-    metadata: dict[str, Any] | None,
+    conversation_id: Optional[str],
+    metadata: dict[str, Any],
     history: Sequence[HostedConversationMessage] = (),
     response_metadata: dict[str, str] | None = None,
 ) -> StreamingResponse:
-    """Apply shared hosted execution and security behavior to one turn."""
+    """Build one hosted SSE response after protocol-specific validation."""
     # Resolve and guard the strategy.
     cfg = get_config()
     strategy_key = cfg.get("AGENT_STRATEGY", "maf_lite")
@@ -504,7 +357,6 @@ def _handle_hosted_request(
         except MissingFoundryCallContextError as exc:
             raise HTTPException(status_code=401, detail=str(exc)) from exc
 
-    # Build the transport-neutral turn request.
     metadata = metadata or {}
     turn = TurnRequest(
         ask=ask,
@@ -519,7 +371,7 @@ def _handle_hosted_request(
     item_id = f"item_{uuid.uuid4().hex}"
 
     logger.info(
-        "[hosted] invocation: strategy=%s conversation_id=%s response_id=%s",
+        "[hosted] response: strategy=%s conversation_id=%s response_id=%s",
         strategy_key,
         conversation_id or "∅",
         response_id,
@@ -540,49 +392,8 @@ def _handle_hosted_request(
     )
 
 
-@app.post(
-    "/responses",
-    summary="Handle a canonical Foundry Responses request",
-    description=(
-        "Accepts canonical string input with stream=true and store=true, then "
-        "streams Azure AI Foundry Responses API SSE events. Conversation may "
-        "be a string id or an object containing id."
-    ),
-    responses=_HOSTED_STREAM_RESPONSES,
-)
-async def responses(request: Request, body: ResponsesRequest) -> StreamingResponse:
-    """Map a canonical Microsoft Foundry Responses request to hosted execution."""
-    conversation_id = (
-        body.conversation.id
-        if isinstance(body.conversation, ResponseConversation)
-        else body.conversation
-    )
-    return _handle_hosted_request(
-        request,
-        ask=body.input,
-        conversation_id=conversation_id,
-        metadata=body.metadata,
-        response_metadata=body.metadata,
-    )
-
-
-@app.post(
-    "/invocations",
-    summary="Handle a compatible Foundry invocation",
-    description=(
-        "Accepts ordered invocation message history, projects prior messages "
-        "into hosted execution, and streams Responses API SSE events."
-    ),
-    responses=_HOSTED_STREAM_RESPONSES,
-)
 async def invocations(request: Request, body: InvocationRequest) -> StreamingResponse:
-    """Translate the compatibility invocation contract to hosted execution.
-
-    The final message must be the current user ask. Messages after the current
-    ask are rejected rather than silently discarded. Toolbox-integrated
-    strategies require the validated platform ``x-agent-foundry-call-id`` in
-    the shared handler; neither route reads or forwards ``Authorization``.
-    """
+    """Translate the legacy Foundry invocation contract into an SSE stream."""
     current_message = body.messages[-1]
     if current_message.role != "user":
         raise HTTPException(
@@ -603,10 +414,463 @@ async def invocations(request: Request, body: InvocationRequest) -> StreamingRes
         {"role": message.role, "text": message.content}
         for message in body.messages[:-1]
     ]
-    return _handle_hosted_request(
+    return await _create_hosted_streaming_response(
         request,
         ask=ask,
         conversation_id=body.conversation_id,
-        metadata=body.metadata,
+        metadata=body.metadata or {},
         history=history,
     )
+
+
+async def _invocations_endpoint(request: Request) -> JSONResponse | StreamingResponse:
+    """Validate the legacy request model before invoking its SSE handler."""
+    try:
+        body = InvocationRequest.model_validate(await request.json())
+        return await invocations(request, body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JSONResponse(
+            {"detail": "The Invocations request body must be valid JSON."},
+            status_code=400,
+        )
+    except ValidationError as exc:
+        return JSONResponse(
+            {"detail": exc.errors(include_url=False)},
+            status_code=422,
+        )
+    except HTTPException as exc:
+        return JSONResponse(
+            {"detail": exc.detail},
+            status_code=exc.status_code,
+            headers=exc.headers,
+        )
+
+
+def _responses_history(
+    items: Sequence[dict[str, Any]],
+) -> list[HostedConversationMessage]:
+    """Project platform-managed Responses history into strategy chat history."""
+    messages: list[HostedConversationMessage] = []
+    for item in items:
+        if item.get("type") not in {"message", "output_message"}:
+            continue
+        role = item.get("role")
+        if role == "developer":
+            role = "system"
+        if role not in {"user", "assistant", "system"}:
+            continue
+        content = item.get("content")
+        if not isinstance(content, list):
+            continue
+        text = "".join(
+            part["text"]
+            for part in content
+            if isinstance(part, dict)
+            and part.get("type") in {"input_text", "output_text"}
+            and isinstance(part.get("text"), str)
+        )
+        if text:
+            messages.append({"role": role, "text": text})
+    return messages
+
+
+async def _responses_conversation_id(
+    context: ResponseContext,
+    provider: ResponseProviderProtocol,
+) -> str | None:
+    """Recover the managed conversation attached to a chained response."""
+    if context.conversation_id:
+        return context.conversation_id
+
+    previous_response_id = (context.request or {}).get("previous_response_id")
+    if not isinstance(previous_response_id, str):
+        return None
+
+    previous_response = await provider.get_response(
+        previous_response_id,
+        context=context.platform_context,
+    )
+    conversation = previous_response.get("conversation")
+    if isinstance(conversation, str):
+        return conversation
+    if isinstance(conversation, dict):
+        conversation_id = conversation.get("id")
+        if isinstance(conversation_id, str):
+            return conversation_id
+    return None
+
+
+async def _cancel_aware_events(
+    events: AsyncIterator[TurnOutputEvent],
+    cancellation_signal: asyncio.Event,
+    shutdown_signal: asyncio.Event,
+) -> AsyncIterator[TurnOutputEvent]:
+    """Stop and close in-flight strategy work on cancellation or shutdown."""
+    iterator = events.__aiter__()
+    active_tasks: set[asyncio.Task[Any]] = set()
+    try:
+        while not cancellation_signal.is_set() and not shutdown_signal.is_set():
+            next_event = asyncio.create_task(anext(iterator))
+            cancelled = asyncio.create_task(cancellation_signal.wait())
+            shutting_down = asyncio.create_task(shutdown_signal.wait())
+            active_tasks.update({next_event, cancelled, shutting_down})
+            done, _ = await asyncio.wait(
+                active_tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if cancelled in done or shutting_down in done:
+                return
+
+            cancelled.cancel()
+            shutting_down.cancel()
+            with suppress(asyncio.CancelledError):
+                await cancelled
+            with suppress(asyncio.CancelledError):
+                await shutting_down
+            active_tasks.clear()
+            try:
+                yield next_event.result()
+            except StopAsyncIteration:
+                return
+    finally:
+        for task in active_tasks:
+            if not task.done():
+                task.cancel()
+        for task in active_tasks:
+            with suppress(asyncio.CancelledError, StopAsyncIteration):
+                await task
+        if hasattr(iterator, "aclose"):
+            await iterator.aclose()
+
+
+async def _responses_events(
+    request: CreateResponse,
+    context: ResponseContext,
+    cancellation_signal: asyncio.Event,
+    provider: ResponseProviderProtocol,
+) -> AsyncIterator[Any]:
+    """Adapt one strategy turn to the official Responses event lifecycle."""
+    ask = (await context.get_input_text()).strip()
+    if not ask:
+        raise ValueError("The Responses input must not be empty.")
+
+    cfg = get_config()
+    strategy_key = cfg.get("AGENT_STRATEGY", "maf_lite")
+    guard_hosted_strategy(strategy_key)
+
+    foundry_call_id: Optional[str] = None
+    if strategy_key in HOSTED_TOOLBOX_STRATEGIES:
+        platform_call_id = context.platform_context.call_id
+        headers = (
+            {"x-agent-foundry-call-id": platform_call_id}
+            if platform_call_id is not None
+            else {}
+        )
+        foundry_call_id = require_foundry_call_id(headers)
+
+    metadata = request.get("metadata")
+    conversation_id = await _responses_conversation_id(context, provider)
+    turn = TurnRequest(
+        ask=ask,
+        conversation_id=conversation_id,
+        question_id=metadata.get("question_id") if metadata else None,
+        user_context={},
+        correlation_id=metadata.get("correlation_id") if metadata else None,
+        foundry_call_id=foundry_call_id,
+    )
+    history = _responses_history(
+        cast(Sequence[dict[str, Any]], await context.get_history())
+    )
+
+    response_stream: ResponseEventStream | None = None
+    message = None
+    text_content = None
+    full_text: list[str] = []
+
+    async for event in _cancel_aware_events(
+        _hosted_stream(turn, strategy_key, history),
+        cancellation_signal,
+        context.shutdown,
+    ):
+        if isinstance(event, TurnConversationEvent):
+            response_stream = ResponseEventStream(
+                response_id=context.response_id,
+                request=request,
+            )
+            response_stream.response.setdefault("tools", [])
+            response_stream.response.setdefault("tool_choice", "auto")
+            response_stream.response["conversation"] = {"id": event.conversation_id}
+            yield response_stream.emit_created()
+            yield response_stream.emit_in_progress()
+            message = response_stream.add_output_item_message()
+            yield message.emit_added()
+            text_content = message.add_text_content()
+            yield text_content.emit_added()
+        elif isinstance(event, TurnTextEvent):
+            if text_content is None:
+                raise RuntimeError("Hosted strategy emitted text before conversation identity.")
+            full_text.append(event.text)
+            yield text_content.emit_delta(event.text)
+        elif isinstance(event, TurnErrorEvent):
+            raise RuntimeError(event.message)
+        elif isinstance(event, TurnCancelledEvent):
+            cancellation_signal.set()
+            return
+
+    if cancellation_signal.is_set() or context.shutdown.is_set():
+        return
+
+    if response_stream is None or message is None or text_content is None:
+        raise RuntimeError("Hosted strategy did not emit a conversation identity.")
+
+    final_text = "".join(full_text)
+    yield text_content.emit_text_done(final_text)
+    yield text_content.emit_done()
+    yield message.emit_done()
+    yield response_stream.emit_completed()
+
+
+class HostedResponsesAgentServerHost(ResponsesAgentServerHost):
+    """Responses host with the image's immutable readiness contract."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._responses_provider = cast(
+            ResponseProviderProtocol,
+            self._endpoint._provider,
+        )
+        for index, route in enumerate(self.routes):
+            route_name = getattr(route, "name", None)
+            if route_name not in {
+                "create_response",
+                "get_response",
+                "delete_response",
+                "cancel_response",
+                "get_input_items",
+            }:
+                continue
+            endpoint = cast(Callable[[Request], Awaitable[Response]], route.endpoint)
+            guarded_endpoint = (
+                self._create_endpoint(endpoint)
+                if route_name == "create_response"
+                else self._responses_endpoint(endpoint)
+            )
+            self.routes[index] = Route(
+                route.path,
+                guarded_endpoint,
+                methods=sorted(route.methods or ()),
+                name=route.name,
+            )
+
+    async def handle_response(
+        self,
+        request: CreateResponse,
+        context: ResponseContext,
+        cancellation_signal: asyncio.Event,
+    ) -> AsyncIterator[Any]:
+        async for event in _responses_events(
+            request,
+            context,
+            cancellation_signal,
+            self._responses_provider,
+        ):
+            yield event
+
+    async def _readiness_endpoint(self, request: Request) -> JSONResponse:
+        return await _health_endpoint(request)
+
+    def _responses_endpoint(
+        self,
+        endpoint: Callable[[Request], Awaitable[Response]],
+    ) -> Callable[[Request], Awaitable[Response]]:
+        async def guarded(request: Request) -> Response:
+            call_context_error = self._call_context_error(request)
+            if call_context_error is not None:
+                return call_context_error
+            return await endpoint(request)
+
+        return guarded
+
+    def _create_endpoint(
+        self,
+        endpoint: Callable[[Request], Awaitable[Response]],
+    ) -> Callable[[Request], Awaitable[Response]]:
+        async def validated(request: Request) -> Response:
+            call_context_error = self._call_context_error(request)
+            if call_context_error is not None:
+                return call_context_error
+
+            try:
+                payload = await request.json()
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return JSONResponse(
+                    {"detail": "The Responses request body must be valid JSON."},
+                    status_code=400,
+                )
+
+            if not isinstance(payload, dict) or "input" not in payload:
+                return JSONResponse(
+                    {"detail": "The Responses request requires an input field."},
+                    status_code=422,
+                )
+
+            supported_fields = {
+                "agent_reference",
+                "background",
+                "conversation",
+                "input",
+                "metadata",
+                "previous_response_id",
+                "store",
+                "stream",
+            }
+            unsupported_fields = sorted(set(payload) - supported_fields)
+            if unsupported_fields:
+                return JSONResponse(
+                    {
+                        "detail": (
+                            "Unsupported Responses request fields: "
+                            + ", ".join(unsupported_fields)
+                            + "."
+                        )
+                    },
+                    status_code=422,
+                )
+
+            response_input = payload["input"]
+            if not isinstance(response_input, str):
+                return JSONResponse(
+                    {
+                        "detail": (
+                            "This hosted adapter supports string Responses input."
+                        )
+                    },
+                    status_code=422,
+                )
+            if not response_input.strip():
+                return JSONResponse(
+                    {"detail": "The Responses input must not be empty."},
+                    status_code=422,
+                )
+
+            conversation = payload.get("conversation")
+            valid_conversation = (
+                conversation is None
+                or (isinstance(conversation, str) and bool(conversation.strip()))
+                or (
+                    isinstance(conversation, dict)
+                    and set(conversation) == {"id"}
+                    and isinstance(conversation["id"], str)
+                    and bool(conversation["id"].strip())
+                )
+            )
+            if not valid_conversation:
+                return JSONResponse(
+                    {
+                        "detail": (
+                            "Responses conversation must be a non-empty id string "
+                            "or an object containing only a non-empty string id."
+                        )
+                    },
+                    status_code=422,
+                )
+
+            if conversation is not None and payload.get("previous_response_id") is not None:
+                return JSONResponse(
+                    {
+                        "detail": (
+                            "Responses conversation and previous_response_id "
+                            "cannot be used together."
+                        )
+                    },
+                    status_code=422,
+                )
+
+            metadata = payload.get("metadata")
+            if metadata is not None and (
+                not isinstance(metadata, dict)
+                or not all(
+                    isinstance(key, str) and isinstance(value, str)
+                    for key, value in metadata.items()
+                )
+            ):
+                return JSONResponse(
+                    {
+                        "detail": (
+                            "Responses metadata must contain only string keys and values."
+                        )
+                    },
+                    status_code=422,
+                )
+
+            return await endpoint(request)
+
+        return validated
+
+    @staticmethod
+    def _call_context_error(request: Request) -> JSONResponse | None:
+        strategy_key = get_config().get("AGENT_STRATEGY", "maf_lite")
+        if strategy_key not in HOSTED_TOOLBOX_STRATEGIES:
+            return None
+        try:
+            require_foundry_call_id(request.headers)
+        except MissingFoundryCallContextError as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=401)
+        return None
+
+
+_DEFAULT_OBSERVABILITY = object()
+
+
+def _configure_host_observability(
+    *,
+    connection_string: str | None,
+    log_level: str | None,
+    enable_sensitive_data: bool,
+) -> None:
+    """Configure SDK telemetry with content capture disabled by default."""
+    del enable_sensitive_data
+    capture_setting = os.environ.get(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+        "false",
+    )
+    configure_agentserver_observability(
+        connection_string=connection_string,
+        log_level=log_level,
+        enable_sensitive_data=capture_setting.strip().lower() in {"true", "1"},
+    )
+
+
+def create_app(
+    *,
+    store: ResponseProviderProtocol | None = None,
+    configure_observability: Any = _DEFAULT_OBSERVABILITY,
+) -> HostedResponsesAgentServerHost:
+    """Create the multi-protocol hosted app with injectable test boundaries."""
+    host_options: dict[str, Any] = {}
+    if configure_observability is _DEFAULT_OBSERVABILITY:
+        host_options["configure_observability"] = _configure_host_observability
+    else:
+        host_options["configure_observability"] = configure_observability
+
+    hosted_app = HostedResponsesAgentServerHost(
+        options=ResponsesServerOptions(
+            additional_server_version=f"gpt-rag-orchestrator/{_APP_VERSION}",
+        ),
+        store=store,
+        routes=[
+            Route("/health", _health_endpoint, methods=["GET"], name="health"),
+            Route(
+                "/invocations",
+                _invocations_endpoint,
+                methods=["POST"],
+                name="invocations",
+            ),
+        ],
+        **host_options,
+    )
+    hosted_app.response_handler(hosted_app.handle_response)
+    return hosted_app
+
+
+app = create_app()

--- a/src/util/foundry_platform.py
+++ b/src/util/foundry_platform.py
@@ -83,12 +83,14 @@ def require_foundry_call_id(headers: Mapping[str, str]) -> str:
     """Return the validated opaque Foundry call id, or fail closed.
 
     Raises :class:`MissingFoundryCallContextError` when the header is
-    missing, empty, too long, or contains characters that would allow
-    outbound header injection when echoed to Toolbox.
+    missing, empty, surrounded by whitespace, too long, or contains characters
+    that would allow outbound header injection when echoed to Toolbox.
     """
+    raw_call_id = headers.get(FOUNDRY_CALL_ID_HEADER)
     call_id = extract_foundry_call_id(headers)
     if (
         not call_id
+        or raw_call_id != call_id
         or len(call_id) > _MAX_CALL_ID_LENGTH
         # ``fullmatch`` (not ``match``) is required here: with ``^...$`` and
         # no ``re.MULTILINE``, Python's ``$`` matches just before a single

--- a/tests/test_foundry_platform.py
+++ b/tests/test_foundry_platform.py
@@ -46,6 +46,12 @@ class TestRequireFoundryCallId:
         with pytest.raises(MissingFoundryCallContextError):
             require_foundry_call_id({FOUNDRY_CALL_ID_HEADER: "   "})
 
+    def test_raises_for_surrounding_whitespace(self):
+        with pytest.raises(MissingFoundryCallContextError):
+            require_foundry_call_id(
+                {FOUNDRY_CALL_ID_HEADER: "  call-abc-123  "}
+            )
+
     def test_raises_when_too_long(self):
         headers = {FOUNDRY_CALL_ID_HEADER: "x" * 257}
         with pytest.raises(MissingFoundryCallContextError):

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -5,7 +5,7 @@ Covers:
 - Terminal closing frames after the text stream
 - Hosted strategy guard (explicit failure for unsupported strategies)
 - Hosted stream execution without Cosmos dependency
-- Hosted FastAPI endpoints (health, readiness, responses, and invocations)
+- Hosted ASGI endpoints (health, readiness, responses, and invocations)
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
@@ -69,11 +70,15 @@ def _parse_frames(frames: list[str]) -> list[dict[str, Any]]:
     return result
 
 
-def _parse_sse_stream(body: str) -> list[dict[str, Any]]:
-    """Parse a complete SSE response body into typed frame dictionaries."""
+def _parse_sse_body(body: str) -> list[dict[str, Any]]:
     return _parse_frames(
         [f"{frame}\n\n" for frame in body.strip().split("\n\n") if frame]
     )
+
+
+def _parse_sse_stream(body: str) -> list[dict[str, Any]]:
+    """Parse a complete SSE response body into typed frame dictionaries."""
+    return _parse_sse_body(body)
 
 
 def _serialize(event, **kwargs):
@@ -87,6 +92,19 @@ def _serialize(event, **kwargs):
             **kwargs,
         )
     )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _disable_test_otel_exporters():
+    previous = os.environ.get("OTEL_SDK_DISABLED")
+    os.environ["OTEL_SDK_DISABLED"] = "true"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("OTEL_SDK_DISABLED", None)
+        else:
+            os.environ["OTEL_SDK_DISABLED"] = previous
 
 
 # ── ResponsesAdapter serialization ───────────────────────────────────────────
@@ -969,6 +987,70 @@ class TestSseGeneratorErrorClassification:
         assert parsed == error_frames
 
 
+class TestCancelAwareEvents:
+    @pytest.mark.asyncio
+    async def test_shutdown_stops_and_closes_blocked_strategy_iterator(self):
+        from api.hosted_entrypoint import _cancel_aware_events
+
+        started = asyncio.Event()
+        closed = asyncio.Event()
+        release = asyncio.Event()
+
+        async def source():
+            try:
+                started.set()
+                await release.wait()
+                yield TurnTextEvent("late")
+            finally:
+                closed.set()
+
+        cancellation = asyncio.Event()
+        shutdown = asyncio.Event()
+        consumer = asyncio.create_task(
+            anext(_cancel_aware_events(source(), cancellation, shutdown))
+        )
+        await started.wait()
+
+        shutdown.set()
+
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(consumer, timeout=1)
+        await asyncio.wait_for(closed.wait(), timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_outer_cancellation_closes_blocked_strategy_iterator(self):
+        from api.hosted_entrypoint import _cancel_aware_events
+
+        started = asyncio.Event()
+        closed = asyncio.Event()
+        release = asyncio.Event()
+
+        async def source():
+            try:
+                started.set()
+                await release.wait()
+                yield TurnTextEvent("late")
+            finally:
+                closed.set()
+
+        consumer = asyncio.create_task(
+            anext(
+                _cancel_aware_events(
+                    source(),
+                    asyncio.Event(),
+                    asyncio.Event(),
+                )
+            )
+        )
+        await started.wait()
+
+        consumer.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+        await asyncio.wait_for(closed.wait(), timeout=1)
+
+
 class TestSseGeneratorLifecycle:
     @pytest.mark.asyncio
     async def test_sequence_numbers_increase_across_complete_stream(self):
@@ -1168,7 +1250,7 @@ class TestHostedConstruction:
 # ── Hosted FastAPI endpoints ─────────────────────────────────────────────────
 
 class TestHostedEntrypointAPI:
-    """Integration-style tests for the FastAPI app in hosted_entrypoint."""
+    """Integration-style tests for the hosted multi-protocol app."""
 
     @pytest.fixture(autouse=True)
     def _patch_deps(self, mock_config, mock_cosmos):
@@ -1186,10 +1268,16 @@ class TestHostedEntrypointAPI:
 
     @pytest.fixture()
     def client(self):
+        from azure.ai.agentserver.responses import InMemoryResponseProvider
         from fastapi.testclient import TestClient
-        from api.hosted_entrypoint import app
+        from api.hosted_entrypoint import create_app
 
-        return TestClient(app, raise_server_exceptions=False)
+        app = create_app(
+            store=InMemoryResponseProvider(),
+            configure_observability=None,
+        )
+        with TestClient(app, raise_server_exceptions=False) as client:
+            yield client
 
     def test_health_and_readiness_return_same_health_response(self, client):
         from api.hosted_entrypoint import HealthResponse, _APP_VERSION
@@ -1216,21 +1304,80 @@ class TestHostedEntrypointAPI:
         assert resp.status_code == 200
         assert set(resp.json()["eligible_strategies"]) == HOSTED_ELIGIBLE_STRATEGIES
 
-    def test_responses_and_invocations_expose_distinct_request_contracts(self, client):
-        paths = client.get("/openapi.json").json()["paths"]
-        responses_contract = paths["/responses"]["post"]
-        invocations_contract = paths["/invocations"]["post"]
+    def test_responses_and_invocations_publish_distinct_route_contracts(self, client):
+        routes = {
+            (route.path, method)
+            for route in client.app.routes
+            for method in (route.methods or set())
+        }
 
-        assert responses_contract["requestBody"] != invocations_contract["requestBody"]
-        assert (
-            responses_contract["requestBody"]["content"]["application/json"]["schema"]["$ref"]
-            .endswith("/ResponsesRequest")
+        assert ("/responses", "POST") in routes
+        assert ("/responses/{response_id}", "GET") in routes
+        assert ("/responses/{response_id}", "DELETE") in routes
+        assert ("/responses/{response_id}/cancel", "POST") in routes
+        assert ("/responses/{response_id}/input_items", "GET") in routes
+        assert ("/invocations", "POST") in routes
+
+    def test_responses_rejects_invocations_payload(self, client):
+        resp = client.post(
+            "/responses",
+            json={"messages": [{"role": "user", "content": "Hi"}]},
         )
-        assert (
-            invocations_contract["requestBody"]["content"]["application/json"]["schema"]["$ref"]
-            .endswith("/InvocationRequest")
+
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == (
+            "The Responses request requires an input field."
         )
-        assert responses_contract["responses"] == invocations_contract["responses"]
+
+    def test_responses_rejects_malformed_json(self, client):
+        response = client.post(
+            "/responses",
+            content="{",
+            headers={"content-type": "application/json"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "The Responses request body must be valid JSON."
+        )
+
+    def test_responses_accepts_live_standard_payload(self, client, mock_config):
+        original = mock_config.get.side_effect
+        mock_config.get.side_effect = (
+            lambda key, default=None, type=str:
+            "maf_lite" if key == "AGENT_STRATEGY" else original(key, default, type)
+        )
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            resp = client.post(
+                "/responses",
+                json={"input": "Hello", "stream": True, "store": True},
+            )
+
+        assert resp.status_code == 200
+        events = _parse_sse_body(resp.text)
+        event_types = [event["event"] for event in events]
+        sequence_numbers = [event["data"]["sequence_number"] for event in events]
+        response_ids = {
+            event["data"]["response"]["id"]
+            for event in events
+            if isinstance(event["data"].get("response"), dict)
+        }
+
+        assert event_types[:2] == ["response.created", "response.in_progress"]
+        assert "response.output_text.delta" in event_types
+        assert event_types[-1] == "response.completed"
+        assert sequence_numbers == list(range(len(events)))
+        assert len(response_ids) == 1
 
     def test_responses_accepts_live_payload_and_streams_full_lifecycle(
         self, client, mock_config
@@ -1259,7 +1406,6 @@ class TestHostedEntrypointAPI:
 
         strategy = MagicMock()
         strategy.initiate_agent_flow = fake_flow
-
         with patch(
             "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
             new=AsyncMock(return_value=strategy),
@@ -1360,11 +1506,63 @@ class TestHostedEntrypointAPI:
         )
 
         assert response.status_code == 422
-        detail = response.json()["detail"]
-        assert any(
-            error["type"] == "extra_forbidden"
-            and error["loc"][-2:] == ["ResponseConversation", "unexpected"]
-            for error in detail
+        assert response.json()["detail"] == (
+            "Responses conversation must be a non-empty id string "
+            "or an object containing only a non-empty string id."
+        )
+
+    @pytest.mark.parametrize(
+        "conversation",
+        [
+            "",
+            "   ",
+            123,
+            [],
+            {"id": None},
+            {"id": 123},
+            {"id": ""},
+        ],
+    )
+    def test_responses_rejects_invalid_conversation_ids(
+        self,
+        client,
+        conversation,
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "input": "Continue",
+                "stream": True,
+                "store": True,
+                "conversation": conversation,
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "Responses conversation must be a non-empty id string "
+            "or an object containing only a non-empty string id."
+        )
+
+    def test_responses_rejects_conversation_with_previous_response_id(
+        self,
+        client,
+    ):
+        response = client.post(
+            "/responses",
+            json={
+                "input": "Continue",
+                "stream": True,
+                "store": True,
+                "conversation": "conv-explicit",
+                "previous_response_id": "resp_previous",
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "Responses conversation and previous_response_id "
+            "cannot be used together."
         )
 
     def test_responses_maps_metadata_without_projecting_legacy_history(
@@ -1373,28 +1571,16 @@ class TestHostedEntrypointAPI:
         self._use_strategy(mock_config, "maf_lite")
         captured = {}
 
-        def fake_sse(
-            turn,
-            strategy_key,
-            response_id,
-            item_id,
-            history,
-            *,
-            model,
-            response_metadata,
-        ):
+        async def fake_stream(turn, strategy_key, history):
             captured.update(
                 turn=turn,
                 strategy_key=strategy_key,
-                response_id=response_id,
-                item_id=item_id,
                 history=history,
-                model=model,
-                response_metadata=response_metadata,
             )
-            return _async_gen(["event: response.completed\ndata: {}\n\n"])
+            yield TurnConversationEvent("conv-metadata")
+            yield TurnTextEvent("answer")
 
-        with patch("api.hosted_entrypoint._sse_generator", new=fake_sse):
+        with patch("api.hosted_entrypoint._hosted_stream", new=fake_stream):
             response = client.post(
                 "/responses",
                 json={
@@ -1411,9 +1597,9 @@ class TestHostedEntrypointAPI:
         assert response.status_code == 200
         assert captured["turn"].question_id == "question-1"
         assert captured["turn"].correlation_id == "correlation-1"
-        assert captured["history"] == ()
-        assert captured["model"] == _MODEL
-        assert captured["response_metadata"] == {
+        assert captured["history"] == []
+        completed = _parse_sse_body(response.text)[-1]["data"]["response"]
+        assert completed["metadata"] == {
             "question_id": "question-1",
             "correlation_id": "correlation-1",
         }
@@ -1430,14 +1616,13 @@ class TestHostedEntrypointAPI:
         )
 
         assert response.status_code == 422
-        detail = response.json()["detail"]
-        assert detail[0]["type"] == "string_type"
-        assert detail[0]["loc"] == ["body", "metadata", "nested"]
+        assert response.json()["detail"] == (
+            "Responses metadata must contain only string keys and values."
+        )
 
     @pytest.mark.parametrize(
         "unsupported_field",
         [
-            {"previous_response_id": "resp_previous"},
             {"instructions": "Ignore prior instructions"},
             {"tools": []},
             {"tool_choice": "auto"},
@@ -1460,20 +1645,24 @@ class TestHostedEntrypointAPI:
         )
 
         assert response.status_code == 422
-        detail = response.json()["detail"]
-        assert detail[0]["type"] == "extra_forbidden"
-        assert detail[0]["loc"] == ["body", next(iter(unsupported_field))]
+        field = next(iter(unsupported_field))
+        assert response.json()["detail"] == (
+            f"Unsupported Responses request fields: {field}."
+        )
 
     def test_responses_accepts_foundry_injected_agent_reference(
         self, client, mock_config
     ):
         self._use_strategy(mock_config, "maf_lite")
 
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
         with patch(
-            "api.hosted_entrypoint._sse_generator",
-            new=lambda *args, **kwargs: _async_gen(
-                ["event: response.completed\ndata: {}\n\n"]
-            ),
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
         ):
             response = client.post(
                 "/responses",
@@ -1510,7 +1699,7 @@ class TestHostedEntrypointAPI:
             },
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 400
 
     @pytest.mark.parametrize(
         "unsupported_input",
@@ -1543,7 +1732,7 @@ class TestHostedEntrypointAPI:
 
         assert response.status_code == 422
         assert (
-            "Only string input is supported; array and multimodal input are not supported."
+            "This hosted adapter supports string Responses input."
             in str(response.json())
         )
 
@@ -1554,25 +1743,368 @@ class TestHostedEntrypointAPI:
         )
 
         assert response.status_code == 422
-        assert "Input must not be empty or whitespace." in str(response.json())
+        assert response.json()["detail"] == "The Responses input must not be empty."
 
-    def test_responses_rejects_non_streaming_request(self, client):
+    @pytest.mark.parametrize(
+        ("setting", "expected"),
+        [
+            (None, False),
+            ("false", False),
+            ("0", False),
+            ("unexpected", False),
+            ("true", True),
+            (" 1 ", True),
+        ],
+    )
+    def test_host_observability_disables_content_capture_by_default(
+        self,
+        monkeypatch,
+        setting,
+        expected,
+    ):
+        from api.hosted_entrypoint import _configure_host_observability
+
+        if setting is None:
+            monkeypatch.delenv(
+                "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+                raising=False,
+            )
+        else:
+            monkeypatch.setenv(
+                "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+                setting,
+            )
+
+        configure = MagicMock()
+        with patch(
+            "api.hosted_entrypoint.configure_agentserver_observability",
+            new=configure,
+        ):
+            _configure_host_observability(
+                connection_string="InstrumentationKey=test",
+                log_level="INFO",
+                enable_sensitive_data=True,
+            )
+
+        configure.assert_called_once_with(
+            connection_string="InstrumentationKey=test",
+            log_level="INFO",
+            enable_sensitive_data=expected,
+        )
+
+    def test_responses_accepts_non_streaming_request(self, client, mock_config):
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            resp = client.post(
+                "/responses",
+                json={"input": "Hello", "stream": False, "store": True},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "completed"
+        assert resp.json()["output"][0]["content"][0]["text"] == "answer"
+
+    def test_responses_persists_retrieves_and_deletes_response(
+        self,
+        client,
+        mock_config,
+    ):
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            yield "stored answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            created = client.post(
+                "/responses",
+                json={"input": "Stored question", "store": True},
+            )
+
+        response_id = created.json()["id"]
+        retrieved = client.get(f"/responses/{response_id}")
+        input_items = client.get(f"/responses/{response_id}/input_items")
+        deleted = client.delete(f"/responses/{response_id}")
+        missing = client.get(f"/responses/{response_id}")
+
+        assert created.status_code == 200
+        assert retrieved.status_code == 200
+        assert retrieved.json()["id"] == response_id
+        assert retrieved.json()["status"] == "completed"
+        assert input_items.status_code == 200
+        assert input_items.json()["object"] == "list"
+        assert input_items.json()["data"][0]["role"] == "user"
+        assert deleted.status_code == 200
+        assert deleted.json() == {
+            "id": response_id,
+            "object": "response",
+            "deleted": True,
+        }
+        assert missing.status_code == 404
+
+    def test_responses_store_false_is_not_retrievable(
+        self,
+        client,
+        mock_config,
+    ):
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            yield "ephemeral answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            created = client.post(
+                "/responses",
+                json={"input": "Ephemeral question", "store": False},
+            )
+
+        assert created.status_code == 200
+        assert client.get(f"/responses/{created.json()['id']}").status_code == 404
+
+    def test_responses_honors_platform_response_id_header(
+        self,
+        client,
+        mock_config,
+    ):
+        from azure.ai.agentserver.responses._id_generator import IdGenerator
+
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+        response_id = IdGenerator.new_response_id()
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            response = client.post(
+                "/responses",
+                headers={"x-agent-response-id": response_id},
+                json={"input": "Question", "stream": True, "store": True},
+            )
+
+        events = _parse_sse_body(response.text)
+        assert response.status_code == 200
+        assert events[0]["data"]["response"]["id"] == response_id
+        assert events[-1]["data"]["response"]["id"] == response_id
+
+    def test_responses_projects_previous_response_history(
+        self,
+        client,
+        mock_config,
+    ):
+        self._use_strategy(mock_config, "maf_agent_service")
+        received = {}
+
+        async def first_flow(_ask):
+            yield "first answer"
+
+        async def second_flow(ask):
+            received["ask"] = ask
+            received["conversation"] = deepcopy(second_strategy.conversation)
+            yield "second answer"
+
+        first_strategy = MagicMock()
+        first_strategy.initiate_agent_flow = first_flow
+        second_strategy = MagicMock()
+        second_strategy.initiate_agent_flow = second_flow
+
+        conversation_resolver = AsyncMock(return_value="conv-managed-chain")
+        with (
+            patch(
+                "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+                new=AsyncMock(side_effect=[first_strategy, second_strategy]),
+            ),
+            patch(
+                "api.hosted_entrypoint.resolve_managed_conversation_id",
+                new=conversation_resolver,
+            ),
+        ):
+            first = client.post(
+                "/responses",
+                json={"input": "first question", "store": True},
+            )
+            second = client.post(
+                "/responses",
+                json={
+                    "input": "follow-up question",
+                    "previous_response_id": first.json()["id"],
+                    "store": True,
+                },
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert received["ask"] == "follow-up question"
+        assert received["conversation"]["thread_id"] == "conv-managed-chain"
+        assert received["conversation"]["messages"] == [
+            {"role": "user", "text": "first question"},
+            {"role": "assistant", "text": "first answer"},
+        ]
+        assert conversation_resolver.await_args_list[0].args == (
+            first_strategy.project_client,
+            None,
+        )
+        assert conversation_resolver.await_args_list[1].args == (
+            second_strategy.project_client,
+            "conv-managed-chain",
+        )
+
+    def test_responses_rejects_unsupported_list_input(self, client):
         response = client.post(
             "/responses",
-            json={"input": "Hello", "stream": False, "store": True},
+            json={
+                "input": [
+                    {"role": "user", "content": "first question"},
+                    {"role": "user", "content": "follow-up question"},
+                ],
+                "store": True,
+            },
         )
 
         assert response.status_code == 422
-        assert "Only stream=true is supported" in str(response.json())
-
-    def test_responses_rejects_non_storing_managed_request(self, client):
-        response = client.post(
-            "/responses",
-            json={"input": "Hello", "stream": True, "store": False},
+        assert response.json()["detail"] == (
+            "This hosted adapter supports string Responses input."
         )
 
-        assert response.status_code == 422
-        assert "Only store=true is supported" in str(response.json())
+    def test_responses_cancel_route_terminates_background_response(
+        self,
+        client,
+        mock_config,
+    ):
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            while True:
+                await asyncio.sleep(0.01)
+                yield "working"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            created = client.post(
+                "/responses",
+                json={
+                    "input": "Long-running question",
+                    "background": True,
+                    "store": True,
+                },
+            )
+            cancelled = client.post(f"/responses/{created.json()['id']}/cancel")
+
+        assert created.status_code == 200
+        assert created.json()["status"] in {"queued", "in_progress"}
+        assert cancelled.status_code == 200
+        assert cancelled.json()["status"] == "cancelled"
+
+    def test_responses_rejects_missing_foundry_call_id_for_toolbox_strategy(
+        self,
+        client,
+        mock_config,
+    ):
+        self._use_strategy(mock_config, "mcp")
+
+        factory = AsyncMock()
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=factory,
+        ):
+            resp = client.post(
+                "/responses",
+                json={"input": "Hello", "stream": True, "store": True},
+            )
+
+        assert resp.status_code == 401
+        assert "x-agent-foundry-call-id" in resp.json()["detail"]
+        factory.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("get", "/responses/{response_id}"),
+            ("delete", "/responses/{response_id}"),
+            ("post", "/responses/{response_id}/cancel"),
+            ("get", "/responses/{response_id}/input_items"),
+        ],
+    )
+    def test_responses_storage_routes_require_toolbox_call_id(
+        self,
+        client,
+        mock_config,
+        method,
+        path,
+    ):
+        from azure.ai.agentserver.responses._id_generator import IdGenerator
+
+        self._use_strategy(mock_config, "mcp")
+        response_id = IdGenerator.new_response_id()
+
+        response = getattr(client, method)(path.format(response_id=response_id))
+
+        assert response.status_code == 401
+        assert "x-agent-foundry-call-id" in response.json()["detail"]
+
+    def test_responses_propagates_platform_call_id_for_toolbox_strategy(
+        self,
+        client,
+        mock_config,
+    ):
+        self._use_strategy(mock_config, "mcp")
+
+        async def fake_flow(_ask):
+            yield "answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with (
+            patch(
+                "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+                new=AsyncMock(return_value=strategy),
+            ),
+            patch(
+                "api.hosted_entrypoint.resolve_managed_conversation_id",
+                new=AsyncMock(return_value="conv-toolbox"),
+            ),
+        ):
+            response = client.post(
+                "/responses",
+                headers={"x-agent-foundry-call-id": "call-toolbox-123"},
+                json={"input": "Question", "stream": True, "store": True},
+            )
+
+        assert response.status_code == 200
+        assert "response.completed" in response.text
+        assert strategy.foundry_call_id == "call-toolbox-123"
 
     def test_invocations_rejects_unsupported_strategy(self, client, mock_config):
         original = mock_config.get.side_effect
@@ -1596,6 +2128,18 @@ class TestHostedEntrypointAPI:
         )
 
         assert resp.status_code == 422
+
+    def test_invocations_rejects_malformed_json(self, client):
+        resp = client.post(
+            "/invocations",
+            content="{",
+            headers={"content-type": "application/json"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == (
+            "The Invocations request body must be valid JSON."
+        )
 
     def test_invocations_rejects_empty_user_message(self, client):
         resp = client.post(
@@ -1785,6 +2329,7 @@ class TestHostedEntrypointAPI:
         "bad_call_id",
         [
             "has spaces",
+            " call-id ",
             "line\nbreak",
             "carriage\rreturn",
             "x" * 257,


### PR DESCRIPTION
## Summary
- host canonical Microsoft Foundry Responses v2 at `POST /responses` with `azure-ai-agentserver-responses`
- preserve the separate legacy `POST /invocations` schema and immutable `/health` and `/readiness` responses
- enforce managed-conversation, Toolbox call-context, cancellation/shutdown, storage, and sensitive-telemetry boundaries
- document the protocol contract and add comprehensive lifecycle and compatibility coverage

## Validation
- `python -m pytest tests\test_hosted_responses.py tests\test_foundry_platform.py -q` (143 passed)
- `python -m pytest -q` (709 passed)
- independent code review: no significant issues found after fixes

No tag, release, package, image, or deployment is published by this PR.