### PR TITLE
fix: persist hosted managed conversations

### DIFF
--- a/src/strategies/agent_provider_v2.py
+++ b/src/strategies/agent_provider_v2.py
@@ -263,7 +263,7 @@ async def stream_agent_run(
 ) -> AsyncIterator[Any]:
     """Stream ``agent.run_stream`` and, if the service rejects the run-time
     ``options`` as an invalid payload *before any output is produced*, retry once
-    with no run-time options.
+    without the optional token limit while preserving required persistence.
 
     This guards against deployments/models where even ``max_tokens``
     (``max_output_tokens``) is not permitted alongside an agent reference. The
@@ -285,10 +285,19 @@ async def stream_agent_run(
             raise
         logging.warning(
             "[AgentProviderV2] Run rejected run-time options %s as invalid payload; "
-            "retrying without run-time options: %s",
+            "retrying without the optional token limit: %s",
             sorted(options.keys()), exc,
         )
-        async for chunk in agent.run_stream(user_message, thread=thread, options={}):
+        retry_options = (
+            {"store": options["store"]}
+            if "store" in options
+            else {}
+        )
+        async for chunk in agent.run_stream(
+            user_message,
+            thread=thread,
+            options=retry_options,
+        ):
             yield chunk
 
 

--- a/src/strategies/single_agent_rag_strategy_v2.py
+++ b/src/strategies/single_agent_rag_strategy_v2.py
@@ -524,7 +524,10 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
                     agent,
                     user_message,
                     thread=thread,
-                    options={"max_tokens": self.max_completion_tokens},
+                    options={
+                        "max_tokens": self.max_completion_tokens,
+                        "store": True,
+                    },
                 ):
                     for event in event_translator.translate(chunk):
                         yield event

--- a/tests/test_single_agent_rag_v2_thread_conversation.py
+++ b/tests/test_single_agent_rag_v2_thread_conversation.py
@@ -88,6 +88,37 @@ class TestEnsureConversationId:
             conv = {"thread_id": "conv_existing"}
             assert await agent_provider_v2.ensure_conversation_id(conv) == "conv_existing"
 
+
+class TestStreamAgentRunFallback:
+    @pytest.mark.asyncio
+    async def test_preserves_store_when_optional_token_limit_is_rejected(self):
+        class FakeAgent:
+            def __init__(self):
+                self.options = []
+
+            async def run_stream(self, _message, *, thread, options):
+                self.options.append(options)
+                if len(self.options) == 1:
+                    raise RuntimeError("invalid_payload")
+                yield types.SimpleNamespace(text="persisted")
+
+        agent = FakeAgent()
+        output = [
+            chunk.text
+            async for chunk in agent_provider_v2.stream_agent_run(
+                agent,
+                "hello",
+                thread=MagicMock(),
+                options={"max_tokens": 100, "store": True},
+            )
+        ]
+
+        assert output == ["persisted"]
+        assert agent.options == [
+            {"max_tokens": 100, "store": True},
+            {"store": True},
+        ]
+
     @pytest.mark.asyncio
     async def test_raises_when_provider_not_initialized(self):
         agent_provider_v2._project_client = None
@@ -133,6 +164,7 @@ class TestStreamAgentThreadResume:
         # A fake agent: async context manager whose get_new_thread records the
         # service_thread_id it was resumed from.
         resume_ids = []
+        run_options = []
 
         def _get_new_thread(*, service_thread_id=None):
             resume_ids.append(service_thread_id)
@@ -147,6 +179,7 @@ class TestStreamAgentThreadResume:
         provider.as_agent = MagicMock(return_value=agent)
 
         async def _fake_stream(*args, **kwargs):
+            run_options.append(kwargs["options"])
             yield types.SimpleNamespace(text="hello")
 
         # One shared conversation object id handed out on first creation.
@@ -176,3 +209,9 @@ class TestStreamAgentThreadResume:
         assert resume_ids == ["conv_stable", "conv_stable"]
         # The stored thread id is the conversation object, never a per-turn resp id.
         assert conv["thread_id"] == "conv_stable"
+        # Foundry only persists Responses input/output on the managed Conversation
+        # when storage is explicitly enabled.
+        assert run_options == [
+            {"max_tokens": s.max_completion_tokens, "store": True},
+            {"max_tokens": s.max_completion_tokens, "store": True},
+        ]


### PR DESCRIPTION
## Summary
- set Responses store=true for reusable hosted-agent runs so managed Conversations retain turn input/output
- preserve store=true when retrying without an unsupported optional token limit
- add first-attempt and retry-path regression coverage

## Validation
- 679 tests passed
- independently reviewed; retry persistence finding fixed