### PR TITLE
fix: persist hosted managed conversation items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **Managed Conversation persistence for hosted Responses.** Completed
+  user/assistant turns are now appended through the Foundry Conversations Items
+  API because the pinned Agent Framework client does not support the Responses
+  `store` option. Both agent and empty-index direct-LLM routes persist history,
+  reject legacy thread IDs, initialize correctly on fresh workers, and
+  reconcile ambiguous write failures without duplicating a committed turn.
+
 - **Offline tokenizer initialization for network-isolated hosted agents.**
   Runtime images now pre-cache the `o200k_base` tokenizer during the image
   build, preventing the first hosted request from attempting public Blob

--- a/src/strategies/agent_provider_v2.py
+++ b/src/strategies/agent_provider_v2.py
@@ -19,6 +19,7 @@ resolved agent definitions) lives at module scope here.
 import asyncio
 import hashlib
 import logging
+import uuid
 from typing import Any, AsyncIterator, Optional, Sequence
 
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
@@ -263,7 +264,7 @@ async def stream_agent_run(
 ) -> AsyncIterator[Any]:
     """Stream ``agent.run_stream`` and, if the service rejects the run-time
     ``options`` as an invalid payload *before any output is produced*, retry once
-    without the optional token limit while preserving required persistence.
+    without the optional token limit.
 
     This guards against deployments/models where even ``max_tokens``
     (``max_output_tokens``) is not permitted alongside an agent reference. The
@@ -288,11 +289,8 @@ async def stream_agent_run(
             "retrying without the optional token limit: %s",
             sorted(options.keys()), exc,
         )
-        retry_options = (
-            {"store": options["store"]}
-            if "store" in options
-            else {}
-        )
+        retry_options = dict(options)
+        retry_options.pop("max_tokens", None)
         async for chunk in agent.run_stream(
             user_message,
             thread=thread,
@@ -352,6 +350,116 @@ async def ensure_conversation_id(conv: dict) -> str:
         conversation.id,
     )
     return conversation.id
+
+
+async def persist_conversation_turn(
+    conversation_id: str,
+    user_message: str,
+    assistant_message: str,
+) -> None:
+    """Append a completed user/assistant turn to a managed Conversation.
+
+    The pinned Azure Agent Framework chat client explicitly drops the Responses
+    ``store`` option as unsupported. Persist the completed turn through the
+    Conversations API instead so hosted compute replacements can resume the
+    full managed history.
+    """
+    client = await _get_openai_client()
+    items = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": user_message,
+                }
+            ],
+        },
+        {
+            "type": "message",
+            "id": f"msg_{uuid.uuid4().hex}",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": assistant_message,
+                    "annotations": [],
+                }
+            ],
+        },
+    ]
+    try:
+        await client.conversations.items.create(
+            conversation_id,
+            items=items,
+        )
+    except Exception:
+        if await _conversation_tail_matches(
+            client,
+            conversation_id,
+            user_message,
+            assistant_message,
+        ):
+            logging.warning(
+                "[AgentProviderV2] Conversation turn create returned an error "
+                "after the turn was committed; treating it as persisted (%s)",
+                conversation_id,
+            )
+            return
+        raise
+    logging.info(
+        "[AgentProviderV2] Persisted completed turn to conversation %s",
+        conversation_id,
+    )
+
+
+def _conversation_item_text(item: Any) -> tuple[str | None, str]:
+    """Return the role and concatenated text from a Conversation message."""
+    role = getattr(item, "role", None)
+    content = getattr(item, "content", None) or []
+    text = "".join(
+        part_text
+        for part in content
+        if isinstance((part_text := getattr(part, "text", None)), str)
+    )
+    return role, text
+
+
+async def _conversation_tail_matches(
+    client: Any,
+    conversation_id: str,
+    user_message: str,
+    assistant_message: str,
+) -> bool:
+    """Reconcile an ambiguous create failure against the persisted tail."""
+    try:
+        page = await client.conversations.items.list(
+            conversation_id,
+            limit=2,
+            order="desc",
+        )
+    except Exception:
+        logging.error(
+            "[AgentProviderV2] Failed to reconcile ambiguous Conversation "
+            "persistence for %s",
+            conversation_id,
+            exc_info=True,
+        )
+        return False
+
+    data = list(getattr(page, "data", None) or [])
+    if len(data) < 2:
+        return False
+    newest_role, newest_text = _conversation_item_text(data[0])
+    previous_role, previous_text = _conversation_item_text(data[1])
+    return (
+        newest_role == "assistant"
+        and newest_text == assistant_message
+        and previous_role == "user"
+        and previous_text == user_message
+    )
 
 
 def reset_legacy_thread(conv: dict) -> None:

--- a/src/strategies/single_agent_rag_strategy_v2.py
+++ b/src/strategies/single_agent_rag_strategy_v2.py
@@ -393,6 +393,8 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
              logging.error(f"[Agent Flow V2] Direct LLM Streaming failed: {e}", exc_info=True)
              raise
 
+        await self._persist_managed_turn(user_message, full_response)
+
         # Add assistant response to history
         self.conversation.setdefault("messages", []).extend([
             {"role": "user", "text": user_message},
@@ -526,7 +528,6 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
                     thread=thread,
                     options={
                         "max_tokens": self.max_completion_tokens,
-                        "store": True,
                     },
                 ):
                     for event in event_translator.translate(chunk):
@@ -538,13 +539,45 @@ class SingleAgentRAGStrategyV2(BaseAgentStrategy):
                         full_response += chunk.text
                         yield chunk.text
 
-        except Exception as e:
+        except Exception:
             err_msg = traceback.format_exc()
             logging.error(f"[Agent Flow V2] Streaming failed: {err_msg}")
-            yield f"[ERROR in Streaming]: {e}"
+            raise
+
+        try:
+            await self._persist_managed_turn(user_message, full_response)
+        except Exception:
+            logging.error(
+                "[Agent Flow V2] Managed Conversation persistence failed",
+                exc_info=True,
+            )
+            raise
 
         # Persist conversation history
         conv.setdefault("messages", []).extend([
             {"role": "user", "text": user_message},
             {"role": "assistant", "text": full_response}
         ])
+
+    async def _persist_managed_turn(
+        self,
+        user_message: str,
+        assistant_message: str,
+    ) -> None:
+        """Persist a completed turn when this runtime has a managed thread."""
+        conversation_id = self.conversation.get("thread_id")
+        if (
+            not conversation_id
+            or self.conversation.get("agent_backend")
+            != agent_provider_v2.AGENT_BACKEND_TAG
+        ):
+            return
+        await agent_provider_v2.get_provider(
+            self.project_endpoint,
+            self.credential,
+        )
+        await agent_provider_v2.persist_conversation_turn(
+            conversation_id,
+            user_message,
+            assistant_message,
+        )

--- a/tests/test_single_agent_rag_v2_direct_llm_history.py
+++ b/tests/test_single_agent_rag_v2_direct_llm_history.py
@@ -15,6 +15,7 @@ history in chronological order. An empty index must never surface an error.
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
+from strategies import agent_provider_v2
 from strategies.agent_strategies import AgentStrategies  # noqa: F401
 
 
@@ -115,6 +116,58 @@ class TestSingleAgentRagV2DirectLLMHistory:
             "content": "como funciona a injecao eletronica?",
         }
         assert out == "Olá mundo"
+
+    @pytest.mark.asyncio
+    async def test_hosted_direct_turn_is_persisted_to_managed_conversation(self):
+        s = self._make_strategy()
+        s.conversation = {
+            "thread_id": "conv_hosted",
+            "agent_backend": agent_provider_v2.AGENT_BACKEND_TAG,
+            "messages": [],
+        }
+        s.project_endpoint = "https://example.services.ai.azure.com/api/projects/p"
+        s.credential = MagicMock()
+
+        with patch(
+            "strategies.single_agent_rag_strategy_v2.agent_provider_v2."
+            "persist_conversation_turn",
+            new=AsyncMock(),
+        ) as persist, patch(
+            "strategies.single_agent_rag_strategy_v2.agent_provider_v2."
+            "get_provider",
+            new=AsyncMock(),
+        ):
+            _, out = await self._run(s, "remember JADE-7394")
+
+        assert out == "Olá mundo"
+        persist.assert_awaited_once_with(
+            "conv_hosted",
+            "remember JADE-7394",
+            "Olá mundo",
+        )
+
+    @pytest.mark.asyncio
+    async def test_direct_turn_does_not_persist_to_legacy_thread_id(self):
+        s = self._make_strategy()
+        s.conversation = {
+            "thread_id": "thread_legacy",
+            "messages": [],
+        }
+
+        with patch(
+            "strategies.single_agent_rag_strategy_v2.agent_provider_v2."
+            "persist_conversation_turn",
+            new=AsyncMock(),
+        ) as persist, patch(
+            "strategies.single_agent_rag_strategy_v2.agent_provider_v2."
+            "get_provider",
+            new=AsyncMock(),
+        ) as get_provider:
+            _, out = await self._run(s, "hello")
+
+        assert out == "Olá mundo"
+        persist.assert_not_awaited()
+        get_provider.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_empty_and_unknown_history_entries_skipped(self):

--- a/tests/test_single_agent_rag_v2_thread_conversation.py
+++ b/tests/test_single_agent_rag_v2_thread_conversation.py
@@ -91,7 +91,7 @@ class TestEnsureConversationId:
 
 class TestStreamAgentRunFallback:
     @pytest.mark.asyncio
-    async def test_preserves_store_when_optional_token_limit_is_rejected(self):
+    async def test_removes_optional_token_limit_when_rejected(self):
         class FakeAgent:
             def __init__(self):
                 self.options = []
@@ -109,14 +109,14 @@ class TestStreamAgentRunFallback:
                 agent,
                 "hello",
                 thread=MagicMock(),
-                options={"max_tokens": 100, "store": True},
+                options={"max_tokens": 100},
             )
         ]
 
         assert output == ["persisted"]
         assert agent.options == [
-            {"max_tokens": 100, "store": True},
-            {"store": True},
+            {"max_tokens": 100},
+            {},
         ]
 
     @pytest.mark.asyncio
@@ -165,6 +165,7 @@ class TestStreamAgentThreadResume:
         # service_thread_id it was resumed from.
         resume_ids = []
         run_options = []
+        persisted_turns = []
 
         def _get_new_thread(*, service_thread_id=None):
             resume_ids.append(service_thread_id)
@@ -182,6 +183,11 @@ class TestStreamAgentThreadResume:
             run_options.append(kwargs["options"])
             yield types.SimpleNamespace(text="hello")
 
+        async def _persist_turn(conversation_id, user_message, assistant_message):
+            persisted_turns.append(
+                (conversation_id, user_message, assistant_message)
+            )
+
         # One shared conversation object id handed out on first creation.
         created = types.SimpleNamespace(id="conv_stable")
         oai = MagicMock()
@@ -195,6 +201,8 @@ class TestStreamAgentThreadResume:
             agent_provider_v2, "stream_agent_run", _fake_stream
         ), patch.object(
             agent_provider_v2, "_get_openai_client", AsyncMock(return_value=oai)
+        ), patch.object(
+            agent_provider_v2, "persist_conversation_turn", _persist_turn
         ):
             # Turn 1
             out1 = "".join([c async for c in s._stream_agent("first question")])
@@ -209,9 +217,169 @@ class TestStreamAgentThreadResume:
         assert resume_ids == ["conv_stable", "conv_stable"]
         # The stored thread id is the conversation object, never a per-turn resp id.
         assert conv["thread_id"] == "conv_stable"
-        # Foundry only persists Responses input/output on the managed Conversation
-        # when storage is explicitly enabled.
         assert run_options == [
-            {"max_tokens": s.max_completion_tokens, "store": True},
-            {"max_tokens": s.max_completion_tokens, "store": True},
+            {"max_tokens": s.max_completion_tokens},
+            {"max_tokens": s.max_completion_tokens},
         ]
+        assert persisted_turns == [
+            ("conv_stable", "first question", "hello"),
+            ("conv_stable", "second question", "hello"),
+        ]
+
+
+class TestPersistConversationTurn:
+    @pytest.mark.asyncio
+    async def test_appends_complete_user_and_assistant_messages(self):
+        oai = MagicMock()
+        oai.conversations.items.create = AsyncMock()
+
+        with patch.object(
+            agent_provider_v2, "_get_openai_client", AsyncMock(return_value=oai)
+        ), patch.object(agent_provider_v2.uuid, "uuid4") as uuid4:
+            uuid4.return_value.hex = "abc123"
+            await agent_provider_v2.persist_conversation_turn(
+                "conv_stable",
+                "remember JADE-7394",
+                "JADE-7394",
+            )
+
+        oai.conversations.items.create.assert_awaited_once_with(
+            "conv_stable",
+            items=[
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "remember JADE-7394",
+                        }
+                    ],
+                },
+                {
+                    "type": "message",
+                    "id": "msg_abc123",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "JADE-7394",
+                            "annotations": [],
+                        }
+                    ],
+                },
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconciles_ambiguous_create_failure_without_duplicate(self):
+        oai = MagicMock()
+        oai.conversations.items.create = AsyncMock(
+            side_effect=RuntimeError("response lost")
+        )
+        oai.conversations.items.list = AsyncMock(
+            return_value=types.SimpleNamespace(
+                data=[
+                    types.SimpleNamespace(
+                        role="assistant",
+                        content=[types.SimpleNamespace(text="JADE-7394")],
+                    ),
+                    types.SimpleNamespace(
+                        role="user",
+                        content=[
+                            types.SimpleNamespace(text="remember JADE-7394")
+                        ],
+                    ),
+                ]
+            )
+        )
+
+        with patch.object(
+            agent_provider_v2, "_get_openai_client", AsyncMock(return_value=oai)
+        ):
+            await agent_provider_v2.persist_conversation_turn(
+                "conv_stable",
+                "remember JADE-7394",
+                "JADE-7394",
+            )
+
+        oai.conversations.items.list.assert_awaited_once_with(
+            "conv_stable",
+            limit=2,
+            order="desc",
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_ambiguous_failure_when_tail_does_not_match(self):
+        oai = MagicMock()
+        oai.conversations.items.create = AsyncMock(
+            side_effect=RuntimeError("response lost")
+        )
+        oai.conversations.items.list = AsyncMock(
+            return_value=types.SimpleNamespace(data=[])
+        )
+
+        with patch.object(
+            agent_provider_v2, "_get_openai_client", AsyncMock(return_value=oai)
+        ), pytest.raises(RuntimeError, match="response lost"):
+            await agent_provider_v2.persist_conversation_turn(
+                "conv_stable",
+                "remember JADE-7394",
+                "JADE-7394",
+            )
+
+    @pytest.mark.asyncio
+    async def test_persistence_failure_is_not_emitted_as_answer_text(
+        self, patch_dependencies, mock_config
+    ):
+        from strategies.single_agent_rag_strategy_v2 import SingleAgentRAGStrategyV2
+
+        with patch(
+            "strategies.single_agent_rag_strategy_v2.get_config",
+            return_value=mock_config,
+        ), patch(
+            "strategies.single_agent_rag_strategy_v2.get_search_client",
+            return_value=MagicMock(),
+        ), patch(
+            "strategies.single_agent_rag_strategy_v2.get_genai_client",
+            return_value=MagicMock(),
+        ):
+            strategy = SingleAgentRAGStrategyV2()
+
+        strategy.search_client = MagicMock()
+        strategy.project_endpoint = "https://example.services.ai.azure.com/api/projects/p"
+        strategy.credential = MagicMock()
+        strategy.model_name = "chat"
+        strategy.conversation = {
+            "thread_id": "conv_stable",
+            "agent_backend": agent_provider_v2.AGENT_BACKEND_TAG,
+        }
+
+        agent = MagicMock()
+        agent.__aenter__ = AsyncMock(return_value=agent)
+        agent.__aexit__ = AsyncMock(return_value=False)
+        agent.get_new_thread.return_value = MagicMock()
+        provider = MagicMock()
+        provider.as_agent.return_value = agent
+
+        async def _fake_stream(*args, **kwargs):
+            yield types.SimpleNamespace(text="completed answer")
+
+        with patch.object(
+            agent_provider_v2, "get_provider", AsyncMock(return_value=provider)
+        ), patch.object(
+            agent_provider_v2,
+            "get_or_create_agent_details",
+            AsyncMock(return_value=MagicMock()),
+        ), patch.object(
+            agent_provider_v2, "stream_agent_run", _fake_stream
+        ), patch.object(
+            agent_provider_v2,
+            "persist_conversation_turn",
+            AsyncMock(side_effect=RuntimeError("storage unavailable")),
+        ):
+            stream = strategy._stream_agent("question")
+            assert await anext(stream) == "completed answer"
+            with pytest.raises(RuntimeError, match="storage unavailable"):
+                await anext(stream)


### PR DESCRIPTION
## Summary
- Replace the ineffective Agent Framework `store` run option with explicit Foundry Conversations Items persistence.
- Persist both agent and empty-index direct-LLM turns while rejecting legacy thread IDs.
- Reconcile ambiguous write failures and propagate unrecoverable persistence errors.

## Live evidence
- Agent Framework 1.0.0b260116 filters `store` as unsupported.
- A real hosted Responses turn completed but left the managed Conversation empty.
- Direct user and assistant item writes to the same private Foundry project succeeded.

## Validation
- `python -m pytest -q`: 717 passed.
- Independent review findings addressed: post-stream error corruption, direct-route omission, fresh-worker initialization, legacy IDs, and ambiguous-write reconciliation.

Related to Azure/GPT-RAG#592 and Azure/GPT-RAG#597.