### PR TITLE
fix: break dependencies<->connectors circular import in hosted entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hosted-agent entrypoint no longer crashes on import (circular import
+  between `dependencies` and `connectors`).** `dependencies.py` eagerly
+  imported `connectors.appconfig` at module level. `connectors/__init__.py`
+  eagerly imports several connector submodules (`cosmosdb`, `search`,
+  `aifoundry`, ...) that each import `dependencies` back, at their own module
+  level, to call `get_config()`. Any entrypoint whose first touch of this
+  package tree is `dependencies` — notably `src/api/hosted_entrypoint.py`,
+  which is intentionally Cosmos-free and never imports `connectors` first —
+  hit `ImportError: cannot import name 'get_config' from partially
+  initialized module 'dependencies' (most likely due to a circular import)`
+  and crashed before uvicorn could bind a port or serve `GET /readiness`.
+  Deployed as a Microsoft Foundry hosted agent, this was observed as the
+  platform returning HTTP 424 `session_not_ready` on invoke ("container
+  started but `/readiness` didn't return HTTP 200 within the timeout"),
+  because the container's Python process never reached that far.
+  `AppConfigClient` construction is now deferred into `get_config()` instead
+  of imported eagerly at module level, breaking the cycle with no change to
+  `get_config()`'s public behavior or the `connectors` package's re-export
+  surface. Added `tests/test_hosted_entrypoint_import.py`, which spawns a
+  fresh interpreter (mirroring the container's `uvicorn ...:app` startup) to
+  regression-test that `api.hosted_entrypoint` imports cleanly and that
+  `dependencies` does not eagerly pull in `connectors` at module level.
+
 ## [v4.0.0] - 2026-08-07
 
 Supersedes v3.12.0 as the SemVer-correct canonical release for the same

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -1,18 +1,35 @@
 """
 Provides dependencies for API calls.
 """
+from __future__ import annotations
+
 import logging
 import os
 import json
 import httpx
 import hmac
 import hashlib
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, TYPE_CHECKING
 from datetime import datetime, timedelta
 from fastapi import HTTPException, Header
-from connectors.appconfig import AppConfigClient
 import jwt
 
+if TYPE_CHECKING:
+    from connectors.appconfig import AppConfigClient
+
+# NOTE: `connectors/__init__.py` imports several submodules (cosmosdb,
+# search, aifoundry, ...) that themselves import this module (`dependencies`)
+# at their own module level to call `get_config()`. Importing
+# `connectors.appconfig` eagerly here therefore creates a circular import:
+# whichever module is imported first (this one, or one of those connector
+# submodules) ends up needing the other before it has finished initializing.
+# This is fatal -- not merely slow -- for any entrypoint that imports
+# `dependencies` before anything else has already loaded `connectors` (for
+# example the hosted-agent entrypoint, `src/api/hosted_entrypoint.py`, which
+# is intentionally Cosmos-free and so never "warms up" `connectors` first).
+# `AppConfigClient` construction is deferred into `get_config()` below to
+# break the cycle; `from __future__ import annotations` keeps the type hints
+# in this module lazy so they don't need the real class at import time.
 __config: AppConfigClient = None
 __cached_public_keys = {}  # {cache_key: {"keys": {...}, "expires_at": datetime}}
 
@@ -142,6 +159,7 @@ def _parse_cache_control_ttl(cache_control_header: str) -> int:
 
 def get_config(action: str = None) -> AppConfigClient:
     global __config
+    from connectors.appconfig import AppConfigClient  # deferred: see note above __config
 
     if action == "refresh":
         __config = AppConfigClient()

--- a/tests/test_hosted_entrypoint_import.py
+++ b/tests/test_hosted_entrypoint_import.py
@@ -1,0 +1,100 @@
+"""Regression test: the hosted-agent entrypoint must import cleanly on a
+fresh interpreter.
+
+``src/api/hosted_entrypoint.py`` is intentionally Cosmos-free and, unlike
+``main.py``, never imports anything from ``connectors`` before it imports
+``dependencies``. That ordering previously triggered a circular import
+(``dependencies`` -> ``connectors`` (package init) -> ``connectors.cosmosdb``
+-> ``dependencies`` again, before ``dependencies.get_config`` existed on the
+partially-initialized module) that crashed the process on the very first
+import -- before uvicorn could ever bind a port or serve ``GET /readiness``.
+Deployed as a Foundry hosted agent, this manifested as the platform reporting
+HTTP 424 ``session_not_ready`` on invoke ("container started but /readiness
+didn't return HTTP 200 within the timeout"), because the container's Python
+process never got that far.
+
+A regular in-process pytest test cannot reproduce this: by the time this test
+module runs, other test modules have already imported ``dependencies`` and
+``connectors`` into ``sys.modules`` in some order that happens to avoid the
+cycle, which would mask a regression. This test therefore spawns a fresh
+interpreter, exactly like the container's ``uvicorn ...:app`` entrypoint
+does, and imports only what the hosted entrypoint needs -- nothing else gets
+a chance to "warm up" ``connectors``/``dependencies`` first.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+
+def _run_fresh_import(import_statement: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC_ROOT)
+    # Keep the probe hermetic: no App Configuration endpoint to reach, no
+    # Azure Monitor connection string, auth disabled so nothing else needs a
+    # live dependency just to construct the ASGI app object.
+    env.pop("APP_CONFIG_ENDPOINT", None)
+    env.pop("APPLICATIONINSIGHTS_CONNECTION_STRING", None)
+    env["DISABLE_AUTH"] = "true"
+    return subprocess.run(
+        [sys.executable, "-c", import_statement],
+        cwd=SRC_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def test_hosted_entrypoint_imports_cleanly_on_a_fresh_interpreter() -> None:
+    """``import api.hosted_entrypoint`` must not raise ImportError.
+
+    This mirrors exactly how the hosted container's startup command
+    (``uvicorn api.hosted_entrypoint:app`` -- see ``HOSTED_STARTUP_COMMAND``
+    in the GPT-RAG umbrella's ``config/deployment/hosted_image.py``) loads
+    this module: a fresh process whose first touch of this package tree is
+    the hosted entrypoint itself.
+    """
+    completed = _run_fresh_import("import api.hosted_entrypoint")
+
+    assert completed.returncode == 0, (
+        "api.hosted_entrypoint failed to import on a fresh interpreter "
+        f"(this is what the hosted agent container runs at startup):\n"
+        f"{completed.stderr}"
+    )
+    assert "ImportError" not in completed.stderr
+    assert "circular import" not in completed.stderr
+
+
+def test_dependencies_module_alone_imports_without_touching_connectors() -> None:
+    """``dependencies`` must not eagerly import ``connectors`` at module
+    level -- that eager reference is exactly what created the cycle with
+    connector submodules (``cosmosdb``, ``search``, ``aifoundry``, ...) that
+    import ``dependencies`` back. ``AppConfigClient`` construction must stay
+    deferred inside ``get_config()``.
+    """
+    completed = _run_fresh_import(
+        "import json, sys\n"
+        "before = set(sys.modules)\n"
+        "import dependencies\n"
+        "after = sorted(m for m in set(sys.modules) - before if m == 'connectors' or m.startswith('connectors.'))\n"
+        "print(json.dumps(after))\n"
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    import json as _json
+
+    loaded_connectors_modules = _json.loads(completed.stdout)
+    assert loaded_connectors_modules == [], (
+        "Importing `dependencies` alone must not pull in `connectors` at "
+        f"module level (it did: {loaded_connectors_modules}); that eager "
+        "coupling is what caused the dependencies<->connectors.cosmosdb "
+        "circular import."
+    )


### PR DESCRIPTION
## Purpose

Fix the root cause of the GPT-RAG hosted-agent readiness blocker documented
in [Azure/GPT-RAG#576](https://github.com/Azure/GPT-RAG/issues/576) and the
umbrella's `docs/hosted_agent_release_matrix.md`: network-isolated live
validation reached the hosted agent version "active" state, but session
readiness returned HTTP 424.

## Root cause

`src/api/hosted_entrypoint.py` imports `dependencies` before it imports
anything else in this package tree (it is intentionally Cosmos-free, so it
never "warms up" `connectors` first, unlike `main.py`). `dependencies.py`
eagerly imported `connectors.appconfig` at module level. `connectors/__init__.py`
eagerly imports several submodules (`cosmosdb`, `search`, `aifoundry`, ...)
that each import `dependencies` back, at *their* module level, to call
`get_config()`. The result is a real circular import:

```
dependencies (line 13: from connectors.appconfig import AppConfigClient)
  -> connectors/__init__.py (line 1: from .cosmosdb import ...)
    -> connectors/cosmosdb.py (line 7: from dependencies import get_config)
      -> ImportError: cannot import name 'get_config' from partially
         initialized module 'dependencies' (most likely due to a circular
         import)
```

This crashes the Python process **before uvicorn ever binds a port or serves
`GET /readiness`**. Deployed as a Microsoft Foundry hosted agent, the
platform's own `/readiness` health probe never gets HTTP 200, and it reports
this precise, documented failure mode
([Foundry troubleshooting reference](https://learn.microsoft.com/azure/foundry/agents/how-to/deploy-hosted-agent-code#troubleshooting)):

> `424 session_not_ready` on invoke | Container started but `/readiness`
> didn't return HTTP 200 within the timeout

The classic (Container Apps) entrypoint `main.py` does not hit this because
it happens to import `connectors.appconfig`/`connectors.cosmosdb` directly,
in an order that "warms up" `connectors` before its own `from dependencies
import ...` statement runs. That's an accident of import ordering, not a
guarantee — `hosted_entrypoint.py` simply has no such accidental warm-up.

## Fix

Defer `AppConfigClient` construction into `get_config()` instead of
importing it eagerly at module level in `dependencies.py`. `get_config()` is
already a lazy singleton (only ever called at request-handling time, never
at import time), so this has no behavior change — it only moves *when* the
import statement runs, not what it does. `from __future__ import annotations`
keeps the existing `AppConfigClient` type hints in the module lazy so they
don't need the real class at import time; a `TYPE_CHECKING`-guarded import
keeps them resolvable for static analysis.

This is deliberately the minimal, root-cause fix: only `dependencies.py`
changes. No connector module's imports, `connectors/__init__.py`'s
re-export surface, or `get_config()`'s public signature changed.

## Validation

- **Reproduced the exact failure** with a fresh interpreter mirroring the
  container's `uvicorn ...:app` startup (`PYTHONPATH=<repo>/src`, importing
  `api.hosted_entrypoint` as the first thing in the process) — fails with
  the documented `ImportError` on unpatched `develop`, imports successfully
  (in ~4s) after this change.
- Added `tests/test_hosted_entrypoint_import.py`: two regression tests that
  spawn a fresh interpreter and assert (1) `api.hosted_entrypoint` imports
  cleanly and (2) importing `dependencies` alone never pulls in `connectors`
  at module level. Confirmed both **fail** on unpatched `develop` (reproducing
  the bug) and **pass** with this fix.
- Full suite: `pytest -q` → **720 passed** (718 existing + 2 new), zero
  regressions.

## Compatibility

No public API change. `get_config()` behavior, return type, and call sites
are unchanged. Classic (Container Apps) and `/invocations` behavior are
unaffected.

## Follow-up after merge

Prepare a `release/4.0.1` PATCH release (bug fix, no behavior change) per
`.github/instructions/release.instructions.md`, then update the GPT-RAG
umbrella's `manifest.json` pin.