### PR TITLE
fix: force store=false unconditionally on hosted /responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## [Unreleased]
 
+### Security
+
+- **Hosted `/responses` now unconditionally forces `store: False`, closing an
+  implicit Foundry managed-persistence path that violated the ADR-0004
+  zero-RBAC, stateless hosted container contract.** The pinned
+  `azure-ai-agentserver-responses==2.0.0b1` host
+  (`ResponsesAgentServerHost.__init__`) auto-activates its own network-bound
+  `FoundryStorageProvider` (built from `DefaultAzureCredential`) whenever no
+  explicit `store` override is supplied and the process detects it is running
+  as a hosted agent — true on every real deployment. Its orchestrator only
+  invokes that provider when the *caller's* `store` is true, and the
+  OpenAI/Foundry Responses contract defaults an omitted `store` to `true`.
+  Live validation confirmed the resulting split: a caller that explicitly sent
+  `store: false` succeeded, while the same request with `store` left unset or
+  `true` deterministically failed with a platform `storage_error` once
+  `NETWORK_ISOLATION=true` blocked the provider's path to the Foundry storage
+  plane. The container's own internal model invocation
+  (`single_agent_rag_strategy_v2.py`, `maf_agent_service_strategy.py`) already
+  hardcoded `store: False` on the *separate*, inner Foundry agent/model call
+  for the hosted runtime — that guarantee was never the gap. The gap was the
+  *outer* wire-level `store` field on the incoming `POST /responses` request,
+  which every caller could still set (or omit) freely, reaching the
+  auto-activated storage provider before any GPT-RAG code ran. Every hosted
+  `/responses` create call (`HostedResponsesAgentServerHost._create_endpoint`)
+  now overrides `store` to `False` unconditionally — regardless of what a
+  caller sends or omits, for both streaming and non-streaming (sync) requests
+  — so the container never depends on Foundry managed persistence and never
+  needs Conversations data-plane RBAC to answer a request. `background: true`
+  requires `store: true` in the pinned SDK and is therefore no longer
+  reachable; it now fails fast with an explicit HTTP 422 instead of the
+  opaque SDK-level 400, since a queued/polled response that can never be
+  retrieved is not a meaningful capability for a stateless container.
+  `/invocations` and classic (non-hosted, Cosmos-backed) `/responses` behavior
+  are **unaffected**. Added `test_responses_ignores_caller_store_and_fails_closed`
+  (parametrized over explicit `store: true` and an omitted `store` field),
+  `test_responses_stream_ignores_caller_store_and_fails_closed`, and
+  `test_responses_rejects_background_mode`; replaced
+  `test_responses_persists_retrieves_and_deletes_response`, which asserted the
+  now-removed caller-controlled persistence round trip.
+
 ## [v4.0.1] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -89,14 +89,24 @@ group-filter fallback is never the default.
 
 `POST /responses` is hosted by Microsoft's
 `azure-ai-agentserver-responses` implementation of the Foundry Responses v2
-protocol. The orchestrator adapter accepts the documented string `input`
-contract with streaming or synchronous execution, storage controls, managed
-`conversation` identity, `previous_response_id`, metadata, and the
-platform-injected `agent_reference`; list input is rejected rather than
-silently losing role semantics in server-thread strategies. Other Responses
-request fields are rejected rather than silently ignored, and `conversation`
-cannot be combined with `previous_response_id`. The protocol host also owns
-response retrieval, input-item listing, cancellation, and deletion.
+protocol. The orchestrator adapter accepts a plain string `input` or an
+ordered array of text-only `role`/`content` message objects, streaming or
+synchronous (`stream`) execution, `metadata`, and the platform-injected
+`agent_reference`. `conversation` and `previous_response_id` are rejected
+outright with HTTP 422 (ADR-0004): a caller-selected server-side state
+selector is never resolved; the authenticated caller must instead send the
+complete, ordered turn history as `input` on every request. `store` is
+overridden to `False` unconditionally, regardless of what the caller sends or
+omits, because the hosted container holds zero managed-Conversations
+data-plane RBAC and must never depend on Foundry's managed persistence — see
+`CHANGELOG.md`. `background: true` requires `store: true` in the underlying
+SDK and is therefore also rejected with HTTP 422. Non-message-object array
+items and multimodal (non-text) content are rejected rather than silently
+losing role semantics or dropping content. Other Responses request fields are
+rejected rather than silently ignored. The protocol host still exposes
+response retrieval, input-item listing, cancellation, and deletion, but since
+every response is created with `store: False` none of those routes ever
+return a previously created response.
 `POST /invocations` remains a separate compatibility protocol for the existing
 `messages` request schema. Both protocols reuse the same hosted strategy
 execution and identity guard after parsing their distinct request contracts.

--- a/src/api/hosted_entrypoint.py
+++ b/src/api/hosted_entrypoint.py
@@ -10,6 +10,14 @@ classic ``main.py`` so that:
   create/read/append/delete, no Conversations client construction). The
   authenticated UI BFF owns managed Conversation lifecycle exclusively and
   sends the complete, bounded, ordered history on every request.
+- Every ``POST /responses`` unconditionally forces ``store: False`` before the
+  pinned ``azure-ai-agentserver-responses`` host processes it (ADR-0004),
+  regardless of what a caller sends or omits. This fails closed against the
+  host's own auto-activated, network-bound Foundry storage provider, which
+  the hosted container has no RBAC to use and which otherwise raises a
+  platform ``storage_error`` under network isolation whenever a caller's
+  ``store`` is left unset (the Responses default is ``true``) or explicit
+  ``true``. See ``HostedResponsesAgentServerHost._create_endpoint``.
 - Only ADR-eligible strategies are admitted; unsupported strategies fail
   explicitly rather than silently falling back.
 - The hosted image is immutable: the ``VERSION`` file is read once at startup
@@ -846,6 +854,57 @@ class HostedResponsesAgentServerHost(ResponsesAgentServerHost):
                     },
                     status_code=422,
                 )
+
+            # The pinned SDK requires ``store: true`` whenever ``background:
+            # true`` is requested (a queued/polled response is meaningless if
+            # it can never be retrieved). This hosted runtime forces
+            # ``store: False`` unconditionally below (ADR-0004), so
+            # ``background: true`` can never be honored. Reject it outright
+            # with an explicit, self-documenting error instead of letting the
+            # caller-opaque SDK-level "background=true requires store=true"
+            # 400 stand as the de-facto contract.
+            if payload.get("background"):
+                return JSONResponse(
+                    {
+                        "detail": (
+                            "The Responses background parameter is not "
+                            "supported by this hosted runtime: background=true "
+                            "requires store=true, and every request is forced "
+                            "to store=False (ADR-0004, zero managed-"
+                            "Conversations RBAC, stateless hosted container)."
+                        )
+                    },
+                    status_code=422,
+                )
+
+            # ADR-0004: the hosted container holds zero managed-Conversations
+            # data-plane RBAC and must never rely on Foundry managed
+            # persistence. ``ResponsesAgentServerHost.__init__`` auto-activates
+            # a network-bound ``FoundryStorageProvider`` whenever no explicit
+            # ``store`` override is supplied and the process detects it is
+            # running as a hosted agent, and the pinned SDK orchestrator only
+            # calls that provider when the *caller's* ``store`` is true. Per
+            # the OpenAI/Foundry Responses contract ``store`` defaults to
+            # ``true`` when omitted, so an unset or explicit ``store: true``
+            # request reaches that provider and fails closed with a platform
+            # ``storage_error`` under network isolation, while ``store: false``
+            # skips it and succeeds. Fail closed unconditionally instead of
+            # trusting caller intent: force ``store: False`` for every create
+            # call regardless of what was sent or omitted, so implicit managed
+            # persistence is never attempted by any caller on any product
+            # surface. Mutating ``payload`` here is sufficient — Starlette's
+            # ``Request.json()`` caches the parsed body dict on the request
+            # instance, so the SDK's own downstream ``await request.json()``
+            # call returns this same, already-overridden object.
+            if payload.get("store") is not False:
+                logger.info(
+                    "Hosted Responses request store=%r (omitted defaults to "
+                    "true); overriding to store=False so Foundry managed "
+                    "persistence is never attempted (ADR-0004 zero-RBAC "
+                    "stateless hosted container).",
+                    payload.get("store"),
+                )
+            payload["store"] = False
 
             return await endpoint(request)
 

--- a/tests/test_hosted_responses.py
+++ b/tests/test_hosted_responses.py
@@ -1589,49 +1589,6 @@ class TestHostedEntrypointAPI:
         assert resp.json()["status"] == "completed"
         assert resp.json()["output"][0]["content"][0]["text"] == "answer"
 
-    def test_responses_persists_retrieves_and_deletes_response(
-        self,
-        client,
-        mock_config,
-    ):
-        self._use_strategy(mock_config, "maf_lite")
-
-        async def fake_flow(_ask):
-            yield "stored answer"
-
-        strategy = MagicMock()
-        strategy.initiate_agent_flow = fake_flow
-
-        with patch(
-            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
-            new=AsyncMock(return_value=strategy),
-        ):
-            created = client.post(
-                "/responses",
-                json={"input": "Stored question", "store": True},
-            )
-
-        response_id = created.json()["id"]
-        retrieved = client.get(f"/responses/{response_id}")
-        input_items = client.get(f"/responses/{response_id}/input_items")
-        deleted = client.delete(f"/responses/{response_id}")
-        missing = client.get(f"/responses/{response_id}")
-
-        assert created.status_code == 200
-        assert retrieved.status_code == 200
-        assert retrieved.json()["id"] == response_id
-        assert retrieved.json()["status"] == "completed"
-        assert input_items.status_code == 200
-        assert input_items.json()["object"] == "list"
-        assert input_items.json()["data"][0]["role"] == "user"
-        assert deleted.status_code == 200
-        assert deleted.json() == {
-            "id": response_id,
-            "object": "response",
-            "deleted": True,
-        }
-        assert missing.status_code == 404
-
     def test_responses_store_false_is_not_retrievable(
         self,
         client,
@@ -1656,6 +1613,93 @@ class TestHostedEntrypointAPI:
 
         assert created.status_code == 200
         assert client.get(f"/responses/{created.json()['id']}").status_code == 404
+
+    @pytest.mark.parametrize(
+        "store_field",
+        [
+            pytest.param({"store": True}, id="explicit-store-true"),
+            pytest.param({}, id="omitted-store-defaults-true"),
+        ],
+    )
+    def test_responses_ignores_caller_store_and_fails_closed(
+        self,
+        client,
+        mock_config,
+        store_field,
+    ):
+        """ADR-0004: the hosted container has zero managed-Conversations RBAC.
+
+        A caller asking for (or defaulting to, since the Responses contract
+        treats an omitted ``store`` as ``true``) managed persistence must never
+        reach the SDK's auto-activated, network-bound Foundry storage
+        provider. The container overrides ``store`` to ``False`` for every
+        create call, so the response is created successfully but is never
+        retrievable, listable, or deletable afterward — regardless of what
+        the caller sent or omitted. This is the fail-closed override that
+        replaces caller-controlled persistence (formerly proven by a
+        ``store: True`` round trip through GET/DELETE, which this test
+        supersedes: that round trip must no longer succeed).
+        """
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            yield "stored answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            created = client.post(
+                "/responses",
+                json={"input": "Stored question", **store_field},
+            )
+
+        assert created.status_code == 200
+        response_id = created.json()["id"]
+
+        assert client.get(f"/responses/{response_id}").status_code == 404
+        assert (
+            client.get(f"/responses/{response_id}/input_items").status_code == 404
+        )
+        assert client.delete(f"/responses/{response_id}").status_code == 404
+
+    def test_responses_stream_ignores_caller_store_and_fails_closed(
+        self,
+        client,
+        mock_config,
+    ):
+        """The override applies uniformly to streaming create calls too."""
+        self._use_strategy(mock_config, "maf_lite")
+
+        async def fake_flow(_ask):
+            yield "streamed answer"
+
+        strategy = MagicMock()
+        strategy.initiate_agent_flow = fake_flow
+
+        with patch(
+            "api.hosted_entrypoint.AgentStrategyFactory.get_strategy",
+            new=AsyncMock(return_value=strategy),
+        ):
+            created = client.post(
+                "/responses",
+                json={"input": "Stored question", "stream": True, "store": True},
+            )
+
+        assert created.status_code == 200
+        events = _parse_sse_body(created.text)
+        response_ids = {
+            event["data"]["response"]["id"]
+            for event in events
+            if isinstance(event["data"].get("response"), dict)
+        }
+        assert len(response_ids) == 1
+        response_id = next(iter(response_ids))
+
+        assert client.get(f"/responses/{response_id}").status_code == 404
 
     def test_responses_honors_platform_response_id_header(
         self,
@@ -1778,11 +1822,17 @@ class TestHostedEntrypointAPI:
         assert response.status_code == 422
         assert response.json()["detail"] == "The Responses input must not be empty."
 
-    def test_responses_cancel_route_terminates_background_response(
+    def test_responses_rejects_background_mode(
         self,
         client,
         mock_config,
     ):
+        """ADR-0004: the hosted runtime forces store=False on every request,
+        and the pinned SDK requires store=true whenever background=true is
+        requested (a queued/polled response is meaningless if it can never
+        be retrieved). background=true must therefore be rejected outright
+        with a self-documenting error instead of silently queuing a response
+        that can never be observed again."""
         self._use_strategy(mock_config, "maf_lite")
 
         async def fake_flow(_ask):
@@ -1805,12 +1855,9 @@ class TestHostedEntrypointAPI:
                     "store": True,
                 },
             )
-            cancelled = client.post(f"/responses/{created.json()['id']}/cancel")
 
-        assert created.status_code == 200
-        assert created.json()["status"] in {"queued", "in_progress"}
-        assert cancelled.status_code == 200
-        assert cancelled.json()["status"] == "cancelled"
+        assert created.status_code == 422
+        assert "background" in created.json()["detail"]
 
     def test_responses_rejects_missing_foundry_call_id_for_toolbox_strategy(
         self,


### PR DESCRIPTION
## Changed

- **Hosted `/responses` now unconditionally forces `store: False`, closing an
  implicit Foundry managed-persistence path that violated the ADR-0004
  zero-RBAC, stateless hosted container contract.**

## Root cause

The pinned `azure-ai-agentserver-responses==2.0.0b1` host
(`ResponsesAgentServerHost.__init__`) auto-activates its own network-bound
`FoundryStorageProvider` (built from `DefaultAzureCredential`) whenever no
explicit `store` override is supplied to `create_app()` and the process
detects it is running as a hosted agent — true on every real deployment.
Its orchestrator only invokes that provider when the **caller's** `store`
is true, and the OpenAI/Foundry Responses contract defaults an omitted
`store` to `true`.

Live matrix validation confirmed the resulting split: a caller that
explicitly sends `store: false` succeeds, while the same request with
`store` left unset or `true` deterministically fails with a platform
`storage_error` once `NETWORK_ISOLATION=true` blocks the provider's path to
the Foundry storage plane.

This repository's hosted strategies (`single_agent_rag_strategy_v2.py`,
`maf_agent_service_strategy.py`) already hardcode `store: False` on the
*separate, inner* Foundry agent/model call for the hosted runtime — that
guarantee was already correct and is **not** duplicated or changed by this
PR. The gap was the *outer*, wire-level `store` field on the incoming
`POST /responses` request itself, which any caller could still set (or
omit) freely, reaching the SDK's auto-activated storage provider before any
GPT-RAG orchestration code runs.

## Fix

`HostedResponsesAgentServerHost._create_endpoint` (`src/api/hosted_entrypoint.py`)
now overrides `store` to `False` unconditionally on every create call —
regardless of what a caller sends or omits, for both streaming and
non-streaming (sync) requests — by mutating the parsed request body before
calling the SDK's own endpoint. (Starlette's `Request.json()` caches the
parsed body on the request instance, so the SDK's downstream `await
request.json()` call observes this same, already-overridden dict — no
request reconstruction needed.)

`background: true` requires `store: true` in the pinned SDK
(`"background=true requires store=true"`) and is therefore no longer a
reachable combination. It now fails fast with an explicit HTTP 422 from
GPT-RAG's own validation instead of surfacing the SDK's generic 400, since a
queued/polled response that can never be retrieved isn't a meaningful
capability for a stateless container.

`/invocations` and classic (non-hosted, Cosmos-backed) `/responses` behavior
are **unaffected** — this change is scoped to `api/hosted_entrypoint.py`'s
`create_response` guard only.

## Tests

- Replaced `test_responses_persists_retrieves_and_deletes_response` (asserted
  the now-removed caller-controlled persistence round trip) with
  `test_responses_ignores_caller_store_and_fails_closed`, parametrized over
  explicit `store: true` **and an omitted `store` field**, asserting the
  created response is never retrievable, listable, or deletable.
- Added `test_responses_stream_ignores_caller_store_and_fails_closed` for the
  streaming path.
- Replaced `test_responses_cancel_route_terminates_background_response` with
  `test_responses_rejects_background_mode`, asserting the new explicit 422.
- `test_responses_store_false_is_not_retrievable` (pre-existing, explicit
  `store: false`) is unchanged and still passes.

## Validation

- `pytest` (full suite): 722 passed.
- `ruff check --select F` on changed files: no findings.
- `python -m compileall src tests`: passed.
- `pip check`: no broken requirements.

## Docs

- Corrected the `README.md` `/responses` contract paragraph, which predated
  the ADR-0004 `conversation`/`previous_response_id` rejection and described a
  stale contract (it said those fields and list input were accepted/rejected
  in ways that no longer matched the code or tests). Now accurately describes
  string/ordered-message-array `input`, the `conversation`/
  `previous_response_id` rejection, the new unconditional `store` override,
  and the new `background` rejection.
- `CHANGELOG.md` `[Unreleased]` updated under `### Security`.

## Residual risk / follow-up (tracked outside this PR)

- This PR does not publish a release/tag; a maintainer must decide the patch
  version (likely `v4.0.2`, PATCH — behavior-narrowing bug fix, no new
  request field, existing `/invocations` and classic behavior unchanged) and
  perform the release step per `.github/instructions/release.instructions.md`.
- Live end-to-end re-validation of the exact matrix (`store` unset/true/false
  under `NETWORK_ISOLATION=true`) against a real hosted deployment with this
  change has **not** been re-run as part of this PR; the umbrella repo's docs
  will keep a live-validation-pending note until that is done.
